### PR TITLE
fix source path of coverage report to avoid losing some files

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,13 +5,13 @@ tag = True
 tag_name = {new_version}
 
 [bumpversion:file:CHANGES.rst]
-search = 
+search =
 	`Unreleased <https://github.com/crim-ca/weaver/tree/master>`_ (latest)
 	========================================================================
-replace = 
+replace =
 	`Unreleased <https://github.com/crim-ca/weaver/tree/master>`_ (latest)
 	========================================================================
-	
+
 	`{new_version} <https://github.com/crim-ca/weaver/tree/{new_version}>`_ ({now:%%Y-%%m-%%d})
 	========================================================================
 
@@ -32,12 +32,12 @@ search = LABEL version="{current_version}"
 replace = LABEL version="{new_version}"
 
 [tool:pytest]
-addopts = 
+addopts =
 	--strict
 	--tb=native
 	weaver/
 python_files = test_*.py
-markers = 
+markers =
 	testbed14: mark test as 'testbed14' validation
 	functional: mark test as functionality validation
 	online: mark test to need internet connection
@@ -60,7 +60,7 @@ targets = .
 [flake8]
 ignore = E126,E226,E402,F401,W504
 max-line-length = 120
-exclude = 
+exclude =
 	src,
 	.git,
 	__pycache__,
@@ -79,11 +79,11 @@ ignore-path = docs/build
 
 [coverage:run]
 branch = true
-source = weaver
+source = ./
 omit = tests/*
 
 [coverage:report]
-exclude_lines = 
+exclude_lines =
 	pragma: no cover
 	raise AssertionError
 	raise NotImplementedError

--- a/setup.cfg
+++ b/setup.cfg
@@ -79,8 +79,16 @@ ignore-path = docs/build
 
 [coverage:run]
 branch = true
+# define source so that filenames all employ the full path relative to repository root
+# avoids mistakenly dropping some file coverage results because of name clashes or path resolution by report parser
+# (see: https://community.codecov.io/t/missing-files-in-codecov-but-not-in-report/825)
 source = ./
-omit = tests/*
+# include only weaver package directory and make sure other locations sometime picked up are ignored
+include = weaver/*
+omit =
+	setup.py
+	docs/*
+	tests/*
 
 [coverage:report]
 exclude_lines =


### PR DESCRIPTION
Some files (most importantly `weaver/utils.py`) were lost during report/calculation of coverage on codecov.io (https://community.codecov.io/t/missing-files-in-codecov-but-not-in-report/825) when source/root is `./weaver`. Others where generating inconsistent coverage values (eg: `weaver/datatype.py`). This fixes both issues.

For some reason, most files where found automatically, but only some listed here where not handled correctly: 
https://codecov.io/gh/crim-ca/weaver/pull/160/changes

