### PR TITLE
Wps execute accept language

### DIFF
--- a/tests/wps_restapi/test_processes.py
+++ b/tests/wps_restapi/test_processes.py
@@ -1,7 +1,7 @@
 import os
 import unittest
 from copy import deepcopy
-from unittest.mock import Mock
+import mock
 
 import pyramid.testing
 import pytest
@@ -509,8 +509,8 @@ class WpsRestApiProcessesTest(unittest.TestCase):
             assert job.accept_language == "fr-CA"
 
     def test_set_wps_language(self):
-        wps = Mock()
-        languages = Mock()
+        wps = mock.Mock()
+        languages = mock.Mock()
         wps.languages = languages
         languages.default = 'en-US'
         languages.supported = ['en-US', 'fr-CA']

--- a/weaver/datatype.py
+++ b/weaver/datatype.py
@@ -326,6 +326,18 @@ class Job(Base):
         self["notification_email"] = email
 
     @property
+    def accept_language(self):
+        # type: () -> Optional[AnyStr]
+        return self.get("accept_language")
+
+    @accept_language.setter
+    def accept_language(self, language):
+        # type: (Optional[Union[AnyStr]]) -> None
+        if not isinstance(language, six.string_types):
+            raise TypeError("Type 'str' is required for '{}.accept_language'".format(type(self)))
+        self["accept_language"] = language
+
+    @property
     def execute_async(self):
         # type: () -> bool
         return self.get("execute_async", True)

--- a/weaver/datatype.py
+++ b/weaver/datatype.py
@@ -567,6 +567,7 @@ class Job(Base):
             "request": self.request,
             "response": self.response,
             "notification_email": self.notification_email,
+            "accept_language": self.accept_language,
         }
 
 

--- a/weaver/store/mongodb.py
+++ b/weaver/store/mongodb.py
@@ -382,6 +382,7 @@ class MongodbJobStore(StoreJobs, MongodbStore):
                  custom_tags=None,          # type: Optional[List[AnyStr]]
                  access=None,               # type: Optional[AnyStr]
                  notification_email=None,   # type: Optional[AnyStr]
+                 accept_language=None,      # type: Optional[AnyStr]
                  ):                         # type: (...) -> Job
         """
         Stores a job in mongodb.
@@ -412,6 +413,7 @@ class MongodbJobStore(StoreJobs, MongodbStore):
                 "tags": list(set(tags)),
                 "access": access,
                 "notification_email": notification_email,
+                "accept_language": accept_language,
             })
             self.collection.insert_one(new_job.params())
             job = self.fetch_by_id(job_id=new_job.id)

--- a/weaver/wps_restapi/processes/processes.py
+++ b/weaver/wps_restapi/processes/processes.py
@@ -60,15 +60,6 @@ if TYPE_CHECKING:
 LOGGER = logging.getLogger(__name__)
 
 
-def set_wps_language(wps, accept_language):
-    """Set the `language` property on the `WebProcessingService` object.
-
-    Given the `accept_language` header value, match the best language
-    to the supported languages.
-    """
-    pass
-
-
 @app.task(bind=True)
 def execute_process(self, job_id, url, headers=None, notification_email=None):
     settings = get_settings(app)
@@ -209,6 +200,23 @@ def execute_process(self, job_id, url, headers=None, notification_email=None):
         job = store.update_job(job)
 
     return job.status
+
+
+def set_wps_language(wps, accept_language):
+    """Set the `language` property on the `WebProcessingService` object.
+
+    Given the `accept_language` header value, match the best language
+    to the supported languages.
+
+    By default, and if no match is found, the `language` property is None.
+    """
+    accepted_languages = [lang.strip() for lang in accept_language.lower().split(",")]
+
+    for accept in accepted_languages:
+        for language in wps.languages.supported:
+            if language.lower().startswith(accept):
+                wps.language = language
+                return
 
 
 def validate_supported_submit_job_handler_parameters(json_body):

--- a/weaver/wps_restapi/processes/processes.py
+++ b/weaver/wps_restapi/processes/processes.py
@@ -204,15 +204,18 @@ def execute_process(self, job_id, url, headers=None, notification_email=None):
 
 def set_wps_language(wps, accept_language):
     # type: (WebProcessingService, str) -> None
-    """Set the `language` property on the `WebProcessingService` object.
+    """Set the :attr:`language` property on the :class:`WebProcessingService` object.
 
-    Given the `accept_language` header value, match the best language
+    Given the `Accept-Language` header value, match the best language
     to the supported languages.
 
-    By default, and if no match is found, the `language` property is None.
+    By default, and if no match is found, the :attr:`WebProcessingService.language`
+    property is set to None.
 
     https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language
     (q-factor weighting is ignored, only order is considered)
+
+    :param str accept_language: the value of the Accept-Language header
     """
     if not hasattr(wps, "languages"):
         # owslib version doesn't support setting a language

--- a/weaver/wps_restapi/swagger_definitions.py
+++ b/weaver/wps_restapi/swagger_definitions.py
@@ -258,6 +258,11 @@ class AcceptHeader(MappingSchema):
     ]))
 
 
+class AcceptLanguageHeader(AcceptHeader):
+    AcceptLanguage = SchemaNode(String(), missing=drop)
+    AcceptLanguage.name = "Accept-Language"
+
+
 class KeywordList(SequenceSchema):
     keyword = SchemaNode(String())
 
@@ -1172,7 +1177,7 @@ class PostProcessesEndpoint(MappingSchema):
 
 
 class PostProcessJobsEndpoint(ProcessPath):
-    header = AcceptHeader()
+    header = AcceptLanguageHeader()
     body = Execute()
 
 


### PR DESCRIPTION
Support the `Accept-Language` header when executing a WPS process, match it to the best-supported language (according to the GetCapabilities call) and forward it to `owslib.wps.WebProcessingService`.

Fixes #73 

Requires https://github.com/geopython/OWSLib/pull/655 and https://github.com/geopython/OWSLib/pull/654 to be released in the next owslib version. This PR shouldn't break anything in the meantime, it just doesn't do anything.