### PR TITLE
Send emails using any smtp address

### DIFF
--- a/custom.cfg.example
+++ b/custom.cfg.example
@@ -32,6 +32,7 @@ wps-email-notify-smtp-host =
 wps-email-notify-from-addr = example@email.com
 wps-email-notify-password = 123456
 wps-email-notify-port = 25
+wps-email-notify-ssl = true
 wps-email-notify-template = /path/to/mako/template.mako
 wps-processes-file = /path/to/wps_processes.yml
 

--- a/custom.cfg.example
+++ b/custom.cfg.example
@@ -28,8 +28,10 @@ wps-output = /path/to/custom/wps-outputs
 wps-restapi = true|false
 wps-restapi-path = /base/path/of/rest/api
 wps-restapi-ref = https://rest-api-reference.com/conformance-path
+wps-email-notify-smtp-host =
 wps-email-notify-from-addr = example@email.com
 wps-email-notify-password = 123456
+wps-email-notify-port = 25
 wps-email-notify-template = /path/to/mako/template.mako
 wps-processes-file = /path/to/wps_processes.yml
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,4 +26,3 @@ shapely
 six
 simplejson
 webob
-yagmail

--- a/weaver/wps_restapi/jobs/notify.py
+++ b/weaver/wps_restapi/jobs/notify.py
@@ -14,6 +14,7 @@ def notify_job(job, job_json, to, settings):
     from_addr = settings.get("weaver.wps_email_notify_from_addr")
     password = settings.get("weaver.wps_email_notify_password")
     port = settings.get("weaver.wps_email_notify_port")
+    ssl = settings.get("weaver.wps_email_notify_ssl")
     # an example template is located in
     # weaver/wps_restapi/templates/notification_email_example.mako
     template_path = settings.get("weaver.wps_email_notify_template")
@@ -26,10 +27,16 @@ def notify_job(job, job_json, to, settings):
 
     message = 'Subject: {}\n\n{}'.format(subject, contents)
 
-    if port == 25:
-        server = smtplib.SMTP(smtp_host, port)
-    else:
+    if ssl:
         server = smtplib.SMTP_SSL(smtp_host, port)
+    else:
+        server = smtplib.SMTP(smtp_host, port)
+        server.ehlo()
+        try:
+            server.starttls()
+            server.ehlo()
+        except smtplib.SMTPException:
+            pass
 
     try:
         if password:

--- a/weaver/wps_restapi/jobs/notify.py
+++ b/weaver/wps_restapi/jobs/notify.py
@@ -1,8 +1,8 @@
 from weaver.datatype import Job
 from mako.template import Template
 from typing import TYPE_CHECKING
-import yagmail
 import os
+import smtplib
 if TYPE_CHECKING:
     from typing import Dict
 
@@ -10,17 +10,34 @@ if TYPE_CHECKING:
 def notify_job(job, job_json, to, settings):
     # type: (Job, Dict, str, Dict) -> None
     subject = "Job {} {}".format(job.process, job.status.title())
+    smtp_host = settings.get("weaver.wps_email_notify_smtp_host")
     from_addr = settings.get("weaver.wps_email_notify_from_addr")
     password = settings.get("weaver.wps_email_notify_password")
-    user = {from_addr: "WPS Notifications"}
-    yag = yagmail.SMTP(user=user, password=password)
-
+    port = settings.get("weaver.wps_email_notify_port")
     # an example template is located in
     # weaver/wps_restapi/templates/notification_email_example.mako
     template_path = settings.get("weaver.wps_email_notify_template")
+
     if not os.path.exists(template_path):
         raise IOError("Template file doesn't exist: {}".format(template_path))
 
     template = Template(filename=template_path)
     contents = template.render(job=job, **job_json)
-    yag.send(to, subject, contents)
+
+    message = 'Subject: {}\n\n{}'.format(subject, contents)
+
+    if port == 25:
+        server = smtplib.SMTP(smtp_host, port)
+    else:
+        server = smtplib.SMTP_SSL(smtp_host, port)
+
+    try:
+        if password:
+            server.login(from_addr, password)
+        result = server.sendmail(from_addr, to, message)
+    finally:
+        server.close()
+
+    if result:
+        code, error_message = result[to]
+        raise IOError("Code: {}, Message: {}".format(code, error_message))

--- a/weaver/wps_restapi/processes/processes.py
+++ b/weaver/wps_restapi/processes/processes.py
@@ -194,12 +194,12 @@ def execute_process(self, job_id, url, headers=None, notification_email=None):
             try:
                 job_json = job_format_json(settings, job)
                 notify_job(job, job_json, notification_email, settings)
-                message = "Sent email to: {}".format(notification_email)
+                message = "Email sent successfully."
                 job.save_log(logger=task_logger, message=message)
             except Exception as exc:
                 exception_class = "{}.{}".format(type(exc).__module__, type(exc).__name__)
                 exception = "{0}: {1}".format(exception_class, exc.message)
-                message = "Couldn't send email to: {} ({})".format(notification_email, exception)
+                message = "Couldn't send email ({})".format(exception)
                 job.save_log(errors=message, logger=task_logger, message=message)
 
         job = store.update_job(job)


### PR DESCRIPTION
- We can now send emails using gmail, or any other email provider.
- Login only occurs when a password is provided in the configuration.
- The notification email is removed from the logs, for privacy reasons.