### PR TITLE
config remote providers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,10 @@ Changes:
 --------
 - Add ``data`` input support for `CWL` `Workflow` step referring to `WPS-3 Process`.
 - Add documentation example references to `Application Package` and `Process` ``Deploy``/``Execute`` repositories.
+- Add parsing of ``providers`` in ``wps_processes.yml`` to directly register remote WPS providers that will dynamically
+  fetch underlying WPS processes, instead of static per-service processes stored locally.
+- Add field ``visible`` to ``wps_processes.yml`` entries to allow directly defining the registered processes visibility.
+- Adjust response of remote provider processes to return the same format as local processes.
 
 Fixes:
 ------

--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,7 @@ install-pkg: install-pip	## install application package dependencies
 .PHONY: install-sys
 install-sys: conda-env	## install system dependencies and required installers/runners
 	@echo "Installing system dependencies..."
-	@bash -c '$(CONDA_CMD) pip install $(PIP_XARGS) --upgrade pip setuptools'
+	@bash -c '$(CONDA_CMD) pip install $(PIP_XARGS) --upgrade $(APP_ROOT)/requirements-sys.txt'
 
 .PHONY: install-pip
 install-pip:	## install application as a package to allow import from another python package

--- a/Makefile
+++ b/Makefile
@@ -186,10 +186,11 @@ install-pkg: install-pip	## install application package dependencies
 	@-bash -c "$(CONDA_CMD) pip install $(PIP_XARGS) -r $(APP_ROOT)/requirements.txt --no-cache-dir"
 	@echo "Install with pip complete."
 
+# don't use 'PIP_XARGS' in this case since extra features could not yet be supported by pip being installed/updated
 .PHONY: install-sys
 install-sys: conda-env	## install system dependencies and required installers/runners
 	@echo "Installing system dependencies..."
-	@bash -c '$(CONDA_CMD) pip install $(PIP_XARGS) --upgrade $(APP_ROOT)/requirements-sys.txt'
+	@bash -c '$(CONDA_CMD) pip install --upgrade -r $(APP_ROOT)/requirements-sys.txt'
 
 .PHONY: install-pip
 install-pip:	## install application as a package to allow import from another python package
@@ -227,14 +228,14 @@ clean-cache:	## remove caches such as DOWNLOAD_CACHE
 
 .PHONY: clean-docs
 clean-docs:	install-dev clean-docs-dirs		## remove documentation artefacts
-	@echo "Removing documenation build files..."
+	@echo "Removing documentation build files..."
 	@$(MAKE) -C "$(APP_ROOT)/docs" clean || true
 
 # extensive cleanup is possible only using sphinx-build
 # allow minimal cleanup when it could not *yet* be installed (dev)
 .PHONY: clean-docs-dirs
 clean-docs-dirs:	## remove documentation artefacts (minimal)
-	@echo "Removing documenation directories..."
+	@echo "Removing documentation directories..."
 	@-rm -fr "$(APP_ROOT)/docs/build"
 	@-rm -fr "$(APP_ROOT)/docs/html"
 	@-rm -fr "$(APP_ROOT)/docs/xml"

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ ifeq ("$(CONDA_ENV_REAL_ACTIVE_PATH)", "")
 endif
 DOWNLOAD_CACHE ?= $(APP_ROOT)/downloads
 PYTHON_VERSION ?= `python -c 'import platform; print(platform.python_version())'`
+PIP_XARGS ?= --use-feature=2020-resolver
 
 # choose conda installer depending on your OS
 CONDA_URL = https://repo.continuum.io/miniconda
@@ -176,30 +177,30 @@ install-all: install-sys install-pkg install-pip install-dev  ## install applica
 .PHONY: install-dev
 install-dev: install-pip	## install development and test dependencies
 	@echo "Installing development packages with pip..."
-	@-bash -c '$(CONDA_CMD) pip install -r $(APP_ROOT)/requirements-dev.txt'
+	@-bash -c '$(CONDA_CMD) pip install $(PIP_XARGS) -r $(APP_ROOT)/requirements-dev.txt'
 	@echo "Install with pip complete. Test service with 'make test*' variations."
 
 .PHONY: install-pkg
 install-pkg: install-pip	## install application package dependencies
 	@echo "Installing base packages with pip..."
-	@-bash -c "$(CONDA_CMD) pip install -r $(APP_ROOT)/requirements.txt --no-cache-dir"
+	@-bash -c "$(CONDA_CMD) pip install $(PIP_XARGS) -r $(APP_ROOT)/requirements.txt --no-cache-dir"
 	@echo "Install with pip complete."
 
 .PHONY: install-sys
 install-sys: conda-env	## install system dependencies and required installers/runners
 	@echo "Installing system dependencies..."
-	@bash -c '$(CONDA_CMD) pip install --upgrade pip setuptools'
+	@bash -c '$(CONDA_CMD) pip install $(PIP_XARGS) --upgrade pip setuptools'
 
 .PHONY: install-pip
 install-pip:	## install application as a package to allow import from another python package
 	@echo "Installing package with pip..."
-	@-bash -c '$(CONDA_CMD) pip install $(APP_ROOT)'
+	@-bash -c '$(CONDA_CMD) pip install $(PIP_XARGS) $(APP_ROOT)'
 	@echo "Install with pip complete."
 
 .PHONY: install-raw
 install-raw:	## install without any requirements or dependencies (suppose everything is setup)
 	@echo "Installing package without dependencies..."
-	@-bash -c '$(CONDA_CMD) pip install -e "$(APP_ROOT)" --no-deps'
+	@-bash -c '$(CONDA_CMD) pip install $(PIP_XARGS) -e "$(APP_ROOT)" --no-deps'
 	@echo "Install package complete."
 
 ## -- Cleanup targets -- ##

--- a/README.rst
+++ b/README.rst
@@ -176,7 +176,7 @@ following improvements. It is also advanced with sponsorship of *U.S. Department
 API of the *Earth System Grid Federation* (`ESGF`_). The findings are reported on the |ogc-tb14|_ thread, and more
 explicitly in the |ogc-tb14-platform-er|_.
 
-The project as been employed for |ogc-tb15-ml|_ to demonstrate the use of Machine Learning interactions withOGC web
+The project has been employed for |ogc-tb15-ml|_ to demonstrate the use of Machine Learning interactions with OGC web
 standards in the context of natural resources applications. The advancements are reported through the |ogc-tb15-ml-er|_.
 
 Developments are continued in |ogc-tb16|_ to improve methodologies in order to provide better

--- a/README.rst
+++ b/README.rst
@@ -173,15 +173,13 @@ Extra Details & Sponsors
 
 The project was initially developed upon *OGC Testbed-14 – ESA Sponsored Threads – Exploitation Platform* findings and
 following improvements. It is also advanced with sponsorship of *U.S. Department of Energy* to support common
-API of the *Earth System Grid Federation* (`ESGF`_). The findings are reported on the
-`OGC Testbed-14 <ogc-tb14>`_ thread, and more explicitly in the
-`ADES & EMS Results and Best Practices Engineering Report <ogc-tb14-platform-er>`_.
+API of the *Earth System Grid Federation* (`ESGF`_). The findings are reported on the |ogc-tb14|_ thread, and more
+explicitly in the |ogc-tb14-platform-er|_.
 
-The project as been employed for `OGC Testbed-15 - ML Thread <ogc-tb15-ml>`_ to demonstrate the use of Machine Learning
-interactions with OGC web standards in the context of natural resources applications. The advancements are reported
-through the `OGC Testbed-15: Machine Learning Engineering Report <ogc-tb15-ml-er>`_.
+The project as been employed for |ogc-tb15-ml|_ to demonstrate the use of Machine Learning interactions withOGC web
+standards in the context of natural resources applications. The advancements are reported through the |ogc-tb15-ml-er|_.
 
-Developments are continued in `OGC Testbed-16 <ogc-tb16>`_ to improve methodologies in order to provide better
+Developments are continued in |ogc-tb16|_ to improve methodologies in order to provide better
 interoperable geospatial data processing in the areas of Earth Observation Application Packages.
 
 The project is furthermore developed through the *Data Analytics for Canadian Climate Services* (`DACCS`_) initiative.
@@ -189,10 +187,17 @@ The project is furthermore developed through the *Data Analytics for Canadian Cl
 Weaver is a **prototype** implemented in Python with the `Pyramid`_ web framework.
 It is part of `PAVICS`_ and `Birdhouse`_ ecosystems.
 
+.. NOTE: all references in this file must remain local (instead of imported from 'references.rst')
+..       to allow Github to directly referring to them from the repository HTML page.
+.. |ogc-tb14| replace:: OGC Testbed-14
 .. _ogc-tb14: https://www.ogc.org/projects/initiatives/testbed14
+.. |ogc-tb14-platform-er| replace:: ADES & EMS Results and Best Practices Engineering Report
 .. _ogc-tb14-platform-er: http://docs.opengeospatial.org/per/18-050r1.html
+.. |ogc-tb15-ml| replace:: OGC Testbed-15 - ML Thread
 .. _ogc-tb15-ml: https://www.ogc.org/projects/initiatives/testbed15#MachineLearning
+.. |ogc-tb15-ml-er| replace:: OGC Testbed-15: Machine Learning Engineering Report
 .. _ogc-tb15-ml-er: http://docs.opengeospatial.org/per/19-027r2.html
+.. |ogc-tb16| replace:: OGC Testbed-16
 .. _ogc-tb16: https://www.ogc.org/projects/initiatives/t-16
 .. _PAVICS: https://ouranosinc.github.io/pavics-sdi/index.html
 .. _Birdhouse: http://bird-house.github.io/

--- a/config/wps_processes.yml.example
+++ b/config/wps_processes.yml.example
@@ -1,13 +1,16 @@
 # Defines a list of WPS-1 processes references from remote service provider to register under Weaver at startup.
-#
+# Can also refer to any other remote WPS using providers.
+
 # Details:
 #   - if only the WPS-1 URL endpoint is provided, all processes found by `GetCapabilities` will be added
-#   - if query `identifier=<process-id>` is provided, only matched process will be added.
-#     alternatively, a list of processes can be specified with `id` sub-field of a given URL reference
+#   - if query `identifier=<process-id>` is provided in the URL, only matched process will be added.
+#   - alternatively, a filtered list of processes to register can be specified with `id` under a given URL reference
 #   - if `name` is not provided, a "clean" (slug) variation of the hostname will be used as service base name
 #   - all processes are deployed using identifier `<service-name>_<process-id>`, with name resolved from above
+#   - processes registered this way are static and local, in the sense that they will only save a snapshot of
+#     the remote service at startup time (see 'providers' alternative).
 # Result:
-#   - for each process, `DescribeProcess` request will indicate how to generate and register a WPS-REST equivalent
+#   - for each process, `DescribeProcess` request will indicate how to generate and register an equivalent WPS-REST
 #   - each process name will combine the service `name` and process `identifier` to reduce chances of conflicts
 processes:
   # will deploy all processes returned by the default `GetCapabilities` operation (missing query parameters are added)
@@ -21,6 +24,9 @@ processes:
   # more verbose `name` to use instead of the default `named-endpoint` that would be resolved from the hostname
   - url: https://named-endpoint/wps
     name: named-endpoint-with-a-twist
+    # directly set visibility to make process publicly available
+    # otherwise it is private by default and cannot be listed nor executed until visibility is updated
+    visible: true
   # explicit list of processes to deploy from all retrieved from `GetCapabilities` response
   # this is essentially equivalent to two `DescribeProcess` URL with specific `identifier` query parameter
   # (this variant saves some request operations and is easier to read)
@@ -28,3 +34,15 @@ processes:
     id:
       - process-1
       - process-2
+
+# When using providers, only the remote service definition (name and remote URL endpoint) are stored.
+# WPS processes under that service will be fetched each time they are requested, making responses dynamic to the
+# referenced service offering response, but prone to unpredictable requests failure if the service becomes unavailable.
+providers:
+  # Without an explicit name, the service will be registered using an appropriate name from the URL reference
+  - https://remote-service/wps
+  # otherwise, the service is registered as is
+  - url: https://other-service/wps
+    name: OverrideName
+    # visibility dictates accessibility of every underlying process (all or nothing)
+    visible: true

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -405,6 +405,7 @@ linkcheck_ignore = [
     r"./docs.*",
     r"docs/source/.*",
     # inter-reference between document page and section headers
+    # when link is itself a documentation reference, they are not resolved correctly, but this works with text replaces
     r":ref:`.*`",
     # dummy values
     r"http[s]*://localhost.*/",

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -398,12 +398,22 @@ intersphinx_mapping = {
 # linkcheck options
 # http://www.sphinx-doc.org/en/stable/config.html?highlight=linkchecker#options-for-the-linkcheck-builder
 linkcheck_ignore = [
+    # paths to local repository files directly referenced in doc (different root dir when built)
+    # path links are handled by 'doc_redirect' extension
+    r"../../../.*",
+    r"./config.*",
+    r"./docs.*",
+    r"docs/source/.*",
+    # inter-reference between document page and section headers
+    r":ref:`.*`",
+    # dummy values
     r"http[s]*://localhost.*/",
     r"http[s]*://example.com.*",
     "https://mouflon.dkrz.de/",
+    # following have sporadic downtimes
     "https://esgf-data.dkrz.de/",
     "https://indico.egi.eu/",
-    "https://docker-registry.crim.ca.*",
+    ".*docker-registry.crim.ca.*",  # protected
     # might not exist yet (we are generating it!)
     "https://pavics-weaver.readthedocs.io/en/latest/api.html",
     # ignore requires.io which just fails periodically - not critical link

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -236,14 +236,26 @@ Configuration of WPS Processes
 =======================================
 
 `Weaver` allows the configuration of services or processes auto-deployment using definitions from a file formatted
-as `wps_processes.yml.example`_. On application startup, provided references will be employed to attempt deployment
-of corresponding processes locally. Given that the resources can be correctly resolved, they will immediately be
-available from `Weaver`'s API without further request needed.
+as `wps_processes.yml.example`_. On application startup, provided references in ``processes`` list will be employed
+to attempt deployment of corresponding processes locally. Given that the resources can be correctly resolved, they
+will immediately be available from `Weaver`'s API without further request needed.
 
 For convenience, every reference URL in the configuration file can either refer to explicit process definition
-(i.e.: endpoint and query parameters that resolve to :ref:`DescribeProcess` response), or a group of processes under a
-common WPS server to iteratively deploy, using a :ref:`GetCapabilities` WPS endpoint. Please refer to
+(i.e.: endpoint and query parameters that resolve to :ref:`DescribeProcess` response), or a group of processes
+under a common WPS server to iteratively register, using a :ref:`GetCapabilities` WPS endpoint. Please refer to
 `wps_processes.yml.example`_ for explicit format, keywords supported, and their resulting behaviour.
+
+.. note::
+    Processes defined under ``processes`` section registered into `Weaver` will correspond to a local snapshot of
+    the remote resource at that point in time, and will not update if the reference changes. On the other hand, their
+    listing and description offering will not require the remote service to be available at all time until execution.
+
+.. versionadded:: 1.14.0
+    When references are specified using ``providers`` section instead of ``processes``, the registration
+    only saves the remote WPS provider endpoint to dynamically populate WPS processes on demand.
+
+    Using this registration method, the processes will always reflect the latest modification from the
+    remote WPS provider.
 
 To specify a custom YAML file, you can define the setting named ``weaver.wps_processes_file`` with the appropriate path
 within the employed ``weaver.ini`` file that starts your application. By default, this setting will look for the

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -46,11 +46,10 @@ Please refer to below references for more details.
 
 .. seealso::
 
-    - |wps-rest-support|_
+    - |process-wps-rest|_
     - :ref:`Deploy` request
 
-.. |wps-rest-support| replace:: Supported :term:`Application Package` locations
-.. _wps-rest-support: :ref:`WPS-REST`
+.. |process-wps-rest| replace:: Supported :term:`Application Package` locations
 
 
 Fixing permission error on input files

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -20,7 +20,7 @@ The installation works on Linux 64 bit distributions (tested on Ubuntu 16.04).
 
 .. note::
     Windows is *not officially supported*, but some patches have been applied to help using it.
-    If you find some problems, please submit an `issue <weaver-issues>`_ or open a pull request with fixes.
+    If you find some problems, please |submit-issue|_ or open a pull request with fixes.
 
 From GitHub Sources
 ===================

--- a/docs/source/package.rst
+++ b/docs/source/package.rst
@@ -61,8 +61,9 @@ CWL Workflow
 definition can be placed in any location supported as for the case of atomic processes
 (see details about :ref:`supported package locations <WPS-REST>`).
 
-.. |process-deploy-op| replace:: Process deployment operation
+.. inter-reference to 'process', but cannot be a link since not included
 .. _process-deploy-op: :ref:`Deploy`
+.. |process-deploy-op| replace:: Process deployment operation
 
 The following :term:`CWL` definition demonstrates an example ``Workflow`` process that would resolve each ``step`` with
 local processes of match IDs.
@@ -298,8 +299,8 @@ it gets parsed as intended type.
     by issue `#51 <https://github.com/crim-ca/weaver/issues/51>`_. It is possible to use a ``Literal`` data of
     type ``string`` corresponding to :term:`WKT` [#]_, [#]_ in the meantime.
 
-.. [#] `WKT Examples <wkt-example>`_
-.. [#] `WKT Formats <wkt-format>`_
+.. [#] |wkt-example|_
+.. [#] |wkt-format|_
 
 File Format
 -----------------------

--- a/docs/source/processes.rst
+++ b/docs/source/processes.rst
@@ -581,8 +581,7 @@ combinations.
 
 .. [#wf]
     Workflows are only available on :term:`EMS` instances. Since they chain processes, no fetch is needed as the first
-    sub-step process will do it instead. See `section about workflows <workflows>`_ as well as :ref:`CWL Workflow` for
-    more details.
+    sub-step process will do it instead. See :ref:`Workflow` process as well as :ref:`CWL Workflow` for more details.
 
 .. todo::
     method to indicate explicit fetch to override these? (https://github.com/crim-ca/weaver/issues/183)
@@ -755,5 +754,5 @@ Workflow (Chaining Step Processes)
 .. seealso::
 
     - :ref:`CWL Workflow`
-    - `Workflow Process Type <Workflow>`_
+    - :ref:`Workflow` process type
 

--- a/docs/source/processes.rst
+++ b/docs/source/processes.rst
@@ -1,3 +1,4 @@
+
 .. _processes:
 .. include:: references.rst
 
@@ -93,6 +94,7 @@ Please refer to :ref:`Configuration of WPS Processes` section for more details o
 .. seealso::
     - `Remote Provider`_
 
+.. _process-wps-rest:
 
 WPS-REST
 --------

--- a/docs/source/references.rst
+++ b/docs/source/references.rst
@@ -54,7 +54,9 @@
 .. _pywps-status: https://pywps.readthedocs.io/en/master/process.html#progress-and-status-report
 .. |pywps-multi-output| replace:: PyWPS Multiple Outputs
 .. _pywps-multi-output: https://pywps.readthedocs.io/en/master/process.html#returning-multiple-files
+.. |wkt-example| replace:: WKT Examples
 .. _wkt-example: https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry
+.. |wkt-format| replace:: WKT Formats
 .. _wkt-format: https://docs.geotools.org/stable/javadocs/org/opengis/referencing/doc-files/WKT.html
 .. |weaver-issues| replace:: Weaver issues
 .. _weaver-issues: https://github.com/crim-ca/weaver/issues

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,14 +10,14 @@ coverage
 doc8>=0.8.1
 flake8
 isort>=4.3.21,<5
-mock
+mock<4
 # AWS mock tests (against boto3)
-moto
+moto==1.3.15.dev1015
 pluggy>=0.7
 pytest
 pylint>=2.5.3,<2.6
 pylint_quotes
-responses
+responses==0.12.0
 # typing extension required for TypedDict
 typing_extensions; python_version < "3.8"
 WebTest

--- a/requirements-sys.txt
+++ b/requirements-sys.txt
@@ -1,0 +1,2 @@
+pip>=20.2.2
+setuptools

--- a/tests/functional/test_wps_package.py
+++ b/tests/functional/test_wps_package.py
@@ -59,6 +59,10 @@ EDAM_NETCDF = EDAM_NAMESPACE + ":" + EDAM_MAPPING[CONTENT_TYPE_APP_NETCDF]
 IANA_TAR = IANA_NAMESPACE + ":" + CONTENT_TYPE_APP_TAR  # noqa # pylint: disable=unused-variable
 IANA_ZIP = IANA_NAMESPACE + ":" + CONTENT_TYPE_APP_ZIP  # noqa # pylint: disable=unused-variable
 
+KNOWN_PROCESS_DESCRIPTION_FIELDS = {
+    "id", "title", "abstract", "inputs", "outputs", "executeEndpoint", "keywords", "metadata", "visibility"
+}
+
 LOGGER = logging.getLogger(__name__)
 
 
@@ -181,8 +185,7 @@ class WpsPackageAppTest(WpsPackageConfigBase):
         assert "minOccurs" not in desc["process"]["outputs"][0]
         assert "maxOccurs" not in desc["process"]["outputs"][0]
         assert "format" not in desc["process"]["outputs"][0]
-        expected_fields = {"id", "title", "abstract", "inputs", "outputs", "executeEndpoint", "keywords", "metadata"}
-        assert len(set(desc["process"].keys()) - expected_fields) == 0
+        assert len(set(desc["process"].keys()) - KNOWN_PROCESS_DESCRIPTION_FIELDS) == 0
 
     def test_literal_io_from_package_and_offering(self):
         """
@@ -1063,8 +1066,7 @@ class WpsPackageAppTest(WpsPackageConfigBase):
         assert isinstance(desc["process"]["outputs"][0]["formats"][0], dict)
         assert desc["process"]["outputs"][0]["formats"][0]["mimeType"] == CONTENT_TYPE_TEXT_PLAIN
         assert desc["process"]["outputs"][0]["formats"][0]["default"] is True
-        expected_fields = {"id", "title", "abstract", "inputs", "outputs", "executeEndpoint", "keywords", "metadata"}
-        assert len(set(desc["process"].keys()) - expected_fields) == 0
+        assert len(set(desc["process"].keys()) - KNOWN_PROCESS_DESCRIPTION_FIELDS) == 0
 
     def test_complex_io_from_package_and_offering(self):
         """

--- a/weaver/processes/builtin/jsonarray2netcdf.py
+++ b/weaver/processes/builtin/jsonarray2netcdf.py
@@ -15,7 +15,7 @@ from six.moves.urllib.parse import urlparse
 if six.PY3:
     from tempfile import TemporaryDirectory
 else:
-    from backports.tempfile import TemporaryDirectory  # noqa # py2
+    from backports.tempfile import TemporaryDirectory  # pylint: disable=E0611  # noqa # py2
 
 CUR_DIR = os.path.abspath(os.path.dirname(__file__))
 sys.path.insert(0, CUR_DIR)

--- a/weaver/processes/builtin/metalink2netcdf.py
+++ b/weaver/processes/builtin/metalink2netcdf.py
@@ -14,7 +14,7 @@ from lxml import etree
 if six.PY3:
     from tempfile import TemporaryDirectory
 else:
-    from backports.tempfile import TemporaryDirectory  # noqa # py2
+    from backports.tempfile import TemporaryDirectory  # pylint: disable=E0611  # noqa # py2
 
 CUR_DIR = os.path.abspath(os.path.dirname(__file__))
 sys.path.insert(0, CUR_DIR)

--- a/weaver/processes/utils.py
+++ b/weaver/processes/utils.py
@@ -393,7 +393,7 @@ def register_wps_processes_from_config(wps_processes_file_path, container):
     When the reference is a service (provider), registration of each WPS process is done individually
     for each of the specified providers with ID ``[service]_[process]`` per listed process by ``GetCapabilities``.
 
-    .. versionchanged:: 1.14.0
+    .. versionadded:: 1.14.0
         When references are specified using ``providers`` section instead of ``processes``, the registration
         only saves the remote WPS provider endpoint to dynamically populate WPS processes on demand.
 

--- a/weaver/processes/utils.py
+++ b/weaver/processes/utils.py
@@ -18,6 +18,7 @@ from pyramid.httpexceptions import (
     HTTPOk,
     HTTPUnprocessableEntity
 )
+from pyramid.settings import asbool
 from six.moves.urllib.error import URLError
 from six.moves.urllib.parse import parse_qs, urlparse
 from six.moves.urllib.request import urlopen
@@ -37,21 +38,22 @@ from weaver.exceptions import (
     PackageTypeError,
     ProcessNotFound,
     ProcessRegistrationError,
+    ServiceNotFound,
     log_unhandled_exceptions
 )
 from weaver.formats import CONTENT_TYPE_APP_JSON, CONTENT_TYPE_TEXT_PLAIN
 from weaver.processes.constants import WPS_COMPLEX_DATA
 from weaver.processes.types import PROCESS_APPLICATION, PROCESS_WORKFLOW
-from weaver.store.base import StoreProcesses
+from weaver.store.base import StoreProcesses, StoreServices
 from weaver.utils import get_sane_name, get_settings, get_url_without_query
+from weaver.visibility import VISIBILITY_PRIVATE, VISIBILITY_PUBLIC
 from weaver.wps import get_wps_output_dir
 from weaver.wps_restapi import swagger_definitions as sd
 from weaver.wps_restapi.utils import get_wps_restapi_base_url
 
 if TYPE_CHECKING:
     from weaver.typedefs import AnyContainer, AnySettingsContainer, FileSystemPathType, JSON, Number
-    from weaver.store.mongodb import MongodbProcessStore
-    from typing import Any, AnyStr, List, Optional
+    from typing import Any, AnyStr, List, Optional, Tuple, Union
     from pywps import Process as ProcessWPS
     import owslib.wps
 LOGGER = logging.getLogger(__name__)
@@ -349,11 +351,51 @@ def deploy_process_from_payload(payload, container):
     return HTTPOk(json=json_response)   # FIXME: should be 201 (created), update swagger accordingly
 
 
+def parse_wps_process_config(config_entry):
+    # type: (Union[JSON, AnyStr]) -> Tuple[AnyStr, AnyStr, List[AnyStr], bool]
+    """
+    Parses the available WPS provider or process entry to retrieve its relevant information.
+
+    :return: WPS provider name, WPS service URL, and list of process identifier(s).
+    :raise ValueError: if the entry cannot be parsed correctly.
+    """
+    if isinstance(config_entry, dict):
+        svc_url = config_entry["url"]
+        svc_name = config_entry.get("name")
+        svc_proc = config_entry.get("id", [])
+        svc_vis = asbool(config_entry.get("visible", False))
+    elif isinstance(config_entry, six.string_types):
+        svc_url = config_entry
+        svc_name = None
+        svc_proc = []
+        svc_vis = False
+    else:
+        raise ValueError("Invalid service value: [{!s}].".format(config_entry))
+    url_p = urlparse(svc_url)
+    qs_p = parse_qs(url_p.query)
+    svc_url = get_url_without_query(url_p)
+    svc_name = svc_name or get_sane_name(url_p.hostname)
+    svc_proc = svc_proc or qs_p.get("identifier", [])
+    if not isinstance(svc_name, six.string_types):
+        raise ValueError("Invalid service value: [{!s}].".format(svc_name))
+    if not isinstance(svc_proc, list):
+        raise ValueError("Invalid process value: [{!s}].".format(svc_proc))
+    return svc_name, svc_url, svc_proc, svc_vis
+
+
 def register_wps_processes_from_config(wps_processes_file_path, container):
     # type: (Optional[FileSystemPathType], AnySettingsContainer) -> None
     """
     Loads a `wps_processes.yml` file and registers `WPS-1` providers processes to the
     current `Weaver` instance as equivalent `WPS-2` processes.
+
+    References listed under ``processes`` are registered.
+    When the reference is a service (provider), registration of each WPS process is done individually
+    for each of the specified providers with ID ``[service]_[process]`` per listed process by ``GetCapabilities``.
+
+    .. versionchanged:: 1.14.0
+        When references are specified using ``providers`` section instead of ``processes``, the registration
+        only saves the remote WPS provider endpoint to dynamically populate WPS processes on demand.
 
     .. seealso::
         - `weaver.wps_processes.yml.example` for additional file format details
@@ -375,34 +417,20 @@ def register_wps_processes_from_config(wps_processes_file_path, container):
     try:
         with open(wps_processes_file_path, "r") as f:
             processes_config = yaml.safe_load(f)
-        processes = processes_config.get("processes")
-        if not processes:
+        processes = processes_config.get("processes") or []
+        providers = processes_config.get("providers") or []
+        if not processes and not providers:
             LOGGER.warning("Nothing to process from file: [%s]", wps_processes_file_path)
             return
 
-        process_store = get_db(container).get_store(StoreProcesses)  # type: MongodbProcessStore
+        db = get_db(container)
+        process_store = db.get_store(StoreProcesses)
+        service_store = db.get_store(StoreServices)
 
+        # either 'service' references to register every underlying 'process' individually
+        # or explicit 'process' references to register by themselves
         for cfg_service in processes:
-            # parse info
-            if isinstance(cfg_service, dict):
-                svc_url = cfg_service["url"]
-                svc_name = cfg_service.get("name")
-                svc_proc = cfg_service.get("id", [])
-            elif isinstance(cfg_service, six.string_types):
-                svc_url = cfg_service
-                svc_name = None
-                svc_proc = []
-            else:
-                raise ValueError("Invalid service value: [{!s}].".format(cfg_service))
-            url_p = urlparse(svc_url)
-            qs_p = parse_qs(url_p.query)
-            svc_url = get_url_without_query(url_p)
-            svc_name = svc_name or get_sane_name(url_p.hostname)
-            svc_proc = svc_proc or qs_p.get("identifier", [])
-            if not isinstance(svc_name, six.string_types):
-                raise ValueError("Invalid service value: [{!s}].".format(svc_name))
-            if not isinstance(svc_proc, list):
-                raise ValueError("Invalid process value: [{!s}].".format(svc_proc))
+            svc_name, svc_url, svc_proc, svc_vis = parse_wps_process_config(cfg_service)
 
             # fetch data
             LOGGER.info("Fetching WPS-1: [%s]", svc_url)
@@ -422,8 +450,9 @@ def register_wps_processes_from_config(wps_processes_file_path, container):
                     continue
                 proc_url = "{}?service=WPS&request=DescribeProcess&identifier={}&version={}" \
                            .format(svc_url, wps_process.identifier, wps.version)
+                svc_vis = VISIBILITY_PUBLIC if svc_vis else VISIBILITY_PRIVATE
                 payload = {
-                    "processDescription": {"process": {"id": proc_id}},
+                    "processDescription": {"process": {"id": proc_id, "visibility": svc_vis}},
                     "executionUnit": [{"href": proc_url}],
                     "deploymentProfileName": "http://www.opengis.net/profiles/eoc/wpsApplication",
                 }
@@ -434,9 +463,28 @@ def register_wps_processes_from_config(wps_processes_file_path, container):
                     else:
                         raise RuntimeError("Process registration failed: [{}]".format(proc_id))
                 except Exception as ex:
-                    LOGGER.exception("Exception during process registration: [%r]", ex)
+                    LOGGER.exception("Exception during process registration: [%r]. Skipping...", ex)
                     continue
 
+        # direct WPS providers to register
+        for cfg_service in providers:
+            svc_name, svc_url, _, svc_vis = parse_wps_process_config(cfg_service)
+            LOGGER.info("Register WPS-1 provider: [%s]", svc_url)
+            WebProcessingService(url=svc_url)  # only attempt fetch to validate it exists
+            try:
+                service_store.fetch_by_name(svc_name)
+            except ServiceNotFound:
+                pass
+            else:
+                LOGGER.warning("Provider already registered: [%s]. Skipping...", svc_name)
+                continue
+            try:
+                service_store.save_service(Service(name=svc_name, url=svc_url, public=svc_vis))
+            except Exception as ex:
+                LOGGER.exception("Exception during provider registration: [%r]. Skipping...", ex)
+                continue
+
+        LOGGER.info("Finished processing configuration file [%s].", wps_processes_file_path)
     except Exception as exc:
         msg = "Invalid WPS-1 providers configuration file [{!r}].".format(exc)
         LOGGER.exception(msg)

--- a/weaver/store/mongodb.py
+++ b/weaver/store/mongodb.py
@@ -1,5 +1,5 @@
 """
-Stores to read/write data to from/to mongodb using pymongo.
+Stores to read/write data to from/to `MongoDB` using pymongo.
 """
 
 import logging
@@ -86,7 +86,7 @@ class MongodbStore(object):
 
 class MongodbServiceStore(StoreServices, MongodbStore):
     """
-    Registry for OWS services. Uses mongodb to store service url and attributes.
+    Registry for OWS services. Uses `MongoDB` to store service url and attributes.
     """
 
     def __init__(self, *args, **kwargs):
@@ -123,15 +123,15 @@ class MongodbServiceStore(StoreServices, MongodbStore):
     def delete_service(self, name, request=None):  # noqa: E811
         # type: (AnyStr, Optional[Request]) -> bool
         """
-        Removes service from mongodb storage.
+        Removes service from `MongoDB` storage.
         """
         self.collection.delete_one({"name": name})
         return True
 
-    def list_services(self, request=None):  # noqa: E811  # noqa: E811
+    def list_services(self, request=None):  # noqa: E811
         # type: (Optional[Request]) -> List[Service]
         """
-        Lists all services in mongodb storage.
+        Lists all services in `MongoDB` storage.
         """
         my_services = []
         for service in self.collection.find().sort("name", pymongo.ASCENDING):
@@ -141,7 +141,7 @@ class MongodbServiceStore(StoreServices, MongodbStore):
     def fetch_by_name(self, name, visibility=None, request=None):  # noqa: E811
         # type: (AnyStr, Optional[AnyStr], Optional[Request]) -> Service
         """
-        Gets service for given ``name`` from mongodb storage.
+        Gets service for given ``name`` from `MongoDB` storage.
         """
         service = self.collection.find_one({"name": name})
         if not service:
@@ -156,7 +156,7 @@ class MongodbServiceStore(StoreServices, MongodbStore):
     def fetch_by_url(self, url, request=None):  # noqa: E811
         # type: (AnyStr, Optional[Request]) -> Service
         """
-        Gets service for given ``url`` from mongodb storage.
+        Gets service for given ``url`` from `MongoDB` storage.
         """
         service = self.collection.find_one({"url": get_base_url(url)})
         if not service:
@@ -166,7 +166,7 @@ class MongodbServiceStore(StoreServices, MongodbStore):
     def clear_services(self, request=None):  # noqa: E811
         # type: (Optional[Request]) -> bool
         """
-        Removes all OWS services from mongodb storage.
+        Removes all OWS services from `MongoDB` storage.
         """
         self.collection.drop()
         return True
@@ -174,7 +174,7 @@ class MongodbServiceStore(StoreServices, MongodbStore):
 
 class MongodbProcessStore(StoreProcesses, MongodbStore):
     """
-    Registry for processes. Uses mongodb to store processes and attributes.
+    Registry for processes. Uses `MongoDB` to store processes and attributes.
     """
     def __init__(self, *args, **kwargs):
         db_args, db_kwargs = MongodbStore.get_args_kwargs(*args, **kwargs)
@@ -364,7 +364,7 @@ class MongodbProcessStore(StoreProcesses, MongodbStore):
 
 class MongodbJobStore(StoreJobs, MongodbStore):
     """
-    Registry for process jobs tracking. Uses mongodb to store job attributes.
+    Registry for process jobs tracking. Uses `MongoDB` to store job attributes.
     """
     def __init__(self, *args, **kwargs):
         db_args, db_kwargs = MongodbStore.get_args_kwargs(*args, **kwargs)
@@ -426,7 +426,7 @@ class MongodbJobStore(StoreJobs, MongodbStore):
     def update_job(self, job):
         # type: (Job) -> Job
         """
-        Updates a job parameters in mongodb storage.
+        Updates a job parameters in `MongoDB` storage.
         :param job: instance of ``weaver.datatype.Job``.
         """
         try:
@@ -440,7 +440,7 @@ class MongodbJobStore(StoreJobs, MongodbStore):
     def delete_job(self, job_id, request=None):  # noqa: E811
         # type: (AnyStr, Optional[Request]) -> bool
         """
-        Removes job from mongodb storage.
+        Removes job from `MongoDB` storage.
         """
         self.collection.delete_one({"id": job_id})
         return True
@@ -448,7 +448,7 @@ class MongodbJobStore(StoreJobs, MongodbStore):
     def fetch_by_id(self, job_id, request=None):  # noqa: E811
         # type: (AnyStr, Optional[Request]) -> Job
         """
-        Gets job for given ``job_id`` from mongodb storage.
+        Gets job for given ``job_id`` from `MongoDB` storage.
         """
         job = self.collection.find_one({"id": job_id})
         if not job:
@@ -458,7 +458,7 @@ class MongodbJobStore(StoreJobs, MongodbStore):
     def list_jobs(self, request=None):  # noqa: E811
         # type: (Optional[Request]) -> List[Job]
         """
-        Lists all jobs in mongodb storage.
+        Lists all jobs in `MongoDB` storage.
         For user-specific access to available jobs, use :meth:`MongodbJobStore.find_jobs` instead.
         """
         jobs = []
@@ -480,7 +480,7 @@ class MongodbJobStore(StoreJobs, MongodbStore):
                   group_by=None,            # type: Optional[Union[AnyStr, List[AnyStr]]]
                   ):                        # type: (...) -> Union[JobListAndCount, JobCategoriesAndCount]
         """
-        Finds all jobs in mongodb storage matching search filters and obtain results with requested paging or grouping.
+        Finds all jobs in `MongoDB` storage matching search filters and obtain results with requested paging or grouping.
 
         :param request: request that lead to this call to obtain permissions and user id.
         :param process: process name to filter matching jobs.
@@ -601,7 +601,7 @@ class MongodbJobStore(StoreJobs, MongodbStore):
     def clear_jobs(self, request=None):  # noqa: E811
         # type: (Optional[Request]) -> bool
         """
-        Removes all jobs from mongodb storage.
+        Removes all jobs from `MongoDB` storage.
         """
         self.collection.drop()
         return True
@@ -609,7 +609,7 @@ class MongodbJobStore(StoreJobs, MongodbStore):
 
 class MongodbQuoteStore(StoreQuotes, MongodbStore):
     """
-    Registry for quotes. Uses mongodb to store quote attributes.
+    Registry for quotes. Uses `MongoDB` to store quote attributes.
     """
     def __init__(self, *args, **kwargs):
         db_args, db_kwargs = MongodbStore.get_args_kwargs(*args, **kwargs)
@@ -635,7 +635,7 @@ class MongodbQuoteStore(StoreQuotes, MongodbStore):
     def fetch_by_id(self, quote_id):
         # type: (AnyStr) -> Quote
         """
-        Gets quote for given ``quote_id`` from mongodb storage.
+        Gets quote for given ``quote_id`` from `MongoDB` storage.
         """
         quote = self.collection.find_one({"id": quote_id})
         if not quote:
@@ -645,7 +645,7 @@ class MongodbQuoteStore(StoreQuotes, MongodbStore):
     def list_quotes(self):
         # type: (...) -> List[Quote]
         """
-        Lists all quotes in mongodb storage.
+        Lists all quotes in `MongoDB` storage.
         """
         quotes = []
         for quote in self.collection.find().sort("id", ASCENDING):
@@ -655,7 +655,7 @@ class MongodbQuoteStore(StoreQuotes, MongodbStore):
     def find_quotes(self, process_id=None, page=0, limit=10, sort=None):
         # type: (Optional[AnyStr], int, int, Optional[AnyStr]) -> Tuple[List[Quote], int]
         """
-        Finds all quotes in mongodb storage matching search filters.
+        Finds all quotes in `MongoDB` storage matching search filters.
 
         Returns a tuple of filtered ``items`` and their ``count``, where ``items`` can have paging and be limited
         to a maximum per page, but ``count`` always indicate the `total` number of matches.
@@ -680,7 +680,7 @@ class MongodbQuoteStore(StoreQuotes, MongodbStore):
 
 class MongodbBillStore(StoreBills, MongodbStore):
     """
-    Registry for bills. Uses mongodb to store bill attributes.
+    Registry for bills. Uses `MongoDB` to store bill attributes.
     """
     def __init__(self, *args, **kwargs):
         db_args, db_kwargs = MongodbStore.get_args_kwargs(*args, **kwargs)
@@ -706,7 +706,7 @@ class MongodbBillStore(StoreBills, MongodbStore):
     def fetch_by_id(self, bill_id):
         # type: (AnyStr) -> Bill
         """
-        Gets bill for given ``bill_id`` from mongodb storage.
+        Gets bill for given ``bill_id`` from `MongoDB` storage.
         """
         bill = self.collection.find_one({"id": bill_id})
         if not bill:
@@ -716,7 +716,7 @@ class MongodbBillStore(StoreBills, MongodbStore):
     def list_bills(self):
         # type: (...) -> List[Bill]
         """
-        Lists all bills in mongodb storage.
+        Lists all bills in `MongoDB` storage.
         """
         bills = []
         for bill in self.collection.find().sort("id", ASCENDING):
@@ -726,7 +726,7 @@ class MongodbBillStore(StoreBills, MongodbStore):
     def find_bills(self, quote_id=None, page=0, limit=10, sort=None):
         # type: (Optional[AnyStr], int, int, Optional[AnyStr]) -> Tuple[List[Bill], int]
         """
-        Finds all bills in mongodb storage matching search filters.
+        Finds all bills in `MongoDB` storage matching search filters.
 
         Returns a tuple of filtered ``items`` and their ``count``, where ``items`` can have paging and be limited
         to a maximum per page, but ``count`` always indicate the `total` number of matches.

--- a/weaver/store/mongodb.py
+++ b/weaver/store/mongodb.py
@@ -480,7 +480,7 @@ class MongodbJobStore(StoreJobs, MongodbStore):
                   group_by=None,            # type: Optional[Union[AnyStr, List[AnyStr]]]
                   ):                        # type: (...) -> Union[JobListAndCount, JobCategoriesAndCount]
         """
-        Finds all jobs in `MongoDB` storage matching search filters and obtain results with requested paging or grouping.
+        Finds all jobs in `MongoDB` storage matching search filters to obtain results with requested paging or grouping.
 
         :param request: request that lead to this call to obtain permissions and user id.
         :param process: process name to filter matching jobs.

--- a/weaver/wps_restapi/processes/processes.py
+++ b/weaver/wps_restapi/processes/processes.py
@@ -427,7 +427,7 @@ def submit_job_handler(request, service_url, is_workflow=False, visibility=None)
     return HTTPCreated(location=location, json=body_data)
 
 
-@sd.jobs_full_service.post(tags=[sd.TAG_PROVIDER_PROCESS, sd.TAG_PROVIDERS, sd.TAG_EXECUTE, sd.TAG_JOBS],
+@sd.jobs_full_service.post(tags=[sd.TAG_PROVIDERS, sd.TAG_PROCESSES, sd.TAG_EXECUTE, sd.TAG_JOBS],
                            renderer=OUTPUT_FORMAT_JSON, schema=sd.PostProviderProcessJobRequest(),
                            response_schemas=sd.post_provider_process_job_responses)
 @log_unhandled_exceptions(logger=LOGGER, message=sd.InternalServerErrorPostProviderProcessJobResponse.description)
@@ -454,7 +454,7 @@ def list_remote_processes(service, request):
     return [convert_process_wps_to_db(service, process, settings) for process in wps.processes]
 
 
-@sd.provider_processes_service.get(tags=[sd.TAG_PROVIDER_PROCESS, sd.TAG_PROVIDERS, sd.TAG_GETCAPABILITIES],
+@sd.provider_processes_service.get(tags=[sd.TAG_PROVIDERS, sd.TAG_PROCESSES, sd.TAG_PROVIDERS, sd.TAG_GETCAPABILITIES],
                                    renderer=OUTPUT_FORMAT_JSON, schema=sd.ProviderEndpoint(),
                                    response_schemas=sd.get_provider_processes_responses)
 @log_unhandled_exceptions(logger=LOGGER, message=sd.InternalServerErrorGetProviderProcessesListResponse.description)
@@ -466,7 +466,7 @@ def get_provider_processes(request):
     store = get_db(request).get_store(StoreServices)
     service = store.fetch_by_name(provider_id, request=request)
     processes = list_remote_processes(service, request=request)
-    return HTTPOk(json=[p.json() for p in processes])
+    return HTTPOk(json={"processes": [p.process_summary() for p in processes]})
 
 
 def describe_provider_process(request):
@@ -486,7 +486,7 @@ def describe_provider_process(request):
     return convert_process_wps_to_db(service, process, get_settings(request))
 
 
-@sd.provider_process_service.get(tags=[sd.TAG_PROVIDER_PROCESS, sd.TAG_PROVIDERS, sd.TAG_DESCRIBEPROCESS],
+@sd.provider_process_service.get(tags=[sd.TAG_PROVIDERS, sd.TAG_PROCESSES, sd.TAG_PROVIDERS, sd.TAG_DESCRIBEPROCESS],
                                  renderer=OUTPUT_FORMAT_JSON, schema=sd.ProviderProcessEndpoint(),
                                  response_schemas=sd.get_provider_process_responses)
 @log_unhandled_exceptions(logger=LOGGER, message=sd.InternalServerErrorGetProviderProcessResponse.description)

--- a/weaver/wps_restapi/providers/providers.py
+++ b/weaver/wps_restapi/providers/providers.py
@@ -47,7 +47,7 @@ def get_providers(request):
             warnings.warn("Exception occurred while fetching wps {0} : {1!r}".format(service.url, exc),
                           NonBreakingExceptionWarning)
 
-    return HTTPOk(json=providers)
+    return HTTPOk(json={"providers": providers})
 
 
 def get_capabilities(service, request):

--- a/weaver/wps_restapi/swagger_definitions.py
+++ b/weaver/wps_restapi/swagger_definitions.py
@@ -147,7 +147,6 @@ TAG_API = "API"
 TAG_JOBS = "Jobs"
 TAG_VISIBILITY = "Visibility"
 TAG_BILL_QUOTE = "Billing & Quoting"
-TAG_PROVIDER_PROCESS = "Provider Processes"
 TAG_PROVIDERS = "Providers"
 TAG_PROCESSES = "Processes"
 TAG_GETCAPABILITIES = "GetCapabilities"
@@ -606,8 +605,14 @@ class LaunchJobQuerystring(MappingSchema):
     field_string.name = "tags"
 
 
+class VisibilityValue(SchemaNode):
+    schema_type = String
+    validator = OneOf(list(VISIBILITY_VALUES))
+    example = VISIBILITY_PUBLIC
+
+
 class Visibility(MappingSchema):
-    value = SchemaNode(String(), validator=OneOf(list(VISIBILITY_VALUES)), example=VISIBILITY_PUBLIC)
+    value = VisibilityValue()
 
 
 #########################################################
@@ -787,6 +792,7 @@ class ProcessCollection(MappingSchema):
 class Process(DescriptionType):
     inputs = InputTypeList(missing=drop)
     outputs = OutputDescriptionList(missing=drop)
+    visibility = VisibilityValue(missing=drop)
     executeEndpoint = SchemaNode(String(), format=URL, missing=drop)
 
 
@@ -1057,10 +1063,6 @@ class ProcessDescriptionBodySchema(MappingSchema):
 
 class ProvidersSchema(SequenceSchema):
     providers_service = ProviderSummarySchema()
-
-
-class ProcessesSchema(SequenceSchema):
-    provider_processes_service = Process()
 
 
 class JobOutputSchema(MappingSchema):
@@ -1392,7 +1394,7 @@ class NotImplementedDeleteProviderResponse(MappingSchema):
 
 class OkGetProviderProcessesSchema(MappingSchema):
     header = JsonHeader()
-    body = ProcessesSchema()
+    body = ProcessCollection()
 
 
 class InternalServerErrorGetProviderProcessesListResponse(MappingSchema):
@@ -1467,7 +1469,7 @@ class InternalServerErrorGetProcessPayloadResponse(MappingSchema):
 
 
 class ProcessVisibilityResponseBodySchema(MappingSchema):
-    value = SchemaNode(String(), validator=OneOf(list(VISIBILITY_VALUES)), example=VISIBILITY_PUBLIC)
+    value = VisibilityValue()
 
 
 class OkGetProcessVisibilitySchema(MappingSchema):

--- a/weaver/wps_restapi/swagger_definitions.py
+++ b/weaver/wps_restapi/swagger_definitions.py
@@ -1405,7 +1405,7 @@ class GetProcessesQuery(MappingSchema):
     providers = SchemaNode(
         Boolean(), example=True, default=False, missing=drop,
         description="List local processes as well as all sub-processes of all registered providers. "
-                    "Applicable only for weaver in {} mode, false otherwise.".format(WEAVER_CONFIGURATION_EMS))
+                    "Applicable only for Weaver in {} mode, false otherwise.".format(WEAVER_CONFIGURATION_EMS))
     detail = SchemaNode(
         Boolean(), example=True, default=True, missing=drop,
         description="Return summary details about each process, or simply their IDs."


### PR DESCRIPTION

- add parsing of `providers` entries in `wps_processes.yml`
- align remote/dynamic provider processes response with local/static processes 
  (under `"processes"` key instead of flat list)

Usefull for upcoming birdhouse-deploy integration with existing WPS providers in the stack