### PR TITLE
Fix builtin process job execution and results href

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,17 @@ Changes
 Unreleased
 ==========
 
+Changes:
+--------
+
+- Avoid long fetch operation using streamed request that defaulted to chuck size of 1.
+  Now, we use an appropriate size according to available memory.
+- Adjust incorrectly parsed href file reference as WPS complex input which resulted in failing location retrieval.
+- Partially address unnecessary fetch of file that has to be passed down to CWL, which will in turn request the file
+  as required. Need update from PyWPS to resolve completely (#91, geopython/pywps#526).
+- Adjust WPS output results to use relative HTTP path in order to recompose the output URL if server settings change.
+- Support WPS output results as value (WPS literal data). Everything was considered an href file beforehand.
+
 1.4.0 (2020-03-18)
 ==================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,13 +7,18 @@ Unreleased
 Changes:
 --------
 
-- Avoid long fetch operation using streamed request that defaulted to chuck size of 1.
-  Now, we use an appropriate size according to available memory.
 - Adjust incorrectly parsed href file reference as WPS complex input which resulted in failing location retrieval.
 - Partially address unnecessary fetch of file that has to be passed down to CWL, which will in turn request the file
   as required. Need update from PyWPS to resolve completely (#91, geopython/pywps#526).
 - Adjust WPS output results to use relative HTTP path in order to recompose the output URL if server settings change.
 - Support WPS output results as value (WPS literal data). Everything was considered an href file beforehand.
+
+Fixes:
+------
+
+- Patch ``builtin`` process execution failing since ``cwltool 2.x`` update.
+- Avoid long fetch operation using streamed request that defaulted to chuck size of 1.
+  Now, we use an appropriate size according to available memory.
 
 1.4.0 (2020-03-18)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,9 @@ Changes:
   as required. Need update from PyWPS to resolve completely (#91, geopython/pywps#526).
 - Adjust WPS output results to use relative HTTP path in order to recompose the output URL if server settings change.
 - Support WPS output results as value (WPS literal data). Everything was considered an href file beforehand.
+- Add additional ``timeout`` and ``retry`` during fetching of remote file for process ``jsonarray2netcdf`` to avoid
+  unnecessary failures during edge case connexion problems.
+- Add support of ``title`` and ``version`` field of ``builtin`` processes.
 
 Fixes:
 ------

--- a/tests/functional/test_builtin.py
+++ b/tests/functional/test_builtin.py
@@ -105,7 +105,8 @@ class BuiltinAppTest(unittest.TestCase):
                 if resp.status_code == 200:
                     if resp.json["status"] in JOB_STATUS_CATEGORIES[STATUS_CATEGORY_RUNNING]:
                         continue
-                    assert resp.json["status"] == STATUS_SUCCEEDED
+                    assert resp.json["status"] == STATUS_SUCCEEDED, \
+                        "Process execution failed. Response body:\n{}".format(resp.json)
                     resp = self.app.get("{}/result".format(job_url), headers=self.json_headers)
                     assert resp.status_code == 200
                     assert resp.json["outputs"][0]["id"] == "output"

--- a/tests/functional/test_ems_end2end.py
+++ b/tests/functional/test_ems_end2end.py
@@ -35,7 +35,7 @@ from weaver.visibility import VISIBILITY_PRIVATE, VISIBILITY_PUBLIC
 from weaver.wps_restapi.utils import get_wps_restapi_base_url
 
 if TYPE_CHECKING:
-    from weaver.typedefs import HeadersType, CookiesType, SettingsType, AnyResponseType, JSON   # noqa: F401
+    from weaver.typedefs import AnyResponseType, CookiesType, HeadersType, JSON, SettingsType   # noqa: F401
     from typing import AnyStr, Dict, Optional, Any, Tuple, Iterable, Callable, Union            # noqa: F401
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -118,7 +118,7 @@ def setup_mongodb_processstore(config=None):
     store = get_db(config).get_store(MongodbProcessStore)
     store.clear_processes()
     # store must be recreated after clear because processes are added automatically on __init__
-    get_db(config)._stores.pop(MongodbProcessStore.type)
+    get_db(config)._stores.pop(MongodbProcessStore.type)  # noqa: W0212
     store = get_db(config).get_store(MongodbProcessStore)
     return store
 

--- a/tests/wps_restapi/test_jobs.py
+++ b/tests/wps_restapi/test_jobs.py
@@ -35,10 +35,11 @@ from weaver.warning import TimeZoneInfoAlreadySetWarning
 from weaver.wps_restapi.swagger_definitions import jobs_full_uri, jobs_short_uri, process_jobs_uri
 
 if TYPE_CHECKING:
-    from owslib.wps import Process as ProcessOWSWPS
-    from pywps.app import Process as ProcessPyWPS
+    # pylint: disable=W0611,unused-import
+    from owslib.wps import Process as ProcessOWSWPS  # noqa: F401
+    from pywps.app import Process as ProcessPyWPS    # noqa: F401
     # pylint: disable=C0103,invalid-name,E1101,no-member
-    MockPatch = mock._patch
+    MockPatch = mock._patch  # noqa: W0212
 
 
 class WpsRestApiJobsTest(unittest.TestCase):

--- a/weaver/processes/builtin/__init__.py
+++ b/weaver/processes/builtin/__init__.py
@@ -46,15 +46,18 @@ def _get_builtin_reference_mapping(root):
     return {os.path.splitext(_pkg)[0]: os.path.join(root, _pkg) for _pkg in builtin_names}
 
 
-def _get_builtin_abstract(process_id, process_path):
-    # type: (AnyStr, AnyStr) -> Union[AnyStr, None]
-    """Retrieves the ``builtin`` process ``abstract`` from its `docstring` (``__doc__``) if it exists."""
+def _get_builtin_metadata(process_id, process_path, meta_field, clean=False):
+    # type: (AnyStr, AnyStr, AnyStr, bool) -> Union[AnyStr, None]
+    """
+    Retrieves the ``builtin`` process ``meta_field`` from its definition if it exists.
+    """
     py_file = os.path.splitext(process_path)[0] + ".py"
     if os.path.isfile(py_file):
         try:
             mod = import_module("{}.{}".format(__name__, process_id))
-            if hasattr(mod, "__doc__") and isinstance(mod.__doc__, six.string_types) and len(mod.__doc__):
-                return clean_json_text_body(mod.__doc__)
+            meta = getattr(mod, meta_field, None)
+            if meta and isinstance(meta, six.string_types):
+                return clean_json_text_body(meta) if clean else meta
         except ImportError:
             pass
     return None
@@ -103,12 +106,16 @@ def register_builtin_processes(container):
         process_info = get_process_definition({}, package=None, reference=process_path)
         process_url = "/".join([restapi_url, "processes", process_id])
         process_package = _get_builtin_package(process_id, process_info["package"])
-        process_abstract = _get_builtin_abstract(process_id, process_path)
+        process_abstract = _get_builtin_metadata(process_id, process_path, "__doc__", clean=True)
+        process_version = _get_builtin_metadata(process_id, process_path, "__version__")
+        process_title = _get_builtin_metadata(process_id, process_path, "__title__")
         process_payload = {
             "processDescription": {
                 "process": {
                     "id": process_id,
                     "type": PROCESS_BUILTIN,
+                    "title": process_title,
+                    "version": process_version,
                     "abstract": process_abstract,
                 }
             },
@@ -119,6 +126,8 @@ def register_builtin_processes(container):
         builtin_processes.append(Process(
             id=process_id,
             type=PROCESS_BUILTIN,
+            title=process_title,
+            version=process_version,
             abstract=process_abstract,
             payload=process_payload,
             package=process_package,

--- a/weaver/processes/builtin/jsonarray2netcdf.py
+++ b/weaver/processes/builtin/jsonarray2netcdf.py
@@ -61,6 +61,7 @@ def j2n(json_reference, output_dir):
                 LOGGER.debug("Fetching NetCDF reference from JSON file: [%s]", file_url)
                 fetch_file(file_url, output_dir)
     except Exception as exc:
+        # log only debug for tracking, re-raise and actual error wil be logged by top process monitor
         LOGGER.debug("Process '%s' raised an exception: [%s]", PACKAGE_NAME, exc)
         raise
     LOGGER.info("Process '%s' execution completed.", PACKAGE_NAME)

--- a/weaver/processes/builtin/jsonarray2netcdf.py
+++ b/weaver/processes/builtin/jsonarray2netcdf.py
@@ -44,21 +44,25 @@ def j2n(json_reference, output_dir):
     # type: (AnyStr, AnyStr) -> None
     LOGGER.info("Process '%s' execution starting...", PACKAGE_NAME)
     LOGGER.debug("Process '%s' output directory: [%s].", PACKAGE_NAME, output_dir)
-    if not os.path.isdir(output_dir):
-        raise ValueError("Output dir [{}] does not exist.".format(output_dir))
-    with tempfile.TemporaryDirectory(prefix="wps_process_{}_".format(PACKAGE_NAME)) as tmp_dir:
-        LOGGER.debug("Fetching JSON file: [%s]", json_reference)
-        json_path = fetch_file(json_reference, tmp_dir)
-        LOGGER.debug("Reading JSON file: [%s]", json_path)
-        with open(json_path) as json_file:
-            json_content = json.load(json_file)
-        if not isinstance(json_content, list) or any(not _is_netcdf_url(f) for f in json_content):
-            LOGGER.error("Invalid JSON: [%s]", json_content)
-            raise ValueError("Invalid JSON file format, expected a plain array of NetCDF file URL strings.")
-        LOGGER.debug("Parsing JSON file references.")
-        for file_url in json_content:
-            LOGGER.debug("Fetching NetCDF reference from JSON file: [%s]", file_url)
-            fetch_file(file_url, output_dir)
+    try:
+        if not os.path.isdir(output_dir):
+            raise ValueError("Output dir [{}] does not exist.".format(output_dir))
+        with tempfile.TemporaryDirectory(prefix="wps_process_{}_".format(PACKAGE_NAME)) as tmp_dir:
+            LOGGER.debug("Fetching JSON file: [%s]", json_reference)
+            json_path = fetch_file(json_reference, tmp_dir)
+            LOGGER.debug("Reading JSON file: [%s]", json_path)
+            with open(json_path) as json_file:
+                json_content = json.load(json_file)
+            if not isinstance(json_content, list) or any(not _is_netcdf_url(f) for f in json_content):
+                LOGGER.error("Invalid JSON: [%s]", json_content)
+                raise ValueError("Invalid JSON file format, expected a plain array of NetCDF file URL strings.")
+            LOGGER.debug("Parsing JSON file references.")
+            for file_url in json_content:
+                LOGGER.debug("Fetching NetCDF reference from JSON file: [%s]", file_url)
+                fetch_file(file_url, output_dir)
+    except Exception as exc:
+        LOGGER.debug("Process '%s' raised an exception: [%s]", PACKAGE_NAME, exc)
+        raise
     LOGGER.info("Process '%s' execution completed.", PACKAGE_NAME)
 
 

--- a/weaver/processes/builtin/jsonarray2netcdf.py
+++ b/weaver/processes/builtin/jsonarray2netcdf.py
@@ -30,6 +30,11 @@ LOGGER = logging.getLogger(__name__)
 LOGGER.addHandler(logging.StreamHandler(sys.stdout))
 LOGGER.setLevel(logging.INFO)
 
+# process details
+__version__ = "1.0"
+__title__ = "JSON array to NetCDF"
+__abstract__ = __doc__  # NOTE: '__doc__' is fetched directly, this is mostly to be informative
+
 
 def _is_netcdf_url(url):
     # type: (Any) -> bool
@@ -49,7 +54,7 @@ def j2n(json_reference, output_dir):
             raise ValueError("Output dir [{}] does not exist.".format(output_dir))
         with tempfile.TemporaryDirectory(prefix="wps_process_{}_".format(PACKAGE_NAME)) as tmp_dir:
             LOGGER.debug("Fetching JSON file: [%s]", json_reference)
-            json_path = fetch_file(json_reference, tmp_dir)
+            json_path = fetch_file(json_reference, tmp_dir, timeout=10, retry=3)
             LOGGER.debug("Reading JSON file: [%s]", json_path)
             with open(json_path) as json_file:
                 json_content = json.load(json_file)
@@ -59,7 +64,7 @@ def j2n(json_reference, output_dir):
             LOGGER.debug("Parsing JSON file references.")
             for file_url in json_content:
                 LOGGER.debug("Fetching NetCDF reference from JSON file: [%s]", file_url)
-                fetch_file(file_url, output_dir)
+                fetch_file(file_url, output_dir, timeout=10, retry=3)
     except Exception as exc:
         # log only debug for tracking, re-raise and actual error wil be logged by top process monitor
         LOGGER.debug("Process '%s' raised an exception: [%s]", PACKAGE_NAME, exc)

--- a/weaver/processes/utils.py
+++ b/weaver/processes/utils.py
@@ -140,6 +140,10 @@ def jsonify_output(output, process_description):
 
     # WPS standard v1.0.0 specify that either a reference or a data field has to be provided
     if output.reference:
+        # NOTE:
+        #   Save the results as relative paths to output directory configured in PyWPS (ie: weaver.wps_output_dir).
+        #   This allows us to easily adjust the result HTTP path according to server configuration
+        #   and it also avoid rewriting the whole db job results if the setting is changed later on.
         json_output["reference"] = output.reference
 
         # Handle special case where we have a reference to a json array containing dataset reference

--- a/weaver/processes/utils.py
+++ b/weaver/processes/utils.py
@@ -140,10 +140,6 @@ def jsonify_output(output, process_description):
 
     # WPS standard v1.0.0 specify that either a reference or a data field has to be provided
     if output.reference:
-        # NOTE:
-        #   Save the results as relative paths to output directory configured in PyWPS (ie: weaver.wps_output_dir).
-        #   This allows us to easily adjust the result HTTP path according to server configuration
-        #   and it also avoid rewriting the whole db job results if the setting is changed later on.
         json_output["reference"] = output.reference
 
         # Handle special case where we have a reference to a json array containing dataset reference

--- a/weaver/processes/wps_package.py
+++ b/weaver/processes/wps_package.py
@@ -1808,6 +1808,7 @@ class WpsPackage(Process):
                     # process single occurrences
                     input_i = input_occurs[0]
                     # handle as reference/data
+                    # NOTE: must not call data/file methods if URL reference, otherwise contents get fetched
                     is_array, elem_type, _, _ = _is_cwl_array_type(cwl_input_info[input_id])
                     if is_array:
                         # extend array data that allow max_occur > 1
@@ -1826,8 +1827,8 @@ class WpsPackage(Process):
                             #   (https://github.com/crim-ca/weaver/issues/91)
                             #   href are sometime already handled (pulled and staged locally), use it directly
                             #   validate using the internal '_file' instead of 'file' otherwise we trigger the fetch
-                            if input_i.file and os.path.isfile(input_i._file):  # noqa:W0212
-                                input_data = input_i.file
+                            if input_i._file and os.path.isfile(input_i._file):  # noqa:W0212
+                                input_data = input_i._file                       # noqa:W0212
                             cwl_inputs[input_id] = self.make_location_input(input_data, input_type, input_i)
                     elif isinstance(input_i, (LiteralInput, BoundingBoxInput)):
                         cwl_inputs[input_id] = input_data

--- a/weaver/typedefs.py
+++ b/weaver/typedefs.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    # pylint: disable=W0611,unused-import
     from weaver.processes.wps_process_base import WpsProcessInterface
     from weaver.datatype import Process
     from weaver.status import AnyStatusType
@@ -12,7 +13,7 @@ if TYPE_CHECKING:
     from pyramid.config import Configurator
     from celery import Celery
     from requests.structures import CaseInsensitiveDict
-    from cwltool.factory import Callable as CWLFactoryCallable  # noqa
+    from cwltool.factory import Callable as CWLFactoryCallable  # noqa: F401
     from webtest.response import TestResponse
     from pywps.app import WPSRequest
     from pywps import Process as ProcessWPS
@@ -29,7 +30,7 @@ if TYPE_CHECKING:
     AnyKey = Union[AnyStr, int]
     JSON = Dict[AnyKey, Union[AnyValue, Dict[AnyKey, "JSON"], List["JSON"]]]
     CWL = Dict[{"cwlVersion": AnyStr, "class": AnyStr, "inputs": JSON, "outputs": JSON}]
-    XML = lxml.etree._Element
+    XML = lxml.etree._Element  # noqa: W0212
 
     AnyContainer = Union[Configurator, Registry, PyramidRequest, Celery]
     SettingValue = AnyValue

--- a/weaver/utils.py
+++ b/weaver/utils.py
@@ -431,17 +431,22 @@ def fetch_file(file_reference, file_outdir):
     :param file_outdir: Output directory path of the fetched file.
     :return: Path of the local copy of the fetched file.
     """
+    file_href = file_reference
     file_path = os.path.join(file_outdir, os.path.basename(file_reference))
     if file_reference.startswith("file://"):
         file_reference = file_reference[7:]
+    LOGGER.debug("Fetch file resolved:\n"
+                 "  Reference: [%s]\n"
+                 "  File Path: [%s]", file_href, file_path)
     if os.path.isfile(file_reference):
-        shutil.copyfile(file_reference, file_path)
+        shutil.copyfile(file_reference, file_path, follow_symlinks=False)
     else:
         with open(file_path, "wb") as file:
             resp = requests.get(file_reference, stream=True)
             resp.raise_for_status()
-            for chunk in resp.iter_content():
+            for chunk in resp.iter_content(chunk_size=None):
                 file.write(chunk)
+    LOGGER.debug("Fetch file written")
     return file_path
 
 

--- a/weaver/wps.py
+++ b/weaver/wps.py
@@ -98,8 +98,9 @@ def get_wps_output_url(container):
     Searches directly in settings, then `weaver.wps_cfg` file, or finally, uses the default values if not found.
     """
     wps_output_default = get_weaver_url(container) + "/wpsoutputs"
-    return _get_settings_or_wps_config(
+    wps_output_config = _get_settings_or_wps_config(
         container, "weaver.wps_output_url", "server", "outputurl", wps_output_default, "WPS output url")
+    return wps_output_config or wps_output_default
 
 
 def load_pywps_cfg(container, config=None):

--- a/weaver/wps_restapi/colander_extras.py
+++ b/weaver/wps_restapi/colander_extras.py
@@ -131,7 +131,7 @@ class OneOfMappingSchema(colander.MappingSchema):
         for schema_class in self._one_of:  # noqa
             try:
                 # instantiate the class if specified with simple reference, other use pre-instantiated schema object
-                if isinstance(schema_class, colander._SchemaMeta):  # noqa:W0212
+                if isinstance(schema_class, colander._SchemaMeta):  # noqa: W0212
                     schema_class = schema_class()
                 valid_one_of.append(schema_class.deserialize(cstruct))
             except colander.Invalid as invalid:

--- a/weaver/wps_restapi/processes/processes.py
+++ b/weaver/wps_restapi/processes/processes.py
@@ -268,14 +268,14 @@ def make_results_relative(results, settings):
     """
     wps_url = get_wps_output_url(settings)
     wps_path = get_wps_output_path(settings)
-    for r in results:
-        ref = r.get("reference")
+    for res in results:
+        ref = res.get("reference")
         if isinstance(ref, six.string_types) and ref:
             if ref.startswith(wps_url):
                 ref = ref.replace(wps_url, "", 1)
             if ref.startswith(wps_path):
                 ref = ref.replace(wps_path, "", 1)
-            r["reference"] = ref
+            res["reference"] = ref
     return results
 
 


### PR DESCRIPTION
# changes
- patch `builtin` process execution failing since cwltool 2.x update
- return `data` result if WPS had a literal output (was assuming only reference file)
- address PyPWS URLHandler which was making a an invalid href because `input.data` was called instead of `input.url` and/or `input.file` as needed
- prepare the field for eventual #91 fix when addressed in geopython/pywps#526

@f-PLT  @MatProv 
Inviting you to follow releases since weaver execution might/will start to impact you through finch for climate services/processes, or other future projects.