### PR TITLE
improve handling race condition of duplicate builtin process registration

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,7 +12,7 @@ Changes:
 
 Fixes:
 ------
-- No change.
+- Improve race condition handling of ``builtin`` process registration at application startup.
 
 `2.1.0 <https://github.com/crim-ca/weaver/tree/2.1.0>`_ (2021-02-26)
 ========================================================================


### PR DESCRIPTION
Previous PRs (#223 [[smoke-test error](https://github.com/crim-ca/weaver/runs/2016670675)], #225 [[smoke-test ok](https://github.com/crim-ca/weaver/runs/2018397147)], #226 [[smoke-test ok](https://github.com/crim-ca/weaver/runs/2017330325)]) illustrated during `smoke-test` that sometimes race conditions happens during `builtin` process registration. 
This PR adds more specific validation of existing processes against new ones to register and catches/ignores situations were the error can be safely discarded. 