### PR TITLE
config workdir and type handling

### DIFF
--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -1,16 +1,17 @@
 # reference: https://github.com/github/issue-labeler
 
-name: "Issue Labeler"
-on:
-  issues:
-    types: [opened, edited]
-
-jobs:
-  triage:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: github/issue-labeler@v2.0
-      with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        configuration-path: .github/labeler-words.yml
-        enable-versioned-regex: 0
+# FIXME: find a way to avoid the label to remove tags...
+#name: "Issue Labeler"
+#on:
+#  issues:
+#    types: [opened, edited]
+#
+#jobs:
+#  triage:
+#    runs-on: ubuntu-latest
+#    steps:
+#    - uses: github/issue-labeler@v2.0
+#      with:
+#        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+#        configuration-path: .github/labeler-words.yml
+#        enable-versioned-regex: 0

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,22 @@ Changes
 `Unreleased <https://github.com/crim-ca/weaver/tree/master>`_ (latest)
 ========================================================================
 
+Changes:
+--------
+
+- Add ``weaver.wps_workdir`` configuration setting to define the location where the underlying ``cwltool`` application
+  should be executed under.
+- Use ``weaver.request_options`` for `WPS GetCapabilities` and `WPS Check Status` requests under the running job.
+- Change default ``DOCKER_REPO`` value defined in ``Makefile`` to point to reference mentioned in ``README.md`` and
+  considered as official deployment location.
+
+Fixes:
+------
+
+- Set ``get_cwl_file_format`` default argument ``must_exist=True`` instead of ``False`` to retrieve original default
+  behaviour of the function. Since `CWL` usually doesn't need to add ``File.format`` field when no corresponding
+  reference actually exists, this default also makes more sense.
+
 `1.8.1 <https://github.com/crim-ca/weaver/tree/1.8.1>`_ (2020-05-22)
 ========================================================================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,8 +8,13 @@ Changes:
 --------
 
 - Add ``weaver.wps_workdir`` configuration setting to define the location where the underlying ``cwltool`` application
-  should be executed under.
+  should be executed under. This can allow more control over the scope of the mounted volumes for *Application Package*
+  running a docker image.
+- Add *experimental* configuration settings ``weaver.cwl_euid`` and ``weaver.cwl_egid`` to provide effective user/group
+  identifiers to employ when running the CWL *Application Package*. Using these require good control of the directory
+  and process I/O locations as invalid permissions could break a previously working job execution.
 - Use ``weaver.request_options`` for `WPS GetCapabilities` and `WPS Check Status` requests under the running job.
+- Enforced removal of some invalid `CWL` hints/requirements that would break the behaviour offered by ``Weaver``.
 - Change default ``DOCKER_REPO`` value defined in ``Makefile`` to point to reference mentioned in ``README.md`` and
   considered as official deployment location.
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,8 +13,16 @@ Changes:
 - Add *experimental* configuration settings ``weaver.cwl_euid`` and ``weaver.cwl_egid`` to provide effective user/group
   identifiers to employ when running the CWL *Application Package*. Using these require good control of the directory
   and process I/O locations as invalid permissions could break a previously working job execution.
+- Add more logging configuration and apply them to ``cwltool`` before execution of *Application Package*.
+- Enforce ``no_match_user=False`` and ``no_read_only=False`` of ``cwltool``'s ``RuntimeContext`` to ensure that docker
+  application is executed with same user as ``weaver`` and that process input files are not modified inplace (readonly)
+  where potentially inaccessible (according to settings). Definition of `CWL` package will need to add
+  `InitialWorkDirRequirement <https://www.commonwl.org/v1.0/CommandLineTool.html#InitialWorkDirRequirement>`_ as per
+  defined by reference specification to stage those files if they need to be accessed with write permissions
+  (see: `example <https://www.commonwl.org/user_guide/15-staging/>`_). Addresses some issues listed in
+  `#155 <https://github.com/crim-ca/weaver/issues/155>`_.
+- Enforce removal of some invalid `CWL` hints/requirements that would break the behaviour offered by ``Weaver``.
 - Use ``weaver.request_options`` for `WPS GetCapabilities` and `WPS Check Status` requests under the running job.
-- Enforced removal of some invalid `CWL` hints/requirements that would break the behaviour offered by ``Weaver``.
 - Change default ``DOCKER_REPO`` value defined in ``Makefile`` to point to reference mentioned in ``README.md`` and
   considered as official deployment location.
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ Changes:
 - Add ``weaver.wps_workdir`` configuration setting to define the location where the underlying ``cwltool`` application
   should be executed under. This can allow more control over the scope of the mounted volumes for *Application Package*
   running a docker image.
+- Add mapping of WPS results from the ``Job``'s UUID to generated `PyWPS` UUID for outputs, status and log locations.
 - Add *experimental* configuration settings ``weaver.cwl_euid`` and ``weaver.cwl_egid`` to provide effective user/group
   identifiers to employ when running the CWL *Application Package*. Using these require good control of the directory
   and process I/O locations as invalid permissions could break a previously working job execution.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,10 @@ Changes:
 - Use ``weaver.request_options`` for `WPS GetCapabilities` and `WPS Check Status` requests under the running job.
 - Change default ``DOCKER_REPO`` value defined in ``Makefile`` to point to reference mentioned in ``README.md`` and
   considered as official deployment location.
+- Add ``application/x-cwl`` MIME-type supported with updated ``EDAM 1.24`` onthology.
+- Add ``application/x-yaml``  MIME-type to known formats.
+- Add ``application/x-tar`` and ``application/tar+gzip`` MIME-type (not official) but resolved as *synonym*
+  ``application/gzip`` (official) to preserve compressed file support during `CWL` format validation.
 
 Fixes:
 ------

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,8 @@ APP_ROOT    := $(abspath $(lastword $(MAKEFILE_NAME))/..)
 APP_NAME    := $(shell basename $(APP_ROOT))
 APP_VERSION ?= 1.8.1
 APP_INI     ?= $(APP_ROOT)/config/$(APP_NAME).ini
-DOCKER_REPO ?= docker-registry.crim.ca/ogc/weaver
+DOCKER_REPO ?= pavics/weaver
+#DOCKER_REPO ?= docker-registry.crim.ca/ogc/weaver
 
 # guess OS (Linux, Darwin,...)
 OS_NAME := $(shell uname -s 2>/dev/null || echo "unknown")

--- a/config/weaver.ini.example
+++ b/config/weaver.ini.example
@@ -33,6 +33,7 @@ mongodb.db_name = weaver
 # --- Weaver Configuration ---
 weaver.configuration = ems
 weaver.url = http://localhost:4001
+
 # --- Weaver requests extension flags ---
 # SSL verification should be enabled for secured connections
 # setting is available for convenience, debug purposes and local environments
@@ -41,7 +42,16 @@ weaver.ssl_verify = true
 # file with request options to be used with 'weaver.utils.request_extra'
 # see 'requests_options.yml.example'
 weaver.request_options =
-# --- WPS settings ---
+
+# --- Weaver CWL settings ---
+# NOTE: [experimental]
+# enforce provided effective user/group identifiers for Application Package execution
+# values must be resolved as integers
+# (default: use cwltool auto-resolution according to running machine and current user/group)
+weaver.cwl_euid =
+weaver.cwl_egid =
+
+# --- Weaver WPS settings ---
 weaver.wps = true
 weaver.wps_url =
 weaver.wps_path = /ows/wps
@@ -50,7 +60,8 @@ weaver.wps_output_dir = /tmp
 weaver.wps_output_url =
 weaver.wps_output_path = /wpsoutputs
 weaver.wps_workdir =
-# --- WPS metadata ---
+
+# --- Weaver WPS metadata ---
 # all attributes under "metadata:main" can be specified as 'weaver.wps_metadata_<field>'
 # (reference: https://pywps.readthedocs.io/en/master/configuration.html#metadata-main)
 weaver.wps_metadata_identification_title=Weaver
@@ -59,13 +70,15 @@ weaver.wps_metadata_identification_keywords=Weaver,WPS,OGC
 weaver.wps_metadata_identification_accessconstraints=NONE
 weaver.wps_metadata_provider_name=CRIM
 weaver.wps_metadata_provider_url=http://pavics-weaver.readthedocs.org/en/latest/
-# --- WPS REST API ---
+
+# --- Weaver WPS REST API ---
 weaver.wps_restapi = true
 weaver.wps_restapi_url =
 weaver.wps_restapi_path = /
 weaver.wps_restapi_ref = https://app.swaggerhub.com/apis/geoprocessing/WPS/
 weaver.wps_restapi_doc = https://raw.githubusercontent.com/opengeospatial/wps-rest-binding/develop/docs/18-062.pdf
-# --- Job email notification ---
+
+# --- Weaver job email notification ---
 weaver.wps_email_encrypt_salt = salty-email
 weaver.wps_email_encrypt_rounds = 100000
 weaver.wps_email_notify_smtp_host =
@@ -75,7 +88,8 @@ weaver.wps_email_notify_port = 25
 weaver.wps_email_notify_ssl = true
 weaver.wps_email_notify_template_dir =
 weaver.wps_email_notify_template_default =
-# --- other configurations ---
+
+# --- Weaver other configurations ---
 # additional processes to load at startup (see 'wps_processes.yml.example')
 weaver.wps_processes_file = wps_processes.yml
 # known remote ADES for processes redirection based on data-sources when using EMS configuration

--- a/config/weaver.ini.example
+++ b/config/weaver.ini.example
@@ -122,7 +122,7 @@ timeout = 10
 ###
 
 [loggers]
-keys = root, weaver, celery
+keys = root, weaver, celery, cwltool
 
 [handlers]
 keys = console
@@ -131,19 +131,25 @@ keys = console
 keys = generic
 
 [logger_root]
-level = DEBUG
+level = INFO
 handlers = console
 
 [logger_weaver]
-level = DEBUG
+level = INFO
 handlers = console
 qualname = weaver
 propagate = 0
 
 [logger_celery]
-level = DEBUG
+level = INFO
 handlers = console
 qualname = celery
+propagate = 0
+
+[logger_cwltool]
+level = INFO
+handlers = console
+qualname = cwltool
 propagate = 0
 
 [handler_console]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -334,7 +334,10 @@ linkcheck_ignore = [
     # might not exist yet (we are generating it!)
     "https://pavics-weaver.readthedocs.io/en/latest/api.html",
     # ignore requires.io which just fails periodically - not critical link
-    "https://requires.io/github/crim-ca/weaver/.*"
+    "https://requires.io/github/crim-ca/weaver/.*",
+    # FIXME: tmp disable due to Retry-After header for rate-limiting by Github not respected
+    #        (see: https://github.com/sphinx-doc/sphinx/issues/7388)
+    "https://github.com/crim-ca/weaver/*",  # limit only our repo so others are still checked
 ]
 
 linkcheck_timeout = 30

--- a/tests/functional/test_wps_package.py
+++ b/tests/functional/test_wps_package.py
@@ -260,7 +260,7 @@ class WpsPackageAppTest(unittest.TestCase):
         ns_json, type_json = get_cwl_file_format(CONTENT_TYPE_APP_JSON, must_exist=True)
         assert "iana" in ns_json  # just to make sure
         ct_not_exists = "x-ogc-dods"    # OpenDAP, still doesn't exist at moment of test creation
-        ns_not_exists, type_not_exists = get_cwl_file_format(ct_not_exists, must_exist=False)
+        ns_not_exists, _ = get_cwl_file_format(ct_not_exists, must_exist=False)
         assert "iana" in ns_not_exists
         body = {
             "processDescription": {

--- a/tests/processes/test_wps_package.py
+++ b/tests/processes/test_wps_package.py
@@ -439,7 +439,7 @@ def assert_formats_equal_any_order(format_result, format_expect):
             if r_fmt.json == e_fmt.json:
                 format_expect.remove(e_fmt)
                 break
-    assert not format_expect, "Not all expected formats matched {}".format([f.json for f in format_expect])
+    assert not format_expect, "Not all expected formats matched {}".format([fmt.json for fmt in format_expect])
 
 
 def test_merge_io_formats_no_wps():

--- a/weaver/database/base.py
+++ b/weaver/database/base.py
@@ -1,9 +1,14 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from weaver.typedefs import AnySettingsContainer
+
+
 class DatabaseInterface(object):
     """Return the unique identifier of db type matching settings."""
     __slots__ = ["type"]
 
-    def __init__(self, registry):   # noqa: E811
-        # FIXME: remove pylint disable when https://github.com/PyCQA/pylint/issues/3364 is fixed
-        # pylint: disable=E1101,no-member
-        if not self.type:
+    def __init__(self, container):   # noqa: E811
+        # type: (AnySettingsContainer) -> None
+        if not self.type:  # pylint: disable=E1101,no-member
             raise NotImplementedError("Database 'type' must be overridden in inheriting class.")

--- a/weaver/database/mongodb.py
+++ b/weaver/database/mongodb.py
@@ -42,10 +42,11 @@ class MongoDatabase(DatabaseInterface):
     _stores = None
     type = "mongodb"
 
-    def __init__(self, registry):
-        super(MongoDatabase, self).__init__(registry)
-        self._database = get_mongodb_engine(registry)
-        self._settings = registry.settings
+    def __init__(self, container):
+        # type: (AnySettingsContainer) -> None
+        super(MongoDatabase, self).__init__(container)
+        self._database = get_mongodb_engine(container)
+        self._settings = get_settings(container)
         self._stores = dict()
 
     def is_ready(self):

--- a/weaver/formats.py
+++ b/weaver/formats.py
@@ -85,13 +85,13 @@ EDAM_MAPPING = {
 FORMAT_NAMESPACES = frozenset([IANA_NAMESPACE, EDAM_NAMESPACE])
 
 
-def get_cwl_file_format(mime_type, make_reference=False, must_exist=False):
+def get_cwl_file_format(mime_type, make_reference=False, must_exist=True):
     # type: (AnyStr, bool, bool) -> Union[Tuple[Union[JSON, None], Union[AnyStr, None]], Union[AnyStr, None]]
     """
     Obtains the corresponding `IANA`/`EDAM` ``format`` value to be applied under a `CWL` I/O ``File`` from
     the ``mime_type`` (`Content-Type` header) using the first matched one.
 
-    If ``make_reference=False``:
+    - If ``make_reference=False``:
         - If there is a match, returns ``tuple({<namespace-name: namespace-url>}, <format>)``:
             1) corresponding namespace mapping to be applied under ``$namespaces`` in the `CWL`.
             2) value of ``format`` adjusted according to the namespace to be applied to ``File`` in the `CWL`.
@@ -99,14 +99,17 @@ def get_cwl_file_format(mime_type, make_reference=False, must_exist=False):
             returns a literal and non-existing definition as ``tuple({"iana": <iana-url>}, <format>)``
         - Otherwise, returns ``(None, None)``
 
-    If ``make_reference=True``:
+    - If ``make_reference=True``:
         - If there is a match, returns the explicit format reference as ``<namespace-url>/<format>``.
         - If there is no match but ``must_exist=False``, returns the literal reference as ``<iana-url>/<format>``.
         - Otherwise, returns a single ``None``.
 
     Note:
-        In situations where ``must_exist=False`` and the default non-existing namespace is returned, the `CWL`
-        behaviour is to evaluate corresponding ``format`` for literal matching strings.
+        In situations where ``must_exist=False`` is used and that the namespace and/or full format URL cannot be
+        resolved to an existing reference, `CWL` will raise a validation error as it cannot confirm the ``format``.
+        You must therefore make sure that the returned reference really exists when using ``must_exist=False`` before
+        providing it to the `CWL` I/O definition. This parameter should be used only for literal string comparison or
+        pre-processing steps to evaluate formats.
     """
     def _make_if_ref(_map, _key, _fmt):
         return os.path.join(_map[_key], _fmt) if make_reference else (_map, "{}:{}".format(_key, _fmt))

--- a/weaver/formats.py
+++ b/weaver/formats.py
@@ -10,15 +10,20 @@ from six.moves.urllib.request import urlopen
 from weaver.utils import request_extra
 
 if TYPE_CHECKING:
-    from weaver.typedefs import JSON                # noqa: F401
-    from typing import AnyStr, Dict, Tuple, Union   # noqa: F401
+    from weaver.typedefs import JSON                            # noqa: F401
+    from typing import AnyStr, Dict, Optional, Tuple, Union     # noqa: F401
 
 # Content-Types
+#   MIME-type nomenclature:
+#       <type> "/" [x- | <tree> "."] <subtype> ["+" suffix] *[";" parameter=value]
+CONTENT_TYPE_APP_CWL = "application/x-cwl"
 CONTENT_TYPE_APP_FORM = "application/x-www-form-urlencoded"
 CONTENT_TYPE_APP_NETCDF = "application/x-netcdf"
 CONTENT_TYPE_APP_GZIP = "application/gzip"
 CONTENT_TYPE_APP_HDF5 = "application/x-hdf5"
-CONTENT_TYPE_APP_TAR = "application/x-tar"
+CONTENT_TYPE_APP_TAR = "application/x-tar"          # map to existing gzip for CWL
+CONTENT_TYPE_APP_TAR_GZ = "application/tar+gzip"    # map to existing gzip for CWL
+CONTENT_TYPE_APP_YAML = "application/x-yaml"
 CONTENT_TYPE_APP_ZIP = "application/zip"
 CONTENT_TYPE_TEXT_HTML = "text/html"
 CONTENT_TYPE_TEXT_PLAIN = "text/plain"
@@ -31,32 +36,65 @@ CONTENT_TYPE_TEXT_XML = "text/xml"
 CONTENT_TYPE_ANY_XML = {CONTENT_TYPE_APP_XML, CONTENT_TYPE_TEXT_XML}
 CONTENT_TYPE_ANY = "*/*"
 
+# explicit mime-type to extension when not literally written in item after '/' (excluding 'x-' prefix)
 _CONTENT_TYPE_EXTENSION_MAPPING = {
     CONTENT_TYPE_APP_NETCDF: ".nc",
     CONTENT_TYPE_APP_GZIP: ".gz",
+    CONTENT_TYPE_APP_TAR_GZ: ".tar.gz",
+    CONTENT_TYPE_APP_YAML: ".yml",
     CONTENT_TYPE_ANY: ".*",   # any for glob
 }  # type: Dict[AnyStr, AnyStr]
 # extend with all known pywps formats
-_CONTENT_TYPE_FORMATS = {
-    # content-types here are fully defined with extra parameters (eg: geotiff as subtype of tiff)
+_CONTENT_TYPE_FORMAT_MAPPING = {
+    # content-types here are fully defined with extra parameters (e.g.: geotiff as subtype of tiff)
     fmt.mime_type: fmt for _, fmt in FORMATS._asdict().items()  # noqa: W0212
 }  # type: Dict[AnyStr, Format]
 _CONTENT_TYPE_EXTENSION_MAPPING.update({
-    ctype: fmt.extension for ctype, fmt in _CONTENT_TYPE_FORMATS.items()  # noqa: W0212
+    ctype: fmt.extension for ctype, fmt in _CONTENT_TYPE_FORMAT_MAPPING.items()  # noqa: W0212
 })
+# redirect type resolution semantically equivalent CWL validators
+# should only be used to map CWL 'format' field if they are not already resolved through existing IANA/EDAM reference
+_CONTENT_TYPE_SYNONYM_MAPPING = {
+    CONTENT_TYPE_APP_TAR: CONTENT_TYPE_APP_GZIP,
+    CONTENT_TYPE_APP_TAR_GZ: CONTENT_TYPE_APP_GZIP,
+}
+
+# Mappings for "CWL->File->Format"
+# IANA contains most standard MIME-types, but might not include special (application/x-hdf5, application/x-netcdf, etc.)
+# EDAM contains many field-specific schemas, but don't have an implicit URL definition (uses 'format_<id>' instead)
+# search:
+#   - IANA: https://www.iana.org/assignments/media-types/media-types.xhtml
+#   - EDAM-classes: http://bioportal.bioontology.org/ontologies/EDAM/?p=classes (section 'Format')
+#   - EDAM-browser: https://ifb-elixirfr.github.io/edam-browser/
+IANA_NAMESPACE = "iana"
+IANA_NAMESPACE_DEFINITION = {IANA_NAMESPACE: "https://www.iana.org/assignments/media-types/"}
+EDAM_NAMESPACE = "edam"
+EDAM_NAMESPACE_DEFINITION = {EDAM_NAMESPACE: "http://edamontology.org/"}
+EDAM_SCHEMA = "http://edamontology.org/EDAM_1.24.owl"
+EDAM_MAPPING = {
+    CONTENT_TYPE_APP_CWL: "format_3857",
+    CONTENT_TYPE_APP_HDF5: "format_3590",
+    CONTENT_TYPE_APP_JSON: "format_3464",
+    CONTENT_TYPE_APP_NETCDF: "format_3650",
+    CONTENT_TYPE_APP_YAML: "format_3750",
+    CONTENT_TYPE_TEXT_PLAIN: "format_1964",
+}
+FORMAT_NAMESPACES = frozenset([IANA_NAMESPACE, EDAM_NAMESPACE])
 
 
 def get_format(mime_type):
     # type: (AnyStr) -> Format
     """Obtains a :class:`Format` with predefined extension and encoding details from known MIME-types."""
     ctype = clean_mime_type_format(mime_type, strip_parameters=True)
-    return _CONTENT_TYPE_FORMATS.get(mime_type, Format(ctype, extension=get_extension(ctype)))
+    return _CONTENT_TYPE_FORMAT_MAPPING.get(mime_type, Format(ctype, extension=get_extension(ctype)))
 
 
 def get_extension(mime_type):
     # type: (AnyStr) -> AnyStr
-    """Retrieves the extension corresponding to ``mime_type`` if explicitly defined, or by simple parsing otherwise."""
-    fmt = _CONTENT_TYPE_FORMATS.get(mime_type)
+    """
+    Retrieves the extension corresponding to :paramref:`mime_type` if explicitly defined, or by parsing it.
+    """
+    fmt = _CONTENT_TYPE_FORMAT_MAPPING.get(mime_type)
     if fmt:
         return fmt.extension
     ext = _CONTENT_TYPE_EXTENSION_MAPPING.get(mime_type)
@@ -66,57 +104,54 @@ def get_extension(mime_type):
     return _CONTENT_TYPE_EXTENSION_MAPPING.get(ctype, ".{}".format(ctype.split("/")[-1].replace("x-", "")))
 
 
-# Mappings for "CWL->File->Format"
-# IANA contains most standard MIME-types, but might not include special (application/x-hdf5, application/x-netcdf, etc.)
-# search:
-#   - IANA: https://www.iana.org/assignments/media-types/media-types.xhtml
-#   - EDAM: http://bioportal.bioontology.org/ontologies/EDAM/?p=classes (section 'Format')
-IANA_NAMESPACE = "iana"
-IANA_NAMESPACE_DEFINITION = {IANA_NAMESPACE: "https://www.iana.org/assignments/media-types/"}
-EDAM_NAMESPACE = "edam"
-EDAM_NAMESPACE_DEFINITION = {EDAM_NAMESPACE: "http://edamontology.org/"}
-EDAM_SCHEMA = "http://edamontology.org/EDAM_1.21.owl"
-EDAM_MAPPING = {
-    CONTENT_TYPE_APP_HDF5: "format_3590",
-    CONTENT_TYPE_APP_JSON: "format_3464",
-    CONTENT_TYPE_APP_NETCDF: "format_3650",
-    CONTENT_TYPE_TEXT_PLAIN: "format_1964",
-}
-FORMAT_NAMESPACES = frozenset([IANA_NAMESPACE, EDAM_NAMESPACE])
-
-
-def get_cwl_file_format(mime_type, make_reference=False, must_exist=True):
-    # type: (AnyStr, bool, bool) -> Union[Tuple[Union[JSON, None], Union[AnyStr, None]], Union[AnyStr, None]]
+def get_cwl_file_format(mime_type, make_reference=False, must_exist=True, allow_synonym=True):
+    # type: (AnyStr, bool, bool, bool) -> Union[Tuple[Optional[JSON], Optional[AnyStr]], Optional[AnyStr]]
     """
     Obtains the corresponding `IANA`/`EDAM` ``format`` value to be applied under a `CWL` I/O ``File`` from
-    the ``mime_type`` (`Content-Type` header) using the first matched one.
+    the :paramref:`mime_type` (`Content-Type` header) using the first matched one.
 
     - If ``make_reference=False``:
-        - If there is a match, returns ``tuple({<namespace-name: namespace-url>}, <format>)``:
+        - If there is a match, returns ``tuple({<namespace-name: namespace-url>}, <format>)`` with:
             1) corresponding namespace mapping to be applied under ``$namespaces`` in the `CWL`.
             2) value of ``format`` adjusted according to the namespace to be applied to ``File`` in the `CWL`.
-        - If there is no match but ``must_exist=False``:
-            returns a literal and non-existing definition as ``tuple({"iana": <iana-url>}, <format>)``
+        - If there is no match but ``must_exist=False``, returns a literal and non-existing definition as
+          ``tuple({"iana": <iana-url>}, <format>)``.
+        -
         - Otherwise, returns ``(None, None)``
 
     - If ``make_reference=True``:
         - If there is a match, returns the explicit format reference as ``<namespace-url>/<format>``.
-        - If there is no match but ``must_exist=False``, returns the literal reference as ``<iana-url>/<format>``.
-        - Otherwise, returns a single ``None``.
+        - If there is no match but ``must_exist=False``, returns the literal reference as ``<iana-url>/<format>``
+          (N.B.: literal non-official MIME-type reference will be returned even if an official synonym exists).
+        - If there is no match but ``must_exist=True`` **AND** ``allow_reference=True``, retry the call with the
+          synonym if available, or move to next step. Skip this step if ``allow_reference=False``.
+        - Returns a single ``None`` as there is not match (directly or synonym).
 
     Note:
         In situations where ``must_exist=False`` is used and that the namespace and/or full format URL cannot be
         resolved to an existing reference, `CWL` will raise a validation error as it cannot confirm the ``format``.
-        You must therefore make sure that the returned reference really exists when using ``must_exist=False`` before
-        providing it to the `CWL` I/O definition. This parameter should be used only for literal string comparison or
-        pre-processing steps to evaluate formats.
+        You must therefore make sure that the returned reference (or a synonym format) really exists when using
+        ``must_exist=False`` before providing it to the `CWL` I/O definition. Setting ``must_exist=False`` should be
+        used only for literal string comparison or pre-processing steps to evaluate formats.
+
+    :param mime_type: Some reference, namespace'd or literal (possibly extended) MIME-type string.
+    :param make_reference: Construct the full URL reference to the resolved MIME-type. Otherwise return tuple details.
+    :param must_exist:
+        Return result only if it can be resolved to an official MIME-type (or synonym if enabled), otherwise ``None``.
+        Non-official MIME-type can be enforced if disabled, in which case `IANA` namespace/URL is used as it preserves
+        the original ``<type>/<subtype>`` format.
+    :param allow_synonym:
+        Allow resolution of non-official MIME-type to an official MIME-type synonym if available.
+        Types defined as *synonym* have semantically the same format validation/resolution for `CWL`.
+        Requires ``must_exist=True``, otherwise the non-official MIME-type is employed directly as result.
+    :returns: Resolved MIME-type format for `CWL` usage, accordingly to specified arguments (see description details).
     """
     def _make_if_ref(_map, _key, _fmt):
         return os.path.join(_map[_key], _fmt) if make_reference else (_map, "{}:{}".format(_key, _fmt))
 
     def _request_extra_various(_mime_type):
         """
-        Attempts multiple request-retry variants to be as permissive as possible to sporadic temporary failures.
+        Attempts multiple request-retry variants to be as permissive as possible to sporadic/temporary failures.
         """
         _mime_type_url = "{}{}".format(IANA_NAMESPACE_DEFINITION[IANA_NAMESPACE], _mime_type)
         try:
@@ -141,10 +176,13 @@ def get_cwl_file_format(mime_type, make_reference=False, must_exist=True):
         return _make_if_ref(EDAM_NAMESPACE_DEFINITION, EDAM_NAMESPACE, EDAM_MAPPING[mime_type])
     if not must_exist:
         return _make_if_ref(IANA_NAMESPACE_DEFINITION, IANA_NAMESPACE, mime_type)
+    if result is None and allow_synonym and mime_type in _CONTENT_TYPE_SYNONYM_MAPPING:
+        mime_type = _CONTENT_TYPE_SYNONYM_MAPPING.get(mime_type)
+        return get_cwl_file_format(mime_type, make_reference=make_reference, must_exist=True, allow_synonym=False)
     return None if make_reference else (None, None)
 
 
-def clean_mime_type_format(mime_type, base_subtype=False, strip_parameters=False):
+def clean_mime_type_format(mime_type, suffix_subtype=False, strip_parameters=False):
     # type: (AnyStr, bool, bool) -> AnyStr
     """
     Removes any additional namespace key or URL from :paramref:`mime_type` so that it corresponds to the generic
@@ -154,20 +192,20 @@ def clean_mime_type_format(mime_type, base_subtype=False, strip_parameters=False
     According to provided arguments, it also cleans up additional parameters or extracts sub-type suffixes.
 
     :param mime_type:
-        MIME-type string that must be cleaned up.
-    :param base_subtype:
-        remove additional sub-type specializations details marked by ``+`` symbol such that an explicit format like
-        ``application/vnd.api+json`` returns only its base format defined as``application/json``.
+        MIME-type, full URL to MIME-type or namespace-formatted string that must be cleaned up.
+    :param suffix_subtype:
+        Remove additional sub-type specializations details separated by ``+`` symbol such that an explicit format like
+        ``application/vnd.api+json`` returns only its most basic suffix format defined as``application/json``.
     :param strip_parameters:
-        removes additional MIME-type parameters such that only the leading part defining the ``type/subtype`` are
+        Removes additional MIME-type parameters such that only the leading part defining the ``type/subtype`` are
         returned. For example, this will get rid of ``; charset=UTF-8`` or ``; version=4.0`` parameters.
 
     .. note::
-        Parameters :paramref:`base_subtype` and :paramref:`strip_parameters` are not necessarily exclusive.
+        Parameters :paramref:`suffix_subtype` and :paramref:`strip_parameters` are not necessarily exclusive.
     """
     if strip_parameters:
         mime_type = mime_type.split(";")[0]
-    if base_subtype and "+" in mime_type:
+    if suffix_subtype and "+" in mime_type:
         # parameters are not necessarily stripped, need to re-append them after if any
         parts = mime_type.split(";", 1)
         if len(parts) < 2:

--- a/weaver/processes/wps_package.py
+++ b/weaver/processes/wps_package.py
@@ -1729,6 +1729,7 @@ class WpsPackage(Process):
         """
         self.payload = kw.pop("payload")
         self.package = kw.pop("package")
+        self.settings = get_settings(app)
         if not self.package:
             raise PackageRegistrationError("Missing required package definition for package process.")
         if not isinstance(self.package, dict):
@@ -1967,7 +1968,6 @@ class WpsPackage(Process):
 
             self.update_status("Launching package...", PACKAGE_PROGRESS_LAUNCHING, STATUS_RUNNING)
 
-            self.settings = get_settings(app)
             is_ems = get_weaver_configuration(self.settings) == WEAVER_CONFIGURATION_EMS
             if is_ems:
                 # EMS dispatch the execution to the ADES

--- a/weaver/processes/wps_package.py
+++ b/weaver/processes/wps_package.py
@@ -1450,12 +1450,14 @@ def _any2cwl_io(wps_io, io_select):
             fmt = _get_field(wps_io, field, search_variations=True)
             if isinstance(fmt, dict):
                 cwl_io_ref, cwl_io_fmt, cwl_io_ext = _get_cwl_fmt_details(fmt)
-                cwl_ns.update(cwl_io_ref)
+                if cwl_io_ref and cwl_io_fmt:
+                    cwl_ns.update(cwl_io_ref)
                 break
             if isinstance(fmt, list):
                 if len(fmt) == 1:
                     cwl_io_ref, cwl_io_fmt, cwl_io_ext = _get_cwl_fmt_details(fmt[0])
-                    cwl_ns.update(cwl_io_ref)
+                    if cwl_io_ref and cwl_io_fmt:
+                        cwl_ns.update(cwl_io_ref)
                     break
                 if io_select == WPS_OUTPUT and len(fmt) > 1:
                     break  # don't use any format because we cannot enforce one

--- a/weaver/processes/wps_package.py
+++ b/weaver/processes/wps_package.py
@@ -1711,7 +1711,7 @@ class WpsPackage(Process):
     package_log_hook_stdout = None  # type: Optional[AnyStr]
     percent = None                  # type: Optional[Number]
     log_file = None                 # type: Optional[AnyStr]
-    log_level = logging.INFO        # type: int
+    log_level = None                # type: Optional[int]
     logger = None                   # type: Optional[logging.Logger]
     step_packages = None            # type: Optional[List[CWL]]
     step_launched = None            # type: Optional[List[AnyStr]]
@@ -1761,6 +1761,8 @@ class WpsPackage(Process):
             :meth:`insert_package_log`
             :func:`retrieve_package_job_log`
         """
+        self.log_level = self.log_level or logging.getLogger("weaver").level
+
         # file logger for output
         self.log_file = get_status_location_log_path(self.status_location)
         log_file_handler = logging.FileHandler(self.log_file)
@@ -1995,6 +1997,7 @@ class WpsPackage(Process):
                 #"docker_tmpdir": cwl_workdir,
                 "tmpdir_prefix": cwl_workdir,
                 "tmp_outdir_prefix": cwl_outdir,
+                "debug": LOGGER.isEnabledFor(logging.DEBUG)
             }
             LOGGER.debug("Using cwltool.RuntimeContext args:\n%s", json.dumps(runtime_params, indent=2))
             runtime_context = RuntimeContext(kwargs=runtime_params)

--- a/weaver/processes/wps_package.py
+++ b/weaver/processes/wps_package.py
@@ -1985,7 +1985,7 @@ class WpsPackage(Process):
             # note:
             #   Parameter 'weaver.wps_workdir' is the base-dir where sub-dir per application packages will be generated.
             #   Parameter 'self.workdir' is the actual location PyWPS reserved for this process (already with sub-dir).
-            #   If no 'weaver.workdir' was provided, reuse PyWps parent workdir since we got access to it.
+            #   If no 'weaver.wps_workdir' was provided, reuse PyWps parent workdir since we got access to it.
             #   Other steps handling outputs need to consider that CWL<->WPS out dirs could match because of this.
             wps_workdir = self.settings.get("weaver.wps_workdir", os.path.dirname(self.workdir))
             # cwltool will add additional unique characters after prefix paths

--- a/weaver/wps_restapi/jobs/jobs.py
+++ b/weaver/wps_restapi/jobs/jobs.py
@@ -51,7 +51,7 @@ def check_status(url=None, response=None, sleep_secs=2, verify=True, settings=No
     :return: OWSLib.wps.WPSExecution object.
     """
     def _retry_file():
-        LOGGER.warning("Failed retrieving status-location, attempting with local file.")
+        LOGGER.warning("Failed retrieving WPS status-location, attempting with local file.")
         if url and not urlparse(url).scheme in ["", "file://"]:
             dir_path = get_wps_output_dir(app)
             wps_out_url = get_wps_output_url(app)
@@ -59,6 +59,7 @@ def check_status(url=None, response=None, sleep_secs=2, verify=True, settings=No
             out_path = os.path.join(dir_path, req_out_url.replace(wps_out_url, "").lstrip("/"))
         else:
             out_path = url.replace("file:://", "")
+        LOGGER.debug("WPS status reference [%s] will be parsed as local file path [%s].", url, out_path)
         if not os.path.isfile(out_path):
             raise HTTPNotFound("Could not find file resource from [{}].".format(url))
         return open(out_path, "r").read()

--- a/weaver/wps_restapi/jobs/jobs.py
+++ b/weaver/wps_restapi/jobs/jobs.py
@@ -67,12 +67,12 @@ def check_status(url=None, response=None, sleep_secs=2, verify=True, settings=No
 
     execution = WPSExecution()
     if response:
-        LOGGER.debug("using response document...")
+        LOGGER.debug("Retrieving WPS status from XML response document...")
         xml = response
     elif url:
         xml_resp = HTTPNotFound()
         try:
-            LOGGER.debug("using status-location url...")
+            LOGGER.debug("Attempt to retrieve WPS status-location from URL...")
             xml_resp = request_extra("get", url, verify=verify, settings=settings)
             xml = xml_resp.content
         except Exception as ex:
@@ -82,7 +82,7 @@ def check_status(url=None, response=None, sleep_secs=2, verify=True, settings=No
             LOGGER.debug("Got not-found during get status: [%r]", xml)
             xml = _retry_file()
     else:
-        raise Exception("you need to provide a status-location url or response object.")
+        raise Exception("Missing status-location URL/file reference or response with XML object.")
     if isinstance(xml, six.string_types):
         xml = xml.encode("utf8", errors="ignore")
     execution.checkStatus(response=xml, sleepSecs=sleep_secs)

--- a/weaver/wps_restapi/jobs/jobs.py
+++ b/weaver/wps_restapi/jobs/jobs.py
@@ -62,6 +62,7 @@ def check_status(url=None, response=None, sleep_secs=2, verify=True, settings=No
         LOGGER.debug("WPS status reference [%s] will be parsed as local file path [%s].", url, out_path)
         if not os.path.isfile(out_path):
             raise HTTPNotFound("Could not find file resource from [{}].".format(url))
+        LOGGER.info("Resolved WPS status-location using local file reference.")
         return open(out_path, "r").read()
 
     execution = WPSExecution()

--- a/weaver/wps_restapi/jobs/jobs.py
+++ b/weaver/wps_restapi/jobs/jobs.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
 LOGGER = get_task_logger(__name__)
 
 
-def check_status(url=None, response=None, sleep_secs=2, verify=False, settings=None):
+def check_status(url=None, response=None, sleep_secs=2, verify=True, settings=None):
     # type: (Optional[AnyStr], Optional[etree.ElementBase], int, bool, Optional[AnySettingsContainer]) -> WPSExecution
     """
     Run :func:`owslib.wps.WPSExecution.checkStatus` with additional exception handling.

--- a/weaver/wps_restapi/processes/processes.py
+++ b/weaver/wps_restapi/processes/processes.py
@@ -150,7 +150,9 @@ def execute_process(self, job_id, url, headers=None, notification_email=None):
 
         mode = EXECUTE_MODE_ASYNC if job.execute_async else EXECUTE_MODE_SYNC
         job.progress = JOB_PROGRESS_EXECUTE_REQUEST
-        job.save_log(logger=task_logger, message="Starting job process execution")
+        job.save_log(logger=task_logger, message="Starting job process execution.")
+        job.save_log(logger=task_logger,
+                     message="Following updates could take a while until the Application Package answers...")
         execution = wps.execute(job.process, inputs=wps_inputs, output=outputs, mode=mode, lineage=True)
         if not execution.process and execution.errors:
             raise execution.errors[0]

--- a/weaver/wps_restapi/swagger_definitions.py
+++ b/weaver/wps_restapi/swagger_definitions.py
@@ -1161,6 +1161,7 @@ class ExecutionUnitList(SequenceSchema):
 class ProcessOffering(MappingSchema):
     process = Process()
     processVersion = SchemaNode(String(), missing=drop)
+    processEndpointWPS1 = SchemaNode(String(), missing=drop, format=URL)
     jobControlOptions = JobControlOptionsList(missing=drop)
     outputTransmission = TransmissionModeList(missing=drop)
 


### PR DESCRIPTION
- extend features of PR #150 using `weaver.wps_workdir` 
    - better setup cwltool tmpdir and results location
    - functional with docker-sibling setup
- fixes incorrect reference when default type parsing is used (introduced by PR #128)
- addresses #155 [experimental] with user/group applied to cwl app & readonly inputs
- avoid reload pywps configs every time
- better setup of cwltool logs according to the rest of the app log level
- map wps-outputs with job uuid to pywps uuid to make it easier to identify matching items