### PR TITLE
pywps workdir

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ Changes:
 - Add file ``weaver.request_options`` INI configuration setting to specify per-request method/URL options.
 - Add ``requests_extra`` support of ``Retry-After`` response header (if any available on ``429`` status) which indicates
   how long to wait until next request to avoid automatically defined response right after.
+- Add ``weaver.wps_workdir`` configuration setting with allow setting corresponding ``pywps.workdir`` directory.
 
 Fixes:
 ------
@@ -29,6 +30,7 @@ Fixes:
 - Fix invalid handling of ``wps_processes.yml`` reference in ``weaver.ini`` when specified as relative path to
   configuration directory.
 - Fix handling of ``WPS<->CWL`` I/O merge of ``data_format`` field against ``supported_formats`` with ``pywps>=4.2.4``.
+- Fix installation of ``yaml``-related packages for Python 2 backward compatibility.
 
 `1.7.0 <https://github.com/crim-ca/weaver/tree/1.7.0>`_ (2020-05-15)
 ========================================================================

--- a/config/weaver.ini.example
+++ b/config/weaver.ini.example
@@ -47,7 +47,10 @@ weaver.wps_output = true
 weaver.wps_output_dir = /tmp
 weaver.wps_output_url =
 weaver.wps_output_path = /wpsoutputs
+weaver.wps_workdir =
 # --- WPS metadata ---
+# all attributes under "metadata:main" can be specified as 'weaver.wps_metadata_<field>'
+# (reference: https://pywps.readthedocs.io/en/master/configuration.html#metadata-main)
 weaver.wps_metadata_identification_title=Weaver
 weaver.wps_metadata_identification_abstract=Weaver internal WPS used for demo and testing.
 weaver.wps_metadata_identification_keywords=Weaver,WPS,OGC

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,8 @@ requests_file
 # ensure minimal 0.15.78 to solve install issue (python 3.8)
 # (https://bitbucket.org/ruamel/yaml/issues/261/error-while-installing-ruamelyaml-setuppy)
 # let cwltool fully define the version if python 2 is used
-ruamel.yaml>=0.15.78,<=0.16.5
+ruamel.yaml>=0.15.78,<=0.16.5; python_version >= "3"
+ruamel.yaml; python_version < "3"
 shapely
 six
 simplejson

--- a/weaver/wps.py
+++ b/weaver/wps.py
@@ -154,6 +154,11 @@ def load_pywps_cfg(container, config=None):
             output_url = pywps_config.get_config_value("server", "outputurl")
         settings["weaver.wps_output_url"] = output_url
 
+    # apply workdir if provided, otherwise use default
+    if "weaver.wps_workdir" in settings:
+        make_dirs(settings["weaver.wps_workdir"], exist_ok=True)
+        WEAVER_PYWPS_CFG.set("server", "workdir", settings["weaver.wps_workdir"])
+
     # enforce back resolved values onto PyWPS config
     WEAVER_PYWPS_CFG.set("server", "setworkdir", "true")
     WEAVER_PYWPS_CFG.set("server", "sethomedir", "true")


### PR DESCRIPTION
- add ``weaver.wps_workdir`` config to set where fetched tmp files will be written to during WPS process execution
- fix yaml requirements for python 2