### PR TITLE
Json output + job captured logging

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,21 @@ Changes
 `Unreleased <https://github.com/crim-ca/weaver/tree/master>`_ (latest)
 ========================================================================
 
+Changes:
+--------
+
+- Improve handling of `WPS-REST` HREF output matching a JSON file with array of URL references corresponding to process
+  pseudo multiple-output format (relates to `#25 <https://github.com/crim-ca/weaver/issues/25>`_). The output is now
+  expanded to contain both the original JSON file reference and the extended contained URL references so that either
+  variation can be retrieved as result.
+
+Fixes:
+------
+
+- Fix handling of WPS-REST output matching a JSON file for multiple-output format specified with a relative local path
+  as specified by job output location. Only remote HTTP references where correctly parsed. Also avoid failing the job if
+  the reference JSON parsing fails. It will simply return the original reference URL in this case without expanded data.
+
 `1.6.0 <https://github.com/crim-ca/weaver/tree/1.6.0>`_ (2020-05-07)
 ========================================================================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,17 +7,19 @@ Changes
 Changes:
 --------
 
-- Improve handling of `WPS-REST` HREF output matching a JSON file with array of URL references corresponding to process
-  pseudo multiple-output format (relates to `#25 <https://github.com/crim-ca/weaver/issues/25>`_). The output is now
-  expanded to contain both the original JSON file reference and the extended contained URL references so that either
-  variation can be retrieved as result.
+- Add additional status log for ``EOImage`` input modification with `OpenSearch` during process execution.
+- Add captured ``stderr/stdout`` logging of underlying `CWL` application being executed to resulting ``Job`` logs
+  (addresses first step of `#131 <https://github.com/crim-ca/weaver/issues/131>`_).
 
 Fixes:
 ------
 
 - Fix handling of WPS-REST output matching a JSON file for multiple-output format specified with a relative local path
   as specified by job output location. Only remote HTTP references where correctly parsed. Also avoid failing the job if
-  the reference JSON parsing fails. It will simply return the original reference URL in this case without expanded data.
+  the reference JSON parsing fails. It will simply return the original reference URL in this case without expanded data
+  (relates to `#25 <https://github.com/crim-ca/weaver/issues/25>`_).
+- Fix `CWL` job logs to be timezone aware, just like most other logs that will report UTC time.
+- Fix JSON response parsing of remote provider processes.
 
 `1.6.0 <https://github.com/crim-ca/weaver/tree/1.6.0>`_ (2020-05-07)
 ========================================================================

--- a/weaver/processes/wps_package.py
+++ b/weaver/processes/wps_package.py
@@ -3,6 +3,7 @@ import logging
 import os
 import shutil
 import tempfile
+import time
 import uuid
 from collections import Hashable, OrderedDict  # pylint: disable=E0611,no-name-in-module   # moved to .abc in Python 3
 from copy import deepcopy
@@ -82,8 +83,6 @@ from weaver.utils import (
     get_sane_name,
     get_settings,
     get_url_without_query,
-    localize_datetime,
-    now,
     null,
     str2bytes
 )
@@ -1706,7 +1705,7 @@ class WpsPackage(Process):
         self.log_file = get_status_location_log_path(self.status_location)
         log_file_handler = logging.FileHandler(self.log_file)
         log_file_formatter = logging.Formatter(fmt=get_log_fmt(), datefmt=get_log_date_fmt())
-        log_file_formatter.converter = lambda *_: localize_datetime(now())
+        log_file_formatter.converter = time.gmtime
         log_file_handler.setFormatter(log_file_formatter)
 
         # prepare package logger

--- a/weaver/wps_restapi/processes/processes.py
+++ b/weaver/wps_restapi/processes/processes.py
@@ -201,7 +201,8 @@ def execute_process(self, job_id, url, headers=None, notification_email=None):
                         job.status_message = "Job succeeded{}.".format(msg_progress)
                         wps_package.retrieve_package_job_log(execution, job)
                         job.save_log(logger=task_logger)
-                        job_results = [jsonify_output(output, process) for output in execution.processOutputs]
+                        job_results = [jsonify_output(output, process, settings)
+                                       for output in execution.processOutputs]
                         job.results = make_results_relative(job_results, settings)
                     else:
                         task_logger.debug("Job failed.")

--- a/weaver/wps_restapi/processes/processes.py
+++ b/weaver/wps_restapi/processes/processes.py
@@ -68,9 +68,9 @@ JOB_PROGRESS_GET_INPUTS = 4
 JOB_PROGRESS_GET_OUTPUTS = 6
 JOB_PROGRESS_EXECUTE_REQUEST = 8
 JOB_PROGRESS_EXECUTE_STATUS_LOCATION = 10
-JOB_PROGRESS_EXECUTE_MONITOR_START = 20
-JOB_PROGRESS_EXECUTE_MONITOR_LOOP = 30
-JOB_PROGRESS_EXECUTE_MONITOR_ERROR = 80
+JOB_PROGRESS_EXECUTE_MONITOR_START = 15
+JOB_PROGRESS_EXECUTE_MONITOR_LOOP = 20
+JOB_PROGRESS_EXECUTE_MONITOR_ERROR = 85
 JOB_PROGRESS_EXECUTE_MONITOR_END = 90
 JOB_PROGRESS_NOTIFY = 95
 JOB_PROGRESS_DONE = 100
@@ -509,9 +509,10 @@ def get_processes(request):
                 response_body.update({"providers": providers})
                 for i, provider in enumerate(providers):
                     provider_id = get_any_id(provider)
-                    processes = requests.request("GET", "{host}/providers/{provider_id}/processes"
-                                                 .format(host=request.host_url, provider_id=provider_id),
-                                                 headers=request.headers, cookies=request.cookies)
+                    response = requests.request("GET", "{host}/providers/{provider_id}/processes"
+                                                .format(host=request.host_url, provider_id=provider_id),
+                                                headers=request.headers, cookies=request.cookies)
+                    processes = response.json().get("processes", [])
                     response_body["providers"][i].update({
                         "processes": processes if detail else [get_any_id(p) for p in processes]
                     })


### PR DESCRIPTION
- Fixes incorrect parsing of JSON output as 'multiple-output' because of new job location that now stores a relative path to file (relates to #25)
- Add more execution log in to saved job logs adding the captured stderr & stdout of the underlying docker app or script.

comparison examples:  
[no-capture.log](https://github.com/crim-ca/weaver/files/4613378/no-capture.log)
[with-capture.log](https://github.com/crim-ca/weaver/files/4613382/with-capture.log)

