### PR TITLE
add minor version prior to esgf merge

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,17 @@ Changes
 
 Changes:
 --------
+- No change.
+
+Fixes:
+------
+- No change.
+
+`1.11.0 <https://github.com/crim-ca/weaver/tree/1.11.0>`_ (2020-07-02)
+========================================================================
+
+Changes:
+--------
 - Generate Weaver OpenAPI specification for readthedocs publication.
 - Add some sections for documentation (`#61 <https://github.com/crim-ca/weaver/issues/61>`_).
 - Add support of documentation RST file redirection to generated HTML for reference resolution in both Github source

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,13 +11,12 @@ Changes:
 - Add multiple CWL ESGF processes and workflows, namely ``SubsetNASAESGF``, ``SubsetNASAESGF`` and many more.
 - Add tests for ESGF processes and workflows.
 - Add documentation for ``ESGF-CWTRequirement`` processes.
-- Reset ``MongoDatabase`` connection when we are in a forked process.
 - Add ``file2string_array`` and ``metalink2netcdf`` builtins.
 - Add ``esgf_process`` ``Wps1Process`` extension, to handle ``ESGF-CWTRequirement`` processes and workflows.
 
 Fixes:
 ------
-- No change.
+- Reset ``MongoDatabase`` connection when we are in a forked process.
 
 `1.11.0 <https://github.com/crim-ca/weaver/tree/1.11.0>`_ (2020-07-02)
 ========================================================================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,12 @@ Changes
 
 Changes:
 --------
-- No change.
+- Add multiple CWL ESGF processes and workflows, namely ``SubsetNASAESGF``, ``SubsetNASAESGF`` and many more.
+- Add tests for ESGF processes and workflows.
+- Add documentation for ``ESGF-CWTRequirement`` processes.
+- Reset ``MongoDatabase`` connection when we are in a forked process.
+- Add ``file2string_array`` and ``metalink2netcdf`` builtins.
+- Add ``esgf_process`` ``Wps1Process`` extension, to handle ``ESGF-CWTRequirement`` processes and workflows.
 
 Fixes:
 ------


### PR DESCRIPTION
@MatProv 
I find the changes introduced in #176 to be a bit too ambitious to be merged as is into master with already many unversioned changes.  So I pushed a `1.11.0` version at the commit just prior to all the ones from #176. 

I also find that such massive change are still quite lacking in term of changelog.
Can you please summarize all changes applied within that PR under the `Unreleased` section?
After this, we will immediately add another tag `1.12.0`. 