### PR TITLE
Fix missing log files

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,7 +12,7 @@ Changes:
 
 Fixes:
 ------
-- No change.
+- Create an ``stdout.log`` or ``stderr.log`` file in case ``cwltool`` hasn't created it.
 
 `1.13.0 <https://github.com/crim-ca/weaver/tree/1.13.0>`_ (2020-07-15)
 ========================================================================

--- a/weaver/processes/wps_workflow.py
+++ b/weaver/processes/wps_workflow.py
@@ -8,6 +8,7 @@ import shutil
 import tempfile
 from functools import cmp_to_key, partial
 from typing import TYPE_CHECKING, Callable, MutableMapping, Text, cast  # these are actually used in the code
+from pathlib import Path
 
 from cwltool import command_line_tool
 from cwltool.builder import CONTENT_LIMIT, Builder, substitute
@@ -270,6 +271,13 @@ class WpsWorkflow(ProcessCWL):
                         try:
                             prefix = fs_access.glob(outdir)
                             key = cmp_to_key(cast(Callable[[Text, Text], int], locale.strcoll))
+
+                            # In case of stdout.log or stderr.log file not created
+                            if glob in ("stdout.log", "stderr.log"):
+                                filepath = Path(fs_access.join(outdir, glob))
+                                if not filepath.is_file():
+                                    Path(filepath).touch()
+
                             result.extend([{
                                 "location": g,
                                 "path": fs_access.join(builder.outdir, g[len(prefix[0])+1:]),

--- a/weaver/processes/wps_workflow.py
+++ b/weaver/processes/wps_workflow.py
@@ -7,8 +7,8 @@ import os
 import shutil
 import tempfile
 from functools import cmp_to_key, partial
-from typing import TYPE_CHECKING, Callable, MutableMapping, Text, cast  # these are actually used in the code
 from pathlib import Path
+from typing import TYPE_CHECKING, Callable, MutableMapping, Text, cast  # these are actually used in the code
 
 from cwltool import command_line_tool
 from cwltool.builder import CONTENT_LIMIT, Builder, substitute

--- a/weaver/processes/wps_workflow.py
+++ b/weaver/processes/wps_workflow.py
@@ -273,7 +273,7 @@ class WpsWorkflow(ProcessCWL):
                             key = cmp_to_key(cast(Callable[[Text, Text], int], locale.strcoll))
 
                             # In case of stdout.log or stderr.log file not created
-                            if glob in ("stdout.log", "stderr.log"):
+                            if glob in (self.tool["stdout"], self.tool["stderr"]):
                                 filepath = Path(fs_access.join(outdir, glob))
                                 if not filepath.is_file():
                                     Path(filepath).touch()


### PR DESCRIPTION
Create an ``stdout.log`` or ``stderr.log`` file in case ``cwltool`` hasn't created it