### PR TITLE
pin astroid<2.5.8 that triggers pylint false positives 

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@
 -r requirements-docs.txt
 # pylint>=2.5 requires astroid>=2.4
 # install/update sometime fails randomly, so enforce it
-astroid>=2.4
+astroid>=2.4,<2.5.8
 bandit
 bump2version
 codacy-coverage


### PR DESCRIPTION
relates to https://github.com/PyCQA/astroid/issues/1017

errors raised by false positives: 
https://github.com/crim-ca/weaver/runs/2776250383?check_suite_focus=true#step:8:295