### PR TITLE
patch pywps-4.4.3 + workaround to avoid file prefetch during validation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,11 @@ Changes:
 
 Fixes:
 ------
-- No change.
+- Pin ``pywps==4.4.3`` and fix incompatibility introduced by its refactor of I/O base classes in
+  `#602 <https://github.com/geopython/pywps/pull/602>`_
+  (specifically `commit 343d825 <https://github.com/geopython/pywps/commit/343d82539576b1e73eee3102654749c3d3137cff>`_),
+  which broke the ``ComplexInput`` work-around to avoid useless of file URLs
+  (see issue `#526 <https://github.com/geopython/pywps/issues/526>`_).
 
 `3.1.0 <https://github.com/crim-ca/weaver/tree/3.1.0>`_ (2021-04-23)
 ========================================================================

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,11 +46,7 @@ pyramid_mako
 python-dateutil
 pyramid_rewrite
 pytz
-# no viable pywps version with Python>3.5 dependencies
-# use '4.2.4' plus a few commits that provide fix, but not yet released
-# FIXME: https://github.com/geopython/pywps/issues/568
-## git+https://github.com/fmigneault/pywps.git@799fb14f31533630ce08c171f844294730861b1a#egg=pywps
-git+https://github.com/geopython/pywps.git@pywps-4.4#egg=pywps
+pywps==4.4.3
 pyyaml>=5.2
 requests
 requests_file

--- a/weaver/processes/wps_package.py
+++ b/weaver/processes/wps_package.py
@@ -1171,8 +1171,8 @@ class WpsPackage(Process):
         #   since href is already handled (pulled and staged locally), use it directly to avoid double fetch with CWL
         #   validate using the internal '_file' instead of 'file' otherwise we trigger the fetch
         #   normally, file should be pulled an this check should fail
-        if input_definition._file and os.path.isfile(input_definition._file):     # noqa: W0212
-            input_location = input_definition._file                               # noqa: W0212
+        if input_definition._iohandler._file and os.path.isfile(input_definition._iohandler._file):  # noqa: W0212
+            input_location = input_definition._iohandler._file                                       # noqa: W0212
         # if source type is data, we actually need to call 'data' (without fetch of remote file, already fetched)
         # value of 'file' in this case points to a local file path where the wanted link was dumped as raw data
         if input_definition.source_type == SOURCE_TYPE.DATA:


### PR DESCRIPTION
- Pin ``pywps==4.4.3`` to avoid future surprises
- fix incompatibility introduced by its refactor of I/O base classes in PR https://github.com/geopython/pywps/pull/602
  https://github.com/geopython/pywps/commit/343d82539576b1e73eee3102654749c3d3137cff moves the location of `_file` that we used to work around the pre-fetch operation caused by `MODE` validation (see https://github.com/geopython/pywps/issues/526).
