### PR TITLE
pyyaml requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ pyramid_celery
 pyramid_mako
 pytz
 pywps
-pyyaml
+pyyaml>=4.2b4
 requests
 requests_file
 shapely


### PR DESCRIPTION
require beta version minimum of yaml until they fix and release 4.2/5.1 versions