### PR TITLE
metadata

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,7 +13,7 @@ Changes:
 
 Fixes:
 ------
-- No changes.
+- Add more examples of supported WPS endpoint metadata (fixes `#84 <https://github.com/crim-ca/weaver/issues/84>`_).
 
 `1.9.0 <https://github.com/crim-ca/weaver/tree/1.9.0>`_ (2020-06-01)
 ========================================================================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,19 @@
 Changes
 *******
 
+.. **REPLACE AND/OR ADD SECTION ENTRIES ACCORDINGLY WITH APPLIED CHANGES**
+
 `Unreleased <https://github.com/crim-ca/weaver/tree/master>`_ (latest)
 ========================================================================
+
+Changes:
+--------
+- Add support of value-typed metadata fields for process description.
+- Enforce ``rel`` field when specifying an ``href`` JSON link to match corresponding XML requirement.
+
+Fixes:
+------
+- No changes.
 
 `1.9.0 <https://github.com/crim-ca/weaver/tree/1.9.0>`_ (2020-06-01)
 ========================================================================

--- a/config/weaver.ini.example
+++ b/config/weaver.ini.example
@@ -67,9 +67,23 @@ weaver.wps_workdir =
 weaver.wps_metadata_identification_title=Weaver
 weaver.wps_metadata_identification_abstract=Weaver internal WPS used for demo and testing.
 weaver.wps_metadata_identification_keywords=Weaver,WPS,OGC
+# access constraints can be comma-separated
 weaver.wps_metadata_identification_accessconstraints=NONE
+weaver.wps_metadata_identification_fees=NONE
 weaver.wps_metadata_provider_name=CRIM
 weaver.wps_metadata_provider_url=http://pavics-weaver.readthedocs.org/en/latest/
+weaver.wps_metadata_contact_name=Francis Charette-Migneault
+weaver.wps_metadata_contact_position=Research Software Developer
+weaver.wps_metadata_contact_phone=1-514-840-1234
+weaver.wps_metadata_contact_fax=1-514-840-1244
+weaver.wps_metadata_contact_deliveryPoint=405, Ogilvy Avenue, suite 101
+weaver.wps_metadata_contact_city=Montréal
+weaver.wps_metadata_contact_stateorprovince=Québec
+weaver.wps_metadata_contact_country=Canada
+weaver.wps_metadata_contact_postalcode=H3N 1M3
+weaver.wps_metadata_contact_email=info@crim.ca
+weaver.wps_metadata_contact_url=https://www.crim.ca/en/contact-us
+weaver.wps_metadata_contact_role=Information
 
 # --- Weaver WPS REST API ---
 weaver.wps_restapi = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,13 +5,21 @@ tag = True
 tag_name = {new_version}
 
 [bumpversion:file:CHANGES.rst]
-search = 
+search =
 	`Unreleased <https://github.com/crim-ca/weaver/tree/master>`_ (latest)
 	========================================================================
-replace = 
+replace =
 	`Unreleased <https://github.com/crim-ca/weaver/tree/master>`_ (latest)
 	========================================================================
-	
+
+	Changes:
+	--------
+	- No change.
+
+	Fixes:
+	------
+	- No change.
+
 	`{new_version} <https://github.com/crim-ca/weaver/tree/{new_version}>`_ ({now:%%Y-%%m-%%d})
 	========================================================================
 
@@ -32,12 +40,12 @@ search = LABEL version="{current_version}"
 replace = LABEL version="{new_version}"
 
 [tool:pytest]
-addopts = 
+addopts =
 	--strict
 	--tb=native
 	weaver/
 python_files = test_*.py
-markers = 
+markers =
 	testbed14: mark test as 'testbed14' validation
 	functional: mark test as functionality validation
 	online: mark test to need internet connection
@@ -60,7 +68,7 @@ targets = .
 [flake8]
 ignore = E126,E226,E402,F401,W504
 max-line-length = 120
-exclude = 
+exclude =
 	src,
 	.git,
 	__pycache__,
@@ -81,13 +89,13 @@ ignore-path = docs/build
 branch = true
 source = ./
 include = weaver/*
-omit = 
+omit =
 	setup.py
 	docs/*
 	tests/*
 
 [coverage:report]
-exclude_lines = 
+exclude_lines =
 	pragma: no cover
 	raise AssertionError
 	raise NotImplementedError

--- a/weaver/wps_restapi/swagger_definitions.py
+++ b/weaver/wps_restapi/swagger_definitions.py
@@ -275,16 +275,30 @@ class KeywordList(SequenceSchema):
 
 
 class JsonLink(MappingSchema):
-    href = SchemaNode(String(), format=URL)
-    rel = SchemaNode(String(), missing=drop)
+    href = SchemaNode(String(), format=URL, description="Reference URL.")
+    rel = SchemaNode(String(), description="Relationship of the contained link respective to the current element.")
     type = SchemaNode(String(), missing=drop)
     hreflang = SchemaNode(String(), missing=drop)
     title = SchemaNode(String(), missing=drop)
 
 
-class Metadata(JsonLink):
+class MetadataBase(MappingSchema):
+    title = SchemaNode(String(), missing=drop)
     role = SchemaNode(String(), format=URL, missing=drop)
-    value = SchemaNode(String(), missing=drop)
+    type = SchemaNode(String(), description="Type of metadata entry.")
+
+
+class MetadataLink(MetadataBase, JsonLink):
+    pass
+
+
+class MetadataValue(MetadataBase):
+    value = SchemaNode(String())
+    lang = SchemaNode(String())
+
+
+class Metadata(OneOfMappingSchema):
+    _one_of = (MetadataLink, MetadataValue)
 
 
 class MetadataList(SequenceSchema):


### PR DESCRIPTION
- Add support of value-typed metadata fields for process description.
- Enforce ``rel`` field when specifying an ``href`` JSON link to match corresponding XML requirement.
- Add more examples of supported WPS endpoint metadata (fixes #84)