### PR TITLE
wps-client cached

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,8 @@ Changes
 
 Changes:
 --------
-- No change.
+- Add caching of remote WPS requests according to ``request-options.yml`` and request header ``Cache-Control`` to allow
+  reduced query of pre-fetched WPS client definition.
 
 Fixes:
 ------

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -394,12 +394,15 @@ def mocked_remote_wps(processes, languages=None):
     class MockProcesses(mock.PropertyMock):
         pass
 
-    class MockLanguages(mock.PropertyMock, Languages):
+    class MockLanguages(mock.PropertyMock):
         pass
 
+    lang = Languages([])
+    lang.supported = languages or []
     mock_processes = MockProcesses
     mock_processes.return_value = processes
-    mock_languages = MockLanguages(languages or [])
+    mock_languages = MockLanguages
+    mock_languages.return_value = lang
     return (
         mock.patch.object(WebProcessingService, "getcapabilities", side_effect=lambda *args, **kwargs: None),
         mock.patch.object(WebProcessingService, "processes", new_callable=mock_processes, create=True),

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -15,6 +15,7 @@ import colander
 import mock
 import moto
 import pyramid_celery
+from owslib.wps import Languages, WebProcessingService
 from pyramid import testing
 from pyramid.config import Configurator
 from pyramid.httpexceptions import HTTPException, HTTPNotFound, HTTPUnprocessableEntity
@@ -32,9 +33,16 @@ from weaver.utils import get_path_kvp, get_url_without_query, get_weaver_url, nu
 from weaver.warning import MissingParameterWarning, UnsupportedOperationWarning
 
 if TYPE_CHECKING:
-    import botocore.client  # noqa
+    from typing import Any, Callable, Iterable, List, Optional, Type, Union
 
-    from weaver.typedefs import Any, AnyResponseType, Callable, List, Optional, SettingsType, Type, Union
+    import botocore.client  # noqa
+    from owslib.wps import Process as ProcessOWSWPS
+    from pywps.app import Process as ProcessPyWPS
+
+    from weaver.typedefs import AnyResponseType, SettingsType
+
+    # pylint: disable=C0103,invalid-name,E1101,no-member
+    MockPatch = mock._patch  # noqa
 
 MOCK_AWS_REGION = "us-central-1"
 
@@ -378,7 +386,29 @@ def mocked_sub_requests(app, function, *args, only_local=False, **kwargs):
         return resp
 
 
+def mocked_remote_wps(processes, languages=None):
+    # type: (List[Union[ProcessPyWPS, ProcessOWSWPS]], Optional[List[str]]) -> Iterable[MockPatch]
+    """
+    Mocks creation of a :class:`WebProcessingService` with provided :paramref:`processes` and returns them directly.
+    """
+    class MockProcesses(mock.PropertyMock):
+        pass
+
+    class MockLanguages(mock.PropertyMock, Languages):
+        pass
+
+    mock_processes = MockProcesses
+    mock_processes.return_value = processes
+    mock_languages = MockLanguages(languages or [])
+    return (
+        mock.patch.object(WebProcessingService, "getcapabilities", side_effect=lambda *args, **kwargs: None),
+        mock.patch.object(WebProcessingService, "processes", new_callable=mock_processes, create=True),
+        mock.patch.object(WebProcessingService, "languages", new_callable=mock_languages, create=True),
+    )
+
+
 def mocked_execute_process():
+    # type: () -> Iterable[MockPatch]
     """
     Provides a mock to call :func:`weaver.processes.execution.execute_process` safely within a test employing
     :class:`webTest.TestApp` without a running ``Celery`` app.
@@ -420,6 +450,7 @@ def mocked_execute_process():
 
 
 def mocked_process_job_runner(job_task_id="mocked-job-id"):
+    # type: (str) -> Iterable[MockPatch]
     """
     Provides a mock that will bypass execution of the process when called during job submission.
 
@@ -434,6 +465,7 @@ def mocked_process_job_runner(job_task_id="mocked-job-id"):
 
 
 def mocked_process_package():
+    # type: () -> Iterable[MockPatch]
     """
     Provides mocks that bypasses execution when calling :module:`weaver.processes.wps_package` functions.
     """
@@ -446,6 +478,7 @@ def mocked_process_package():
 
 
 def mocked_aws_credentials(test_func):
+    # type: (Callable[[...], Any]) -> Callable
     """Mocked AWS Credentials for :py:mod:`moto`.
 
     When using this fixture, ensures that if other mocks fail, at least credentials should be invalid to avoid
@@ -463,6 +496,7 @@ def mocked_aws_credentials(test_func):
 
 
 def mocked_aws_s3(test_func):
+    # type: (Callable[[...], Any]) -> Callable
     """
     Mocked AWS S3 bucket for :py:mod:`boto3` over mocked AWS credentials using :py:mod:`moto`.
 

--- a/tests/wps/test_utils.py
+++ b/tests/wps/test_utils.py
@@ -1,5 +1,6 @@
 import contextlib
 import copy
+
 import mock
 
 from tests.utils import mocked_remote_wps

--- a/tests/wps/test_utils.py
+++ b/tests/wps/test_utils.py
@@ -1,14 +1,52 @@
+import contextlib
+import copy
 import mock
 
-from weaver.wps.utils import set_wps_language
+from tests.utils import mocked_remote_wps
+from weaver.formats import ACCEPT_LANGUAGE_EN_US, ACCEPT_LANGUAGE_FR_CA, CONTENT_TYPE_APP_JSON, CONTENT_TYPE_APP_XML
+from weaver.wps.utils import get_wps_client, set_wps_language
 
 
 def test_set_wps_language():
     wps = mock.Mock()
     languages = mock.Mock()
     wps.languages = languages
-    languages.default = "en-US"
-    languages.supported = ["en-US", "fr-CA"]
+    languages.default = ACCEPT_LANGUAGE_EN_US
+    languages.supported = [ACCEPT_LANGUAGE_EN_US, ACCEPT_LANGUAGE_FR_CA]
 
     set_wps_language(wps, "ru, fr;q=0.5")
-    assert wps.language == "fr-CA"
+    assert wps.language == ACCEPT_LANGUAGE_FR_CA
+
+
+def test_get_wps_client_headers_preserved():
+    """
+    Validate that original request headers are not modified following WPS client sub-requests.
+    """
+    test_wps_url = "http://dont-care.com/wps"
+    test_headers = {
+        "Content-Type": CONTENT_TYPE_APP_XML,
+        "Content-Length": "0",
+        "Accept-Language": ACCEPT_LANGUAGE_EN_US,
+        "Accept": CONTENT_TYPE_APP_JSON,
+        "Authorization": "Bearer: FAKE",  # nosec
+    }
+    test_copy_headers = copy.deepcopy(test_headers)
+    # following are removed for sub-request
+    test_wps_headers = {
+        "Accept-Language": ACCEPT_LANGUAGE_EN_US,
+        "Authorization": "Bearer: FAKE",  # nosec
+    }
+
+    with contextlib.ExitStack() as stack:
+        patches = mocked_remote_wps([])
+        mocks = []
+        for patch in patches:
+            mocks.append(stack.enter_context(patch))
+
+        wps = get_wps_client(test_wps_url, headers=test_headers)
+
+    for mocked in mocks:
+        assert mocked.called
+    assert test_headers == test_copy_headers, "Input headers must be unmodified after WPS client call"
+    assert wps.headers == test_wps_headers, "Only allowed headers should have been passed down to WPS client"
+    assert wps.url == test_wps_url

--- a/tests/wps/test_utils.py
+++ b/tests/wps/test_utils.py
@@ -26,19 +26,19 @@ def test_get_wps_client_headers_preserved():
     test_headers = {
         "Content-Type": CONTENT_TYPE_APP_XML,
         "Content-Length": "0",
-        "Accept-Language": ACCEPT_LANGUAGE_EN_US,
+        "Accept-Language": ACCEPT_LANGUAGE_FR_CA,
         "Accept": CONTENT_TYPE_APP_JSON,
         "Authorization": "Bearer: FAKE",  # nosec
     }
     test_copy_headers = copy.deepcopy(test_headers)
     # following are removed for sub-request
     test_wps_headers = {
-        "Accept-Language": ACCEPT_LANGUAGE_EN_US,
+        "Accept-Language": ACCEPT_LANGUAGE_FR_CA,
         "Authorization": "Bearer: FAKE",  # nosec
     }
 
     with contextlib.ExitStack() as stack:
-        patches = mocked_remote_wps([])
+        patches = mocked_remote_wps([], [ACCEPT_LANGUAGE_FR_CA])
         mocks = []
         for patch in patches:
             mocks.append(stack.enter_context(patch))
@@ -49,4 +49,5 @@ def test_get_wps_client_headers_preserved():
         assert mocked.called
     assert test_headers == test_copy_headers, "Input headers must be unmodified after WPS client call"
     assert wps.headers == test_wps_headers, "Only allowed headers should have been passed down to WPS client"
+    assert wps.language == ACCEPT_LANGUAGE_FR_CA, "Language should have been passed down to WPS client from header"
     assert wps.url == test_wps_url

--- a/tests/wps_restapi/test_processes.py
+++ b/tests/wps_restapi/test_processes.py
@@ -7,7 +7,6 @@ import colander
 import pyramid.testing
 import pytest
 import responses
-import webtest
 
 from tests.utils import (
     get_test_weaver_app,
@@ -81,7 +80,6 @@ class WpsRestApiProcessesTest(unittest.TestCase):
         cls.config = setup_config_with_mongodb(settings=settings)
         cls.app = get_test_weaver_app(config=cls.config)
         cls.json_headers = {"Accept": CONTENT_TYPE_APP_JSON, "Content-Type": CONTENT_TYPE_APP_JSON}
-        cls.app = webtest.TestApp(cls.config.make_wsgi_app())
 
     @classmethod
     def tearDownClass(cls):

--- a/weaver/wps/utils.py
+++ b/weaver/wps/utils.py
@@ -2,6 +2,7 @@ import logging
 import os
 import tempfile
 from configparser import ConfigParser
+from copy import deepcopy
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
@@ -24,7 +25,8 @@ from weaver.utils import (
     invalidate_region,
     is_uuid,
     make_dirs,
-    request_extra
+    request_extra,
+    retry_on_cache_error
 )
 
 LOGGER = logging.getLogger(__name__)
@@ -161,6 +163,7 @@ def _get_wps_client_cached(url, headers, verify, language):
     return wps
 
 
+@retry_on_cache_error
 def get_wps_client(url, container=None, verify=None, headers=None, language=None):
     # type: (str, Optional[AnySettingsContainer], bool, Optional[HeadersType], Optional[str]) -> WebProcessingService
     """
@@ -178,6 +181,8 @@ def get_wps_client(url, container=None, verify=None, headers=None, language=None
     else:
         headers = headers or {}
     # remove invalid values that should be recomputed by the client as needed
+    # employ the provided headers instead of making new ones in order to forward any language/authorization definition
+    headers = deepcopy(headers)  # don't modify original headers for sub-requests for next steps that could use them
     for header in ["Accept", "Content-Length", "Content-Type", "Content-Transfer-Encoding"]:
         hdr_low = header.lower()
         for hdr in [header, hdr_low, header.replace("-", "_"), hdr_low.replace("-", "_")]:

--- a/weaver/wps/utils.py
+++ b/weaver/wps/utils.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
 import lxml.etree
+from beaker.cache import cache_region
 from owslib.wps import WebProcessingService, WPSExecution
 from pyramid.httpexceptions import HTTPNotFound
 from pywps import configuration as pywps_config
@@ -13,11 +14,14 @@ from pywps import configuration as pywps_config
 from weaver.config import get_weaver_configuration
 from weaver.typedefs import XML
 from weaver.utils import (
-    get_cookie_headers,
+    get_header,
+    get_no_cache_option,
+    get_request_options,
     get_settings,
     get_ssl_verify_option,
     get_url_without_query,
     get_weaver_url,
+    invalidate_region,
     is_uuid,
     make_dirs,
     request_extra
@@ -27,7 +31,7 @@ LOGGER = logging.getLogger(__name__)
 if TYPE_CHECKING:
     from typing import Dict, Union, Optional
 
-    from weaver.typedefs import AnyRequestType, AnySettingsContainer, HeadersType
+    from weaver.typedefs import AnyRequestType, AnySettingsContainer, HeadersType, ProcessOWS
 
 
 def _get_settings_or_wps_config(container,                  # type: AnySettingsContainer
@@ -99,7 +103,8 @@ def get_wps_output_url(container):
     """
     wps_output_default = get_weaver_url(container) + "/wpsoutputs"
     wps_output_config = _get_settings_or_wps_config(
-        container, "weaver.wps_output_url", "server", "outputurl", wps_output_default, "WPS output url")
+        container, "weaver.wps_output_url", "server", "outputurl", wps_output_default, "WPS output url"
+    )
     return wps_output_config or wps_output_default
 
 
@@ -138,6 +143,24 @@ def get_wps_local_status_location(url_status_location, container, must_exist=Tru
     return out_path
 
 
+@cache_region("request")
+def _describe_process_cached(self, identifier, xml=None):
+    # type: (WebProcessingService, str, Optional[XML]) -> ProcessOWS
+    LOGGER.debug("Request WPS DescribeProcess to [%s] with [id: %s]", self.url, identifier)
+    return self.describeprocess_method(identifier, xml=xml)  # noqa  # method created by '_get_wps_client_cached'
+
+
+@cache_region("request")
+def _get_wps_client_cached(url, headers, verify, language):
+    # type: (str, HeadersType, bool, Optional[str]) -> WebProcessingService
+    LOGGER.debug("Request WPS GetCapabilities to [%s]", url)
+    wps = WebProcessingService(url=url, headers=headers, verify=verify)
+    set_wps_language(wps, accept_language=language)
+    setattr(wps, "describeprocess_method", wps.describeprocess)  # backup real method, them override with cached
+    setattr(wps, "describeprocess", lambda *_, **__: _describe_process_cached(wps, *_, **__))
+    return wps
+
+
 def get_wps_client(url, container=None, verify=None, headers=None, language=None):
     # type: (str, Optional[AnySettingsContainer], bool, Optional[HeadersType], Optional[str]) -> WebProcessingService
     """
@@ -150,16 +173,30 @@ def get_wps_client(url, container=None, verify=None, headers=None, language=None
     :param language: preferred response language if supported by the service.
     :returns: created WPS client object with configured request options.
     """
-    headers = headers or {}
     if headers is None and hasattr(container, "headers"):
-        headers = get_cookie_headers(container.headers)
+        headers = container.headers
+    else:
+        headers = headers or {}
     # remove invalid values that should be recomputed by the client as needed
-    for hdr in ["Accept", "Content-Length", "Content-Type", "Content-Transfer-Encoding"]:
-        headers.pop(hdr, None)
+    for header in ["Accept", "Content-Length", "Content-Type", "Content-Transfer-Encoding"]:
+        hdr_low = header.lower()
+        for hdr in [header, hdr_low, header.replace("-", "_"), hdr_low.replace("-", "_")]:
+            headers.pop(hdr, None)
+    opts = get_request_options("get", url, container)
     if verify is None:
-        verify = get_ssl_verify_option("get", url, container)
-    wps = WebProcessingService(url=url, headers=headers, verify=verify)
-    set_wps_language(wps, request=container, accept_language=language)
+        verify = get_ssl_verify_option("get", url, container, request_options=opts)
+    # convert objects to allow caching keys against values (object instances always different)
+    language = language or getattr(container, "accept_language", None) or get_header("Accept-Language", headers)
+    if language is not None and not isinstance(language, str):
+        language = str(language)
+    if headers is not None and not isinstance(headers, dict):
+        headers = dict(headers)
+    request_args = (url, headers, verify, language)
+    if get_no_cache_option(headers, request_options=opts):
+        for func in (_get_wps_client_cached, _describe_process_cached):
+            caching_args = (func, "request", *request_args)
+            invalidate_region(caching_args)
+    wps = _get_wps_client_cached(*request_args)
     return wps
 
 
@@ -185,7 +222,8 @@ def check_wps_status(location=None,     # type: Optional[str]
         if not out_path:
             raise HTTPNotFound("Could not find file resource from [{}].".format(location))
         LOGGER.info("Resolved WPS status-location using local file reference.")
-        return open(out_path, "r").read()
+        with open(out_path, "r") as f:
+            return f.read()
 
     execution = WPSExecution()
     if response:
@@ -341,6 +379,7 @@ def set_wps_language(wps, accept_language=None, request=None):
         # owslib version doesn't support setting a language
         return
 
+    accept_language = str(accept_language)  # in case it is one of pyramid AcceptLanguage objects
     accepted_languages = [lang.strip().split(";")[0] for lang in accept_language.lower().split(",")]
 
     for accept in accepted_languages:

--- a/weaver/wps_restapi/processes/processes.py
+++ b/weaver/wps_restapi/processes/processes.py
@@ -106,7 +106,6 @@ def get_provider_process(request):
     """
     try:
         process = describe_provider_process(request)
-        sd.ProcessOffering().deserialize(process)
         process_offering = process.offering()
         return HTTPOk(json=process_offering)
     # FIXME: handle colander invalid directly in tween (https://github.com/crim-ca/weaver/issues/112)


### PR DESCRIPTION
wps-client creation caching control according to beaker config and request headers

Avoids re-querying the full process listing and client object such that multiple calls of `/providers/x/processes/y`, `/providers/x/processes/z`, etc. will only do an initial `getcapabilites`, and will reuse the object for subsequent `describeprocess` operation until the cache expires or is enforced with no-cache.
