### PR TITLE
improving travis-ci test sequence with staged error reports

### DIFF
--- a/.github/labeler-words.yml
+++ b/.github/labeler-words.yml
@@ -12,3 +12,13 @@ feature:
 
 bug:
   - 'bug'
+
+ci:
+  - 'ci'
+  - 'travis'
+  - 'github'
+
+tests:
+  - 'coverage'
+  - 'functional test[s]*'
+  - 'unittest[s]*'

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,7 +80,6 @@ jobs:
         - make info
   allow_failures:
     - python: "2.7"   # deprecated support
-    - python: "3.8"   # experimental packages
     - os: windows     # experimental support
   fast_finish: true   # required jobs will indicate success as soon as possible
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,6 @@ services:
   - docker
 before_install:
   - source tests/travis-ci/weaver.env
-  - cp -f tests/travis-ci/custom.cfg ./
   - cp -f tests/travis-ci/data_sources.json ./
   - make --version
   - make info
@@ -70,10 +69,15 @@ jobs:
       os: windows
       language: bash
       python: "3.8"
+      env: TEST_TARGET=test
       before_install:
-        - choco install python3
+        - choco install python3 make
         - export PATH="/c/Python38:/c/Python38/Scripts:$PATH"
         - python -m pip install --upgrade pip wheel
+        - source tests/travis-ci/weaver.env
+        - cp -f tests/travis-ci/data_sources.json ./
+        - make --version
+        - make info
   allow_failures:
     - python: "2.7"   # deprecated support
     - python: "3.8"   # experimental packages

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,7 @@
+version: ~> 1.0
 language: python
 os:
   - linux
-  - os: windows
-    language: sh
-    python: "3.8"
-    before_install:
-      - choco install python3
-      - export PATH="/c/Python38:/c/Python38/Scripts:$PATH"
-      - python -m pip install --upgrade pip wheel
 python:
   - "3.7"  # default test python
   - "2.7"
@@ -15,11 +9,17 @@ python:
   - "3.8"
 env:
   global:
-  - secure: j7fuAPDXdl0SF1My1f0e3hr8mq4idP41jsz98Y1hN30GGOmIputScxIwSjIBi8zFCJ+K4RleMIoWLhnFsMeMD4DapRqDe5YnJJFOyfiyplzEcn4yONYRJf1nzfXBrpoGSEibgr/e3uYK62bkantI+b0pBPNAKbRjbRKKwTKEAxWb1pfaAMEQMB8/Wmvo0XYAZRB96H4q/7Dtd4CaIqh99Fs/9TjaGdNNtDtjwL0AWPXNfamsA8oNW0frNp1lEYpJpRE+PHFiKWZWyrRqjDA/UNU2UE/2H1O53I6tUXGJjORrUGRp1M9Xq/NhC8C4l7KrdpYH7YkYdvRDts3+XmJZ5kCsGB35YLP8DF1yUXIL4ZMskegBsBKqKKgnXGo4uYkaHp0QR2r8v2tdO8q3JWGYLSCgGVu5YkHU6Nlqf98W5LQLYSuZEkLplrk9vISHNS6TI4G3m7huToY1HwOu01hTZHAEhr/ouUxOfu6pQs8ZYVCyj98o65KFlFCRa7qKHc2/lXVbFPaOeQmFYqCGfFMTB0G0DHlsyOJk3QzoTr0HxJlbEwh9XLJOAnGO/TwcOUZndlj0+lTuCTpeBhjHywr+b00HnYtJ3cVnUVjT8TZydG2ATogeKRvOe0m58ug36EUGwbjr0JoN2hHjeFNSdvTUzFFFmRBY9rps47rzEDyRBGc=
-  - secure: jtK2GwC2Z97r1LdZpqDoj7UGVbTq9Dk+CdXXRbrWuSFCc/SA/TFFeEaHJHm1V0oVFeC5YVpu2B7Z/Di71SmqF/tafArLuDF5LCFegddZBlG372xaKn/ilfLRriA9dyb/yopmnRInqh9ynd1/CokNFjMAKuj4bZYJZImL7nsY9iCdAfuv51thQg2Nd4oj50SiR9MSgEhxOsdos5CncJqSbJrw9KEJGpz69ZtOD6p6UVfd8PgCaDSRuU/RaTAZLLFznRW4+OcUyOy1KXkmEyo7YoF6D/OJvS5INYvACk3/5o5qNYA7YJh6MfQbHd0Y9qvjGO6jvPRikNWhbo4pvCDNx37A5B9BdvUQFpP1T1SdBGCWdfF9qDvskw95kryh/fbs5YTd6rjQUGlQ9Qzt7eJFUd3SpasZRviqcHHyGCJtTqOw0ow6rMYmk2dSDoAi+/H6DDxuZc/a0K+s9U/fCDGCUCee2IyD8zz1CoG+BKO66rVHN1eeuOKlaDzmG6gPLcTbOCcP/jlM/KlBTQO2vzUvc7k0tBb9NunLXSV2eu5zXPyyVbCsKkc2wCNKO40Hsmx9+lALmS4LVlxNBHcNmdHWYiSIOVH2yhM7Ud1/Wsj2NVjzd2KJ5WAuO85cegn3r1o+VtsFNr8YeFdiNCyYETgfxs3OoLnhG/wN++oxXGeXXpQ=
-  - secure: BZBVvKMZaMuMBq3LvdwpBEnyk2OO9yDu+Izxqvoba3/QT2zD0lA8bOFFUYErjuhKecmda1OyNnjdejs2wpGxEEal21AR/BoNHeVTH7euaQzjhWo9MaBnnpFqsKABxy4EFdHZHGD90LrrFoCj7HgI4w+BxABQSsdSuWNYHl4oCyAF9TsPnKGFIlW0HlAR32rxaWHjuxVtxLkiws2GJbyjA3EDSJb7vB5pfnJPTaLTPkgZpAWHa8cGQoXQrZdfG0an7dg3GdPKPc75N0piVqnpEDK89wCpjSK5AwYrsjcc5E1cjJiab9XNopZDLxQzWf8+u455TrSAvcZNkev5o/qg1hbHqnUkOoMvGbipyyNxu0/dzElesRYQ7673fGT/yiZDd7re9qUz31HFIDC5TUfMPoVs0NMX+lNHEDy9FH5UvVV8udTVAJPw5+7vjzd3CpMIGWHt9Syk6OwU1BxdHIeielrlfK7YMkgXQe69KcLKwIdg5QaF7l4I0EtDQ4Ra5d/N36uyLejBIZ7laOgl1IAO9zUXoEtvEI7mcivvWAOSdV6FblG5U4K+/27d3FxRmO06KuIVaYEbPp2HWeVaJADxqTVpRp5bUZ8aEGWihI4L74UbHXWRUPkHt4AG16Ubb/hTrYnCCKL3pvUMFBU5/LoJeyjCVGgi0WOFBaJJazl3XyI=
-  - secure: L5Ko19kx9zbaqZJWKP+elx5G4/OO8WC0PnY4Dacv0hULtv09sEP0g4EKcMP6spMeEsz4B/i/JQzySSqaprcP0Jl2MumjMD4tN9XOHhGQKeqT7FwchyVm0d7HfB2eIQ9wrgNn+4+b3sJPKDla+0OGONLR29CZNZvu9Ev1iPUkfHYz0CFdP2FDNyMJv6XMln6uOPtpSXyIi/YdRCWWVwIjIdp2oMordGt66EUq1BIfv4gcVuBYfekljs/62llt2m4FXh5Z2LkUt7/4od4RZyWvM6yaYk33iSul0uzGJ7hfTRoHbJbJTMlmjkQTZoCFGdnCxIGpVSHR57hOin82NVw5Uj3Y+T/0QwyYCrH0khaqThUEqnvAhd0zf0HsBwpABVzjK8wWynF7aN11vWzTURr7RzaDSMAhWRvfjlrurRkPcsFpewzg8KvowdrFT5MErj3YVWL2/0TqEKImlB/v+ip35YFk3ZigJtA7UKQajAW+zrEbf0pizEmdyUmZDBlBJ5euDJybM+hk204MSYgA1CTSzVlgWoW+M0UPOJtPDnC1YaHtcUBhEWx/rJeIVq3GfBuwN0xHm1WhcctIv7+WR+Fn3QadvWeCc2EcQOdDzqKI52GI+RyFYQheXTL2ULpRpBdzbAD0JkVueFhCFdWTv7EHIak3WCal+P2DC9ay4TzFlW4=
-  - secure: MteZFKkISMErROvLnjoZipPFBPWoaF0xxncTD76qN1AO2N/oK59O4pxSYN6+yqP8KEp4K1maNOsV2BcE5WGkH5R6jfdezVfvxKbKIoIECWhgK2e0rR4Cp4833cw4F6maSqcLkJL5zDeHyHbofzLLVd/1qugz07vZx2GJGTgt2KJtN+j0zeVp0SC7BQwY8RZZ0BSZB06SjsG05AiBIUfnJqVmGCb1ORZvPD5F6sa0HF/dsuR+m6ITYhQfR6A2gKpW6ZE5YS1wNg/J4gybQcko1jZMaiORdUcKH+0DyedhBh6Ne2spfC5kvIUynEm63u5igRwEXIeLQoicV2C87w2u3EkVP+2WOFQDyyfv8pBPXRhXg3UbtJQEuE6hRDXWyQJ8gBjA349aUQppp/D4garo5B6A7diJiPPr6xNk1g+1CPTFtEfWig+B9xFsNzgyacIchh7YHUB4Rz2FJvJ3zD+ntj7BJzj11Uha3U+l0/nna/R7YqmtmN8Av4/J8CYmDs1Sv8aLJYU/jW8fGaoDR//P5hhy8T9IS3h/FRTeSntFeBkBNjM+hHZ0C6ets3hDduMKYLr9il9MyJz6TdxB/87X0uBbfIdod1lucUFZQs9G71XtiNJKR1JWelWu8vG4oRogXbgj7JlAgJubaGmHoGXJvc7anx13uLs1ta6AbbQYMvA=
+    - secure: j7fuAPDXdl0SF1My1f0e3hr8mq4idP41jsz98Y1hN30GGOmIputScxIwSjIBi8zFCJ+K4RleMIoWLhnFsMeMD4DapRqDe5YnJJFOyfiyplzEcn4yONYRJf1nzfXBrpoGSEibgr/e3uYK62bkantI+b0pBPNAKbRjbRKKwTKEAxWb1pfaAMEQMB8/Wmvo0XYAZRB96H4q/7Dtd4CaIqh99Fs/9TjaGdNNtDtjwL0AWPXNfamsA8oNW0frNp1lEYpJpRE+PHFiKWZWyrRqjDA/UNU2UE/2H1O53I6tUXGJjORrUGRp1M9Xq/NhC8C4l7KrdpYH7YkYdvRDts3+XmJZ5kCsGB35YLP8DF1yUXIL4ZMskegBsBKqKKgnXGo4uYkaHp0QR2r8v2tdO8q3JWGYLSCgGVu5YkHU6Nlqf98W5LQLYSuZEkLplrk9vISHNS6TI4G3m7huToY1HwOu01hTZHAEhr/ouUxOfu6pQs8ZYVCyj98o65KFlFCRa7qKHc2/lXVbFPaOeQmFYqCGfFMTB0G0DHlsyOJk3QzoTr0HxJlbEwh9XLJOAnGO/TwcOUZndlj0+lTuCTpeBhjHywr+b00HnYtJ3cVnUVjT8TZydG2ATogeKRvOe0m58ug36EUGwbjr0JoN2hHjeFNSdvTUzFFFmRBY9rps47rzEDyRBGc=
+    - secure: jtK2GwC2Z97r1LdZpqDoj7UGVbTq9Dk+CdXXRbrWuSFCc/SA/TFFeEaHJHm1V0oVFeC5YVpu2B7Z/Di71SmqF/tafArLuDF5LCFegddZBlG372xaKn/ilfLRriA9dyb/yopmnRInqh9ynd1/CokNFjMAKuj4bZYJZImL7nsY9iCdAfuv51thQg2Nd4oj50SiR9MSgEhxOsdos5CncJqSbJrw9KEJGpz69ZtOD6p6UVfd8PgCaDSRuU/RaTAZLLFznRW4+OcUyOy1KXkmEyo7YoF6D/OJvS5INYvACk3/5o5qNYA7YJh6MfQbHd0Y9qvjGO6jvPRikNWhbo4pvCDNx37A5B9BdvUQFpP1T1SdBGCWdfF9qDvskw95kryh/fbs5YTd6rjQUGlQ9Qzt7eJFUd3SpasZRviqcHHyGCJtTqOw0ow6rMYmk2dSDoAi+/H6DDxuZc/a0K+s9U/fCDGCUCee2IyD8zz1CoG+BKO66rVHN1eeuOKlaDzmG6gPLcTbOCcP/jlM/KlBTQO2vzUvc7k0tBb9NunLXSV2eu5zXPyyVbCsKkc2wCNKO40Hsmx9+lALmS4LVlxNBHcNmdHWYiSIOVH2yhM7Ud1/Wsj2NVjzd2KJ5WAuO85cegn3r1o+VtsFNr8YeFdiNCyYETgfxs3OoLnhG/wN++oxXGeXXpQ=
+    - secure: BZBVvKMZaMuMBq3LvdwpBEnyk2OO9yDu+Izxqvoba3/QT2zD0lA8bOFFUYErjuhKecmda1OyNnjdejs2wpGxEEal21AR/BoNHeVTH7euaQzjhWo9MaBnnpFqsKABxy4EFdHZHGD90LrrFoCj7HgI4w+BxABQSsdSuWNYHl4oCyAF9TsPnKGFIlW0HlAR32rxaWHjuxVtxLkiws2GJbyjA3EDSJb7vB5pfnJPTaLTPkgZpAWHa8cGQoXQrZdfG0an7dg3GdPKPc75N0piVqnpEDK89wCpjSK5AwYrsjcc5E1cjJiab9XNopZDLxQzWf8+u455TrSAvcZNkev5o/qg1hbHqnUkOoMvGbipyyNxu0/dzElesRYQ7673fGT/yiZDd7re9qUz31HFIDC5TUfMPoVs0NMX+lNHEDy9FH5UvVV8udTVAJPw5+7vjzd3CpMIGWHt9Syk6OwU1BxdHIeielrlfK7YMkgXQe69KcLKwIdg5QaF7l4I0EtDQ4Ra5d/N36uyLejBIZ7laOgl1IAO9zUXoEtvEI7mcivvWAOSdV6FblG5U4K+/27d3FxRmO06KuIVaYEbPp2HWeVaJADxqTVpRp5bUZ8aEGWihI4L74UbHXWRUPkHt4AG16Ubb/hTrYnCCKL3pvUMFBU5/LoJeyjCVGgi0WOFBaJJazl3XyI=
+    - secure: L5Ko19kx9zbaqZJWKP+elx5G4/OO8WC0PnY4Dacv0hULtv09sEP0g4EKcMP6spMeEsz4B/i/JQzySSqaprcP0Jl2MumjMD4tN9XOHhGQKeqT7FwchyVm0d7HfB2eIQ9wrgNn+4+b3sJPKDla+0OGONLR29CZNZvu9Ev1iPUkfHYz0CFdP2FDNyMJv6XMln6uOPtpSXyIi/YdRCWWVwIjIdp2oMordGt66EUq1BIfv4gcVuBYfekljs/62llt2m4FXh5Z2LkUt7/4od4RZyWvM6yaYk33iSul0uzGJ7hfTRoHbJbJTMlmjkQTZoCFGdnCxIGpVSHR57hOin82NVw5Uj3Y+T/0QwyYCrH0khaqThUEqnvAhd0zf0HsBwpABVzjK8wWynF7aN11vWzTURr7RzaDSMAhWRvfjlrurRkPcsFpewzg8KvowdrFT5MErj3YVWL2/0TqEKImlB/v+ip35YFk3ZigJtA7UKQajAW+zrEbf0pizEmdyUmZDBlBJ5euDJybM+hk204MSYgA1CTSzVlgWoW+M0UPOJtPDnC1YaHtcUBhEWx/rJeIVq3GfBuwN0xHm1WhcctIv7+WR+Fn3QadvWeCc2EcQOdDzqKI52GI+RyFYQheXTL2ULpRpBdzbAD0JkVueFhCFdWTv7EHIak3WCal+P2DC9ay4TzFlW4=
+    - secure: MteZFKkISMErROvLnjoZipPFBPWoaF0xxncTD76qN1AO2N/oK59O4pxSYN6+yqP8KEp4K1maNOsV2BcE5WGkH5R6jfdezVfvxKbKIoIECWhgK2e0rR4Cp4833cw4F6maSqcLkJL5zDeHyHbofzLLVd/1qugz07vZx2GJGTgt2KJtN+j0zeVp0SC7BQwY8RZZ0BSZB06SjsG05AiBIUfnJqVmGCb1ORZvPD5F6sa0HF/dsuR+m6ITYhQfR6A2gKpW6ZE5YS1wNg/J4gybQcko1jZMaiORdUcKH+0DyedhBh6Ne2spfC5kvIUynEm63u5igRwEXIeLQoicV2C87w2u3EkVP+2WOFQDyyfv8pBPXRhXg3UbtJQEuE6hRDXWyQJ8gBjA349aUQppp/D4garo5B6A7diJiPPr6xNk1g+1CPTFtEfWig+B9xFsNzgyacIchh7YHUB4Rz2FJvJ3zD+ntj7BJzj11Uha3U+l0/nna/R7YqmtmN8Av4/J8CYmDs1Sv8aLJYU/jW8fGaoDR//P5hhy8T9IS3h/FRTeSntFeBkBNjM+hHZ0C6ets3hDduMKYLr9il9MyJz6TdxB/87X0uBbfIdod1lucUFZQs9G71XtiNJKR1JWelWu8vG4oRogXbgj7JlAgJubaGmHoGXJvc7anx13uLs1ta6AbbQYMvA=
+    - CONDA_HOME=$HOME/conda
+    - DOWNLOAD_CACHE=$HOME/downloads
+  matrix:
+    - START_TARGET=       TEST_TARGET=test-unit
+    - START_TARGET=start  TEST_TARGET=test-func
+    - START_TARGET=       TEST_TARGET=test-online
 cache:
   - pip
   - directories:
@@ -38,17 +38,16 @@ before_install:
   - make info
 install:
   - make install
-before_script:
-  - sleep 5
 stages:
-  - check   # run linting checks and don't bother with the rest if invalid
-  - test    # use default stage to run job matrix variations
-  - coverage
-  - extra
-  - functional
+  - check     # run linting checks and don't bother with the rest if invalid
+  - test      # use default stage to run job matrix variations
+  - extra     # extra tests that did not belong to any other category
+  - coverage  # only run once after everything else
 script:
+  # start as required as sleep a bit to let application boot before tests
+  - if [ "${START_TARGET}" == "start" ]; then make start; sleep 5; fi
   # script executed for each job matrix variation in 'test' stage
-  - make test-unit
+  - make ${TEST_TARGET}
 jobs:
   include:
     # use stages to quick fail faster tests
@@ -64,16 +63,22 @@ jobs:
       script: make coverage
     - stage: extra
       name: "Extra Tests"
-      script: make TEST='not (functional or testbed14) and (slow or online)' test-spec
-    - stage: functional
-      name: "Functional Tests"
       script:
-        - make start
-        - make test-func test-online
+        - make TESTS='(slow or testbed14) and not functional' test-spec
+    - stage: test
+      name: "Windows Test (experimental)"
+      os: windows
+      language: bash
+      python: "3.8"
+      before_install:
+        - choco install python3
+        - export PATH="/c/Python38:/c/Python38/Scripts:$PATH"
+        - python -m pip install --upgrade pip wheel
   allow_failures:
     - python: "2.7"   # deprecated support
     - python: "3.8"   # experimental packages
     - os: windows     # experimental support
+  fast_finish: true   # required jobs will indicate success as soon as possible
 notifications:
   email: false
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ script:
   - make ${MAKE_TEST_CMD}
 stages:
   - check
-  - test
+  - unittest
   - coverage
   - extra
   - functional
@@ -55,7 +55,7 @@ jobs:
       python: "3.7"
       os: linux
       env: MAKE_TEST_CMD=check docs
-    - stage: test  # use default stage to avoid duplicate run
+    - stage: unittest
       name: "Unit Tests"
       env: MAKE_TEST_CMD=test-unit
     - stage: coverage
@@ -69,6 +69,9 @@ jobs:
     - stage: functional
       name: "Functional Tests"
       env: MAKE_TEST_CMD=test-func test-online
+  # ignore default stage
+  exclude:
+    - stage: test
   allow_failures:
     - python: "2.7"   # deprecated support
     - python: "3.8"   # experimental packages

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ script:
   - make ${MAKE_TEST_CMD}
 stages:
   - check
-  - unittest
+  - test
   - coverage
   - extra
   - functional
@@ -55,7 +55,7 @@ jobs:
       python: "3.7"
       os: linux
       env: MAKE_TEST_CMD=check docs
-    - stage: unittest
+    - stage: test  # use default stage to avoid duplicate run
       name: "Unit Tests"
       env: MAKE_TEST_CMD=test-unit
     - stage: coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,17 @@
 language: python
 os:
   - linux
-  - windows
+  - os: windows
+    language: sh
+    python: "3.8"
+    before_install:
+      - choco install python3
+      - export PATH="/c/Python38:/c/Python38/Scripts:$PATH"
+      - python -m pip install --upgrade pip wheel
 python:
+  - "3.7"  # default test python
   - "2.7"
   - "3.6"
-  - "3.7"
   - "3.8"
 env:
   global:
@@ -35,7 +41,7 @@ install:
 before_script:
   - sleep 5
 stages:
-  - check   # run linting checks and don't bother with the rest if invlaid
+  - check   # run linting checks and don't bother with the rest if invalid
   - test    # use default stage to run job matrix variations
   - coverage
   - extra

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 os:
   - linux
+  - windows
 python:
   - "2.7"
   - "3.6"
@@ -31,18 +32,17 @@ before_install:
   - make info
 install:
   - make install
-  - make start
 before_script:
   - sleep 5
-script:
-  # run operation for each job matrix variation
-  - make ${MAKE_TEST_CMD}
 stages:
-  - check
-  - test  # use default stage to run matrix
+  - check   # run linting checks and don't bother with the rest if invlaid
+  - test    # use default stage to run job matrix variations
   - coverage
   - extra
   - functional
+script:
+  # script executed for each job matrix variation in 'test' stage
+  - make test-unit
 jobs:
   include:
     # use stages to quick fail faster tests
@@ -50,21 +50,20 @@ jobs:
       name: "Linter Checks"
       python: "3.7"
       os: linux
-      env: MAKE_TEST_CMD=check docs
-    - stage: test
-      name: "Unit Tests"
-      env: MAKE_TEST_CMD=test-unit
+      script: make check docs
     - stage: coverage
       name: "Coverage"
       python: "3.7"
       os: linux
-      env: MAKE_TEST_CMD=coverage
+      script: make coverage
     - stage: extra
       name: "Extra Tests"
-      env: MAKE_TEST_CMD=TEST='not (functional or testbed14) and (slow or online)' test-spec
+      script: make TEST='not (functional or testbed14) and (slow or online)' test-spec
     - stage: functional
       name: "Functional Tests"
-      env: MAKE_TEST_CMD=test-func test-online
+      script:
+        - make start
+        - make test-func test-online
   allow_failures:
     - python: "2.7"   # deprecated support
     - python: "3.8"   # experimental packages

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,15 +35,11 @@ install:
 before_script:
   - sleep 5
 script:
-  # run static analysis only once (run ifs separately to identify the failing case)
-  - if [ "${TRAVIS_PYTHON_VERSION}" == "3.7" ]; then make check; fi
-  - if [ "${TRAVIS_PYTHON_VERSION}" == "3.7" ]; then make coverage; fi
-  - if [ "${TRAVIS_PYTHON_VERSION}" == "3.7" ]; then make docs; fi
-  # run tests for each python version
+  # run operation for each job matrix variation
   - make ${MAKE_TEST_CMD}
 stages:
   - check
-  - unittest
+  - test  # use default stage to run matrix
   - coverage
   - extra
   - functional
@@ -55,7 +51,7 @@ jobs:
       python: "3.7"
       os: linux
       env: MAKE_TEST_CMD=check docs
-    - stage: unittest
+    - stage: test
       name: "Unit Tests"
       env: MAKE_TEST_CMD=test-unit
     - stage: coverage
@@ -69,9 +65,6 @@ jobs:
     - stage: functional
       name: "Functional Tests"
       env: MAKE_TEST_CMD=test-func test-online
-  # ignore default stage
-  exclude:
-    - stage: test
   allow_failures:
     - python: "2.7"   # deprecated support
     - python: "3.8"   # experimental packages

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 os:
   - linux
-#  - osx
 python:
   - "2.7"
   - "3.6"
@@ -41,12 +40,39 @@ script:
   - if [ "${TRAVIS_PYTHON_VERSION}" == "3.7" ]; then make coverage; fi
   - if [ "${TRAVIS_PYTHON_VERSION}" == "3.7" ]; then make docs; fi
   # run tests for each python version
-  - make test
-matrix:
+  - make ${MAKE_TEST_CMD}
+stages:
+  - check
+  - unittest
+  - coverage
+  - extra
+  - functional
+jobs:
+  include:
+    # use stages to quick fail faster tests
+    - stage: check
+      name: "Linter Checks"
+      python: "3.7"
+      os: linux
+      env: MAKE_TEST_CMD=check docs
+    - stage: unittest
+      name: "Unit Tests"
+      env: MAKE_TEST_CMD=test-unit
+    - stage: coverage
+      name: "Coverage"
+      python: "3.7"
+      os: linux
+      env: MAKE_TEST_CMD=coverage
+    - stage: extra
+      name: "Extra Tests"
+      env: MAKE_TEST_CMD=TEST='not (functional or testbed14) and (slow or online)' test-spec
+    - stage: functional
+      name: "Functional Tests"
+      env: MAKE_TEST_CMD=test-func test-online
   allow_failures:
-    - os: osx
     - python: "2.7"   # deprecated support
     - python: "3.8"   # experimental packages
+    - os: windows     # experimental support
 notifications:
   email: false
 after_success:

--- a/Makefile
+++ b/Makefile
@@ -275,7 +275,7 @@ test-unit: install-dev		## run unit tests (skip long running and online tests)
 	 	--junitxml $(APP_ROOT)/tests/results.xml"
 
 .PHONY: test-func
-test-func: install-dev		## run funtional tests (online and usage specific)
+test-func: install-dev		## run functional tests (online and usage specific)
 	@echo "Running functional tests..."
 	@bash -c "$(CONDA_CMD) pytest tests -v -m 'functional' --junitxml $(APP_ROOT)/tests/results.xml"
 

--- a/tests/travis-ci/custom.cfg
+++ b/tests/travis-ci/custom.cfg
@@ -1,9 +1,0 @@
-[buildout]
-extends = buildout.cfg
-
-[settings]
-mongodb-host = localhost
-mongodb-port = 27017
-mongodb-dbname = weaver-travis-test
-
-data-sources = data_sources.json


### PR DESCRIPTION
Use travis stages for early failure of linter checks before batch tests with job/env/matrix.
Also, travis will mark success build earlier if all required tests are passed regardless of optional ones.

Before we had to open the "Python 3.7"  test which was running linters and look through the whole log to check if this was the cause of failure. This specific test was also very long as it ran many extras.

Failing use cases will also be more clearly highlighted per-version, per-os and per-test subset.

# what we had before: 
![image](https://user-images.githubusercontent.com/19194484/81885703-ed624800-9568-11ea-8201-3bf9fd6e77d3.png)

# what we got now: 
![image](https://user-images.githubusercontent.com/19194484/81885649-ca379880-9568-11ea-9c65-06d477f23f96.png)
