### PR TITLE
Resolve requirements

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,7 +12,8 @@ Changes:
 
 Fixes:
 ------
-- No change.
+- Address multiple invalid dependency requirements breaking installed packages over builtin Python packages
+  (see also `geopython/pywps #568 <https://github.com/geopython/pywps/issues/568>`_).
 
 `1.14.0 <https://github.com/crim-ca/weaver/tree/1.14.0>`_ (2021-01-11)
 ========================================================================

--- a/Makefile
+++ b/Makefile
@@ -28,26 +28,33 @@ CONDA_ENV_REAL_TARGET_PATH := $(realpath $(CONDA_ENV_PATH))
 CONDA_ENV_REAL_ACTIVE_PATH := $(realpath ${CONDA_PREFIX})
 # environment already active - use it directly
 ifneq ("$(CONDA_ENV_REAL_ACTIVE_PATH)", "")
-	CONDA_ENV_MODE := [using active environment]
-	CONDA_ENV := $(notdir $(CONDA_ENV_REAL_ACTIVE_PATH))
-	CONDA_CMD :=
+  CONDA_ENV_MODE := [using active environment]
+  CONDA_ENV := $(notdir $(CONDA_ENV_REAL_ACTIVE_PATH))
+  CONDA_CMD :=
 endif
 # environment not active but it exists - activate and use it
 ifneq ($(CONDA_ENV_REAL_TARGET_PATH), "")
-	CONDA_ENV := $(notdir $(CONDA_ENV_REAL_TARGET_PATH))
+  CONDA_ENV := $(notdir $(CONDA_ENV_REAL_TARGET_PATH))
 endif
 # environment not active and not found - create, activate and use it
 ifeq ("$(CONDA_ENV)", "")
-	CONDA_ENV := $(APP_NAME)
+  CONDA_ENV := $(APP_NAME)
 endif
 # update paths for environment activation
 ifeq ("$(CONDA_ENV_REAL_ACTIVE_PATH)", "")
-	CONDA_ENV_MODE := [will activate environment]
-	CONDA_CMD := source "$(CONDA_HOME)/bin/activate" "$(CONDA_ENV)";
+  CONDA_ENV_MODE := [will activate environment]
+  CONDA_CMD := source "$(CONDA_HOME)/bin/activate" "$(CONDA_ENV)";
 endif
 DOWNLOAD_CACHE ?= $(APP_ROOT)/downloads
 PYTHON_VERSION ?= `python -c 'import platform; print(platform.python_version())'`
-PIP_XARGS ?= --use-feature=2020-resolver
+PIP_USE_FEATURE := `python -c '\
+	import pip; \
+	from distutils.version import LooseVersion; \
+	print(LooseVersion(pip.__version__) < LooseVersion("21.0"))'`
+PIP_XARGS ?=
+ifeq ("$(PIP_USE_FEATURE)", "True")
+  PIP_XARGS := --use-feature=2020-resolver $(PIP_XARGS)
+endif
 
 # choose conda installer depending on your OS
 CONDA_URL = https://repo.continuum.io/miniconda

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,8 @@ cwltool>=1.0.20180820141117,<2; python_version < "3"
 #        remove properly as per https://github.com/crim-ca/weaver/issues/154
 cwltool>=2,<=3.0.20200324120055; python_version >= "3"
 duration
+git+https://github.com/ESGF/esgf-compute-api.git@v2.1.0#egg=cwt ; python_version < "3"
+git+https://github.com/ESGF/esgf-compute-api.git@v2.3.7#egg=esgf-compute-api ; python_version > "3"
 flufl.enum; python_version < "3"
 # gunicorn >20 breaks some config.ini loading parameters (paste)
 # it is also only available for Python >=3.5
@@ -32,7 +34,11 @@ pyramid>=1.7.3
 pyramid_celery
 pyramid_mako
 pytz
-pywps>=4.2.4
+# no viable pywps version with Python>3.5 dependencies
+# use '4.2.4' plus a few commits that provide fix, but not yet released
+# FIXME: https://github.com/geopython/pywps/issues/568
+git+https://github.com/geopython/pywps.git@dd7db7b#egg=pywps ; python_version >= "3"
+pywps==4.2.4; python_version < "3"
 pyyaml>=5.2
 requests
 requests_file

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,7 @@ pytz
 # no viable pywps version with Python>3.5 dependencies
 # use '4.2.4' plus a few commits that provide fix, but not yet released
 # FIXME: https://github.com/geopython/pywps/issues/568
-git+https://github.com/geopython/pywps.git@dd7db7b#egg=pywps ; python_version >= "3"
+git+https://github.com/fmigneault/pywps.git@799fb14f31533630ce08c171f844294730861b1a#egg=pywps ; python_version >= "3"
 pywps==4.2.4; python_version < "3"
 pyyaml>=5.2
 requests

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,9 @@ sys.path.insert(0, os.path.join(CUR_DIR, os.path.split(CUR_DIR)[-1]))
 # pylint: disable=C0413,wrong-import-order
 from weaver import __meta__  # isort:skip # noqa: E402
 
-requirements = [line.strip() for line in open("requirements.txt")]
+requirements = {line.strip() for line in open("requirements.txt")}
+links = {line for line in requirements if "git+https" in line}
+requirements = requirements - links
 
 setup(name=__meta__.__name__,
       version=__meta__.__version__,
@@ -48,10 +50,8 @@ setup(name=__meta__.__name__,
       zip_safe=False,
       test_suite="tests",
       python_requires=">=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, <4",
-      install_requires=requirements,
-      dependency_links=[
-          "git+https://github.com/ESGF/esgf-compute-api.git@v2.1.0#egg=cwt"
-      ],
+      install_requires=list(requirements),
+      dependency_links=list(links),
       entry_points={
           "paste.app_factory": [
               "main = {}:main".format(__meta__.__name__)

--- a/weaver/processes/esgf_process.py
+++ b/weaver/processes/esgf_process.py
@@ -3,7 +3,7 @@ import time
 from collections import defaultdict
 from typing import TYPE_CHECKING, Optional
 
-import cwt
+import cwt  # noqa  # package: esgf-compute-api
 
 from weaver.processes.wps1_process import Wps1Process
 from weaver.status import STATUS_FAILED, STATUS_RUNNING, STATUS_SUCCEEDED


### PR DESCRIPTION
- temp fix for https://github.com/geopython/pywps/issues/568 (mismatch python 2/3 deps)
  resolved via targeting https://github.com/geopython/pywps/pull/569
- patch esgf-cwt api that still referenced a version that uses `print` without parenthesis (python 2 style)
- handle pip 21.0 that will raise eventually due to `--use-feature=2020-resolver`
  `make` will add it on the fly as needed 
