### PR TITLE
fix invalid Not keyword resolution 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,8 @@ Fixes:
 - Fix default execution mode specification in process job control options
   (fixes `#182 <https://github.com/opengeospatial/ogcapi-processes/pull/182>`_).
 - Fix old OGC-API WPS REST bindings link in landing page for the more recent `OGC-API Processes` specification.
+- Fix invalid deserialization of schemas using ``not`` keyword that would result in all fields returned instead of
+  limiting them to the expected fields from the schema definitions for ``LiteralInputType`` in process description.
 
 `3.1.0 <https://github.com/crim-ca/weaver/tree/3.1.0>`_ (2021-04-23)
 ========================================================================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,8 @@ Fixes:
 - Fix old OGC-API WPS REST bindings link in landing page for the more recent `OGC-API Processes` specification.
 - Fix invalid deserialization of schemas using ``not`` keyword that would result in all fields returned instead of
   limiting them to the expected fields from the schema definitions for ``LiteralInputType`` in process description.
+- Adjust ``InputType`` and ``OutputType`` schemas to use ``allOf`` instead of ``anyOf`` definition since all sub-schemas
+  that define them must be combined, with their respectively required or optional fields.
 
 `3.1.0 <https://github.com/crim-ca/weaver/tree/3.1.0>`_ (2021-04-23)
 ========================================================================

--- a/tests/functional/test_wps_package.py
+++ b/tests/functional/test_wps_package.py
@@ -48,8 +48,15 @@ IANA_TAR = IANA_NAMESPACE + ":" + CONTENT_TYPE_APP_TAR  # noqa # pylint: disable
 IANA_ZIP = IANA_NAMESPACE + ":" + CONTENT_TYPE_APP_ZIP  # noqa # pylint: disable=unused-variable
 
 KNOWN_PROCESS_DESCRIPTION_FIELDS = {
-    "id", "title", "abstract", "inputs", "outputs", "executeEndpoint", "keywords", "metadata", "visibility"
+    "id", "title", "abstract", "keywords", "metadata", "inputs", "outputs", "executeEndpoint", "visibility"
 }
+# intersection of fields in InputType and specific sub-schema LiteralInputType
+KNOWN_PROCESS_DESCRIPTION_INPUT_DATA_FIELDS = {
+    "id", "title", "abstract", "keywords", "metadata", "links", "literalDataDomains", "additionalParameters",
+    "minOccurs", "maxOccurs"
+}
+# corresponding schemas of input, but min/max occurs not expected
+KNOWN_PROCESS_DESCRIPTION_OUTPUT_DATA_FIELDS = KNOWN_PROCESS_DESCRIPTION_INPUT_DATA_FIELDS - {"minOccurs", "maxOccurs"}
 
 LOGGER = logging.getLogger(__name__)
 
@@ -134,6 +141,11 @@ class WpsPackageAppTest(WpsPackageConfigBase):
         assert "maxOccurs" not in desc["process"]["outputs"][0]
         assert "format" not in desc["process"]["outputs"][0]
         assert len(set(desc["process"].keys()) - KNOWN_PROCESS_DESCRIPTION_FIELDS) == 0
+        # make sure that deserialization of literal fields did not produce over-verbose metadata
+        for p_input in desc["process"]["inputs"]:
+            assert len(set(p_input) - KNOWN_PROCESS_DESCRIPTION_INPUT_DATA_FIELDS) == 0
+        for p_output in desc["process"]["outputs"]:
+            assert len(set(p_output) - KNOWN_PROCESS_DESCRIPTION_OUTPUT_DATA_FIELDS) == 0
 
     def test_literal_io_from_package_and_offering(self):
         """

--- a/weaver/wps_restapi/colander_extras.py
+++ b/weaver/wps_restapi/colander_extras.py
@@ -1422,7 +1422,9 @@ class NotKeywordSchema(KeywordMapper):
     """
     Allows specifying specific schema conditions that fails underlying schema definition validation if present.
 
-    This is equivalent to OpenAPI object mapping with ``additionalProperties: false``, but is more explicit in
+    Corresponds to the ``not`` specifier of `OpenAPI` specification.
+
+    This is equivalent to `OpenAPI` object mapping with ``additionalProperties: false``, but is more explicit in
     the definition of invalid or conflicting field names with explicit definitions during deserialization.
 
     Example::
@@ -1436,8 +1438,20 @@ class NotKeywordSchema(KeywordMapper):
         class MappingWithoutType(NotKeywordSchema, RequiredItem):
             _not = [MappingWithType()]
 
+        class MappingOnlyNotType(NotKeywordSchema):
+            _not = [MappingWithType()]
+
         # following will raise invalid error even if 'item' is valid because 'type' is also present
         MappingWithoutType().deserialize({"type": "invalid", "item": "valid"})
+
+        # following will return successfully with only 'item' because 'type' was not present
+        MappingWithoutType().deserialize({"item": "valid", "value": "ignore"})
+        # result: {"item": "valid"}
+
+        # following will return an empty mapping dropping 'item' since it only needs to ensure 'type' was not present,
+        # but did not provide any additional fields requirement from other class inheritances
+        MappingOnlyNotType().deserialize({"item": "valid"})
+        # result: {}
 
     .. seealso::
         - :class:`OneOfKeywordSchema`
@@ -1457,7 +1471,7 @@ class NotKeywordSchema(KeywordMapper):
 
     def _deserialize_keyword(self, cstruct):
         """
-        Test each possible case, raise if any corresponding schema was successfully validated.
+        Raise if any sub-node schema that should NOT be present was successfully validated.
         """
         invalid_not = dict()
         for schema_class in self._not:  # noqa
@@ -1473,7 +1487,10 @@ class NotKeywordSchema(KeywordMapper):
         if invalid_not:
             message = "Value contains not allowed fields from schema conditions: {}".format(invalid_not)
             raise colander.Invalid(node=self, msg=message, value=cstruct)
-        return cstruct
+        # If schema was a plain NotKeywordSchema, the result will be empty as it serves only to validate
+        # that the subnodes are not present. Otherwise, if it derives from other mapping classes, apply them.
+        # If deserialization was not applied here, everything in the original cstruct would bubble up.
+        return ExtendedMappingSchema.deserialize(self, cstruct)
 
 
 class KeywordTypeConverter(TypeConverter):

--- a/weaver/wps_restapi/swagger_definitions.py
+++ b/weaver/wps_restapi/swagger_definitions.py
@@ -768,8 +768,8 @@ class InputTypeDefinition(OneOfKeywordSchema):
     ]
 
 
-class InputType(AnyOfKeywordSchema):
-    _any_of = [
+class InputType(AllOfKeywordSchema):
+    _all_of = [
         InputDescriptionType(),
         InputTypeDefinition(),
         WithMinMaxOccurs(),

--- a/weaver/wps_restapi/swagger_definitions.py
+++ b/weaver/wps_restapi/swagger_definitions.py
@@ -803,8 +803,8 @@ class OutputTypeDefinition(OneOfKeywordSchema):
     ]
 
 
-class OutputType(AnyOfKeywordSchema):
-    _any_of = [
+class OutputType(AllOfKeywordSchema):
+    _all_of = [
         OutputTypeDefinition(),
         OutputDescriptionType(),
     ]


### PR DESCRIPTION
fix invalid Not keyword resolution for `LiteralInputType` which resulted into too verbose process description inputs

The missing deserialization of the resulting mapping following OpenAPI `not` keyword validation resulted into all fields under a literal input type to bubble up in the process description. For example, fields like `data_format`, `mode`, `mimetype`, `workdir`, etc. that come from the pywps/owslib/cwl object json conversion would be returned.
