### PR TITLE
fix missing jobControlOptions in pre-deployed processes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ Changes:
 
 Fixes:
 ------
-- No change.
+- Fix backward compatibility of pre-deployed processes that did not define ``jobControlOptions`` that is now required.
+  Missing definition are substituted in-place by default ``["execute-async"]`` mode.
 
 `3.2.0 <https://github.com/crim-ca/weaver/tree/3.2.0>`_ (2021-06-08)
 ========================================================================

--- a/tests/test_datatype.py
+++ b/tests/test_datatype.py
@@ -54,8 +54,8 @@ def test_process_job_control_options_resolution():
     ]:
         assert test_process.jobControlOptions == [EXECUTE_CONTROL_OPTION_ASYNC]
     # other valid definitions should be preserved as is
-    p = Process(id="test-{}".format(uuid.uuid4()), package={}, jobControlOptions=[EXECUTE_CONTROL_OPTION_SYNC])
-    assert p.jobControlOptions == [EXECUTE_CONTROL_OPTION_SYNC]
-    p = Process(id="test-{}".format(uuid.uuid4()), package={}, jobControlOptions=[EXECUTE_CONTROL_OPTION_SYNC,
-                                                                                  EXECUTE_CONTROL_OPTION_ASYNC])
-    assert p.jobControlOptions == [EXECUTE_CONTROL_OPTION_SYNC, EXECUTE_CONTROL_OPTION_ASYNC]
+    proc = Process(id="test-{}".format(uuid.uuid4()), package={}, jobControlOptions=[EXECUTE_CONTROL_OPTION_SYNC])
+    assert proc.jobControlOptions == [EXECUTE_CONTROL_OPTION_SYNC]
+    proc = Process(id="test-{}".format(uuid.uuid4()), package={}, jobControlOptions=[EXECUTE_CONTROL_OPTION_SYNC,
+                                                                                     EXECUTE_CONTROL_OPTION_ASYNC])
+    assert proc.jobControlOptions == [EXECUTE_CONTROL_OPTION_SYNC, EXECUTE_CONTROL_OPTION_ASYNC]

--- a/tests/test_datatype.py
+++ b/tests/test_datatype.py
@@ -1,6 +1,8 @@
+import uuid
 from copy import deepcopy
 
 from weaver.datatype import Process
+from weaver.execute import EXECUTE_CONTROL_OPTION_ASYNC, EXECUTE_CONTROL_OPTION_SYNC
 
 
 def test_package_encode_decode():
@@ -40,3 +42,20 @@ def test_package_encode_decode():
     assert "$namespace" not in process_package_encoded["executionUnits"][0]["unit"]
     assert _replace_specials("$namespace") in process_package_encoded["executionUnits"][0]["unit"]
     assert package == process.package, "package obtained from the process method should be the original decoded version"
+
+
+def test_process_job_control_options_resolution():
+    # invalid or matching default mode should be corrected to default async list
+    for test_process in [
+        Process(id="test-{}".format(uuid.uuid4()), package={}, jobControlOptions=None),
+        Process(id="test-{}".format(uuid.uuid4()), package={}, jobControlOptions=[None]),
+        Process(id="test-{}".format(uuid.uuid4()), package={}, jobControlOptions=[]),
+        Process(id="test-{}".format(uuid.uuid4()), package={}, jobControlOptions=[EXECUTE_CONTROL_OPTION_ASYNC]),
+    ]:
+        assert test_process.jobControlOptions == [EXECUTE_CONTROL_OPTION_ASYNC]
+    # other valid definitions should be preserved as is
+    p = Process(id="test-{}".format(uuid.uuid4()), package={}, jobControlOptions=[EXECUTE_CONTROL_OPTION_SYNC])
+    assert p.jobControlOptions == [EXECUTE_CONTROL_OPTION_SYNC]
+    p = Process(id="test-{}".format(uuid.uuid4()), package={}, jobControlOptions=[EXECUTE_CONTROL_OPTION_SYNC,
+                                                                                  EXECUTE_CONTROL_OPTION_ASYNC])
+    assert p.jobControlOptions == [EXECUTE_CONTROL_OPTION_SYNC, EXECUTE_CONTROL_OPTION_ASYNC]

--- a/tests/wps_restapi/test_processes.py
+++ b/tests/wps_restapi/test_processes.py
@@ -215,7 +215,7 @@ class WpsRestApiProcessesTest(unittest.TestCase):
 
         # change value that will trigger schema error on check
         process = self.process_store.fetch_by_id(process_name)
-        process["jobControlOptions"] = "random"  # invalid
+        process["outputTransmission"] = "random"  # invalid (don't use jobControlOptions fixed in-place)
         process["visibility"] = VISIBILITY_PUBLIC
         self.process_store.save_process(process, overwrite=True)
 

--- a/weaver/datatype.py
+++ b/weaver/datatype.py
@@ -15,7 +15,7 @@ from owslib.wps import Process as ProcessOWS, WPSException
 from pywps import Process as ProcessWPS
 
 from weaver.exceptions import ProcessInstanceError
-from weaver.execute import EXECUTE_CONTROL_OPTION_ASYNC
+from weaver.execute import EXECUTE_CONTROL_OPTION_ASYNC, EXECUTE_CONTROL_OPTIONS
 from weaver.formats import ACCEPT_LANGUAGE_EN_US, CONTENT_TYPE_APP_JSON
 from weaver.processes.convert import ows2json, wps2json_io
 from weaver.processes.types import (
@@ -832,6 +832,9 @@ class Process(Base):
     def jobControlOptions(self):  # noqa: N802
         # type: () -> List[str]
         self.setdefault("jobControlOptions", [EXECUTE_CONTROL_OPTION_ASYNC])
+        if not isinstance(self["jobControlOptions"], list):  # eg: None, bw-compat
+            self["jobControlOptions"] = [EXECUTE_CONTROL_OPTION_ASYNC]
+        self["jobControlOptions"] = [mode for mode in self["jobControlOptions"] if mode in EXECUTE_CONTROL_OPTIONS]
         if len(self["jobControlOptions"]) == 0:
             self["jobControlOptions"].append(EXECUTE_CONTROL_OPTION_ASYNC)
         return self.get("jobControlOptions")


### PR DESCRIPTION
support pre-deployed processes that did not provide jobControlOptions by providing the default value `["async-execute"]`