### PR TITLE
Don't cast values when validating a job's POST body

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,13 @@ Changes
 Unreleased
 ==========
 
+Fixes:
+------
+
+- Fix a bug where the validation of OneOf items was casting the value to the first valid possibility.
+  Now, it doesn't change the value if it's valid without casting it (and still casts it if it's 
+  necessary to make it valid).
+
 1.1.0 (2020-02-17)
 ==================
 

--- a/tests/wps_restapi/test_processes.py
+++ b/tests/wps_restapi/test_processes.py
@@ -544,6 +544,28 @@ class WpsRestApiProcessesTest(unittest.TestCase):
             assert resp.status_code in [400, 422], msg.format(i, resp.status_code)
             assert resp.content_type == CONTENT_TYPE_APP_JSON, msg.format(i, resp.content_type)
 
+    def test_execute_process_dont_cast_one_of(self):
+        """
+        Optional parameters for execute job shouldn't raise an error if omitted,
+        and should resolve to default values if any was specified.
+        """
+        # get basic mock/data templates
+        name = fully_qualified_name(self)
+        execute_mock_data_tests = list()
+
+        mock_execute = mocked_process_job_runner("job-{}".format(name))
+        data_execute = self.get_process_execute_template("100")
+        execute_mock_data_tests.append((mock_execute, data_execute))
+
+        with contextlib.ExitStack() as stack:
+            for exe in mock_execute:
+                stack.enter_context(exe)
+            path = "/processes/{}/jobs".format(self.process_public.identifier)
+            resp = self.app.post_json(path, params=data_execute, headers=self.json_headers)
+            assert resp.status_code == 201, "Expected job submission without inputs created without error."
+            job = self.job_store.fetch_by_id(resp.json["jobID"])
+            assert job.inputs[0]["data"] == "100"  # not cast to float or integer
+
     def test_execute_process_no_error_not_required_params(self):
         """
         Optional parameters for execute job shouldn't raise an error if omitted,

--- a/tests/wps_restapi/test_processes.py
+++ b/tests/wps_restapi/test_processes.py
@@ -546,8 +546,7 @@ class WpsRestApiProcessesTest(unittest.TestCase):
 
     def test_execute_process_dont_cast_one_of(self):
         """
-        Optional parameters for execute job shouldn't raise an error if omitted,
-        and should resolve to default values if any was specified.
+        When validating the schema for OneOf values, don't cast the result to the first valid schema.
         """
         # get basic mock/data templates
         name = fully_qualified_name(self)

--- a/weaver/wps_restapi/colander_extras.py
+++ b/weaver/wps_restapi/colander_extras.py
@@ -142,9 +142,8 @@ class OneOfMappingSchema(colander.MappingSchema):
             for valid in valid_one_of:
                 if isinstance(valid, dict) and all(cstruct[k] == v for k, v in valid.items()):
                     return valid
-            else:
-                # If that fails, return the first valid deserialization
-                return valid_one_of[0]
+            # If that fails, return the first valid deserialization
+            return valid_one_of[0]
 
         message = "Incorrect type, must be one of: {}. Errors for each case: {}" \
                   .format(list(invalid_one_of), invalid_one_of)

--- a/weaver/wps_restapi/processes/processes.py
+++ b/weaver/wps_restapi/processes/processes.py
@@ -315,7 +315,7 @@ def submit_job_handler(request, service_url, is_workflow=False, visibility=None)
     except Exception as ex:
         raise HTTPBadRequest("Invalid JSON body cannot be decoded for job submission. [{}]".format(ex))
     try:
-        sd.Execute().deserialize(json_body)
+        json_body = sd.Execute().deserialize(json_body)
     except colander.Invalid as ex:
         raise HTTPBadRequest("Invalid schema: [{}]".format(str(ex)))
 

--- a/weaver/wps_restapi/processes/processes.py
+++ b/weaver/wps_restapi/processes/processes.py
@@ -315,7 +315,7 @@ def submit_job_handler(request, service_url, is_workflow=False, visibility=None)
     except Exception as ex:
         raise HTTPBadRequest("Invalid JSON body cannot be decoded for job submission. [{}]".format(ex))
     try:
-        json_body = sd.Execute().deserialize(json_body)
+        sd.Execute().deserialize(json_body)
     except colander.Invalid as ex:
         raise HTTPBadRequest("Invalid schema: [{}]".format(str(ex)))
 


### PR DESCRIPTION
For example, an input of `{"id": "test", "data": "2020"}`
was cast to `{"id": "test", "data": 2020.0}`
because `DataFloat` is the first item in `weaver.wps_restapi.swagger_definitions.ValueType`