### PR TITLE
Fixed cwl running environment to prevent dysfunctions for next cwl patch

### DIFF
--- a/tests/functional/test_wps_package.py
+++ b/tests/functional/test_wps_package.py
@@ -37,10 +37,7 @@ from weaver.formats import (
     IANA_NAMESPACE,
     get_cwl_file_format
 )
-from weaver.processes.constants import (
-    CWL_REQUIREMENT_APP_DOCKER,
-    CWL_REQUIREMENT_INIT_WORKDIR
-)
+from weaver.processes.constants import CWL_REQUIREMENT_APP_DOCKER, CWL_REQUIREMENT_INIT_WORKDIR
 from weaver.utils import get_any_value
 
 EDAM_PLAIN = EDAM_NAMESPACE + ":" + EDAM_MAPPING[CONTENT_TYPE_TEXT_PLAIN]

--- a/tests/functional/test_wps_package.py
+++ b/tests/functional/test_wps_package.py
@@ -1393,10 +1393,6 @@ class WpsPackageAppWithS3BucketTest(WpsPackageConfigBase):
                     ]
                 }
             },
-            "hints": {CWL_REQUIREMENT_APP_BUILTIN: {
-                # ensure remote files are downloaded prior to CWL execution
-                "process": self._testMethodName,
-            }},
             "inputs": [
                 # regardless of reference type, they must be fetched as file before CWL call
                 {"id": "input_with_http", "type": "File"},

--- a/tests/functional/test_wps_package.py
+++ b/tests/functional/test_wps_package.py
@@ -37,7 +37,11 @@ from weaver.formats import (
     IANA_NAMESPACE,
     get_cwl_file_format
 )
-from weaver.processes.constants import CWL_REQUIREMENT_APP_BUILTIN, CWL_REQUIREMENT_INIT_WORKDIR
+from weaver.processes.constants import (
+    CWL_REQUIREMENT_APP_BUILTIN,
+    CWL_REQUIREMENT_APP_DOCKER,
+    CWL_REQUIREMENT_INIT_WORKDIR
+)
 from weaver.utils import get_any_value
 
 EDAM_PLAIN = EDAM_NAMESPACE + ":" + EDAM_MAPPING[CONTENT_TYPE_TEXT_PLAIN]
@@ -1378,6 +1382,9 @@ class WpsPackageAppWithS3BucketTest(WpsPackageConfigBase):
             "baseCommand": "echo",
             "arguments": ["$(runtime.outdir)"],
             "requirements": {
+                CWL_REQUIREMENT_APP_DOCKER: {
+                    "dockerPull": "alpine:latest"
+                },
                 CWL_REQUIREMENT_INIT_WORKDIR: {
                     # directly copy files to output dir in order to retrieve them by glob
                     "listing": [

--- a/tests/functional/test_wps_package.py
+++ b/tests/functional/test_wps_package.py
@@ -38,7 +38,6 @@ from weaver.formats import (
     get_cwl_file_format
 )
 from weaver.processes.constants import (
-    CWL_REQUIREMENT_APP_BUILTIN,
     CWL_REQUIREMENT_APP_DOCKER,
     CWL_REQUIREMENT_INIT_WORKDIR
 )

--- a/tests/json_examples/opensearch_deploy.cwl
+++ b/tests/json_examples/opensearch_deploy.cwl
@@ -14,6 +14,11 @@
         }
       }
     },
+    "requirements":{
+      "DockerRequirement": {
+        "dockerPull": "alpine:latest"
+      }
+    },
     "outputs": {
       "output": {
         "type": "File"

--- a/tests/json_examples/opensearch_deploy.json
+++ b/tests/json_examples/opensearch_deploy.json
@@ -100,6 +100,11 @@
             }
           }
         },
+        "requirements":{
+          "DockerRequirement": {
+            "dockerPull": "alpine:latest"
+          }
+        },
         "outputs": {
           "output": {
             "outputBinding": {

--- a/tests/test_opensearch.py
+++ b/tests/test_opensearch.py
@@ -16,11 +16,7 @@ from pywps.inout.inputs import LiteralInput
 from tests.utils import setup_mongodb_processstore
 from weaver.datatype import Process
 from weaver.processes import opensearch
-from weaver.processes.constants import (
-    OPENSEARCH_AOI,
-    OPENSEARCH_END_DATE,
-    OPENSEARCH_START_DATE
-)
+from weaver.processes.constants import OPENSEARCH_AOI, OPENSEARCH_END_DATE, OPENSEARCH_START_DATE
 from weaver.processes.opensearch import _make_specific_identifier  # noqa: W0212
 from weaver.utils import get_any_id
 from weaver.wps_restapi.processes import processes

--- a/tests/test_opensearch.py
+++ b/tests/test_opensearch.py
@@ -96,7 +96,7 @@ def get_dummy_payload():
 
 def get_opensearch_payload():
     payload = load_json_test_file("opensearch_deploy.json")
-    payload["execution_unit"]["unit"]["requirements"] = {
+    payload["executionUnit"][0]["unit"]["requirements"] = {
         CWL_REQUIREMENT_APP_DOCKER: {
             "dockerPull": "alpine:latest"
         }

--- a/tests/test_opensearch.py
+++ b/tests/test_opensearch.py
@@ -17,7 +17,6 @@ from tests.utils import setup_mongodb_processstore
 from weaver.datatype import Process
 from weaver.processes import opensearch
 from weaver.processes.constants import (
-    CWL_REQUIREMENT_APP_DOCKER,
     OPENSEARCH_AOI,
     OPENSEARCH_END_DATE,
     OPENSEARCH_START_DATE
@@ -95,13 +94,7 @@ def get_dummy_payload():
 
 
 def get_opensearch_payload():
-    payload = load_json_test_file("opensearch_deploy.json")
-    payload["executionUnit"][0]["unit"]["requirements"] = {
-        CWL_REQUIREMENT_APP_DOCKER: {
-            "dockerPull": "alpine:latest"
-        }
-    }
-    return payload
+    return load_json_test_file("opensearch_deploy.json")
 
 
 def test_transform_execute_parameters_wps():

--- a/tests/test_opensearch.py
+++ b/tests/test_opensearch.py
@@ -16,7 +16,12 @@ from pywps.inout.inputs import LiteralInput
 from tests.utils import setup_mongodb_processstore
 from weaver.datatype import Process
 from weaver.processes import opensearch
-from weaver.processes.constants import OPENSEARCH_AOI, OPENSEARCH_END_DATE, OPENSEARCH_START_DATE
+from weaver.processes.constants import (
+    CWL_REQUIREMENT_APP_DOCKER,
+    OPENSEARCH_AOI,
+    OPENSEARCH_END_DATE,
+    OPENSEARCH_START_DATE
+)
 from weaver.processes.opensearch import _make_specific_identifier  # noqa: W0212
 from weaver.utils import get_any_id
 from weaver.wps_restapi.processes import processes
@@ -90,11 +95,13 @@ def get_dummy_payload():
 
 
 def get_opensearch_payload():
-    return load_json_test_file("opensearch_deploy.json")
-
-
-def get_opensearch_process():
-    return Process(load_json_test_file("opensearch_process.json"))
+    payload = load_json_test_file("opensearch_deploy.json")
+    payload["execution_unit"]["unit"]["requirements"] = {
+        CWL_REQUIREMENT_APP_DOCKER: {
+            "dockerPull": "alpine:latest"
+        }
+    }
+    return payload
 
 
 def test_transform_execute_parameters_wps():


### PR DESCRIPTION
Update the `cwl` payloads that are running directly in `weaver`, to avoid any dysfunction when the security [issue](https://www.crim.ca/jira/browse/DAC-437) will be fixed.