### PR TITLE
Execute request with inline values and arrays under mapping (fixes #265)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,9 @@ testdata.json
 .pydevproject
 .settings
 
+## VS Code
+*.vscode
+
 ## PyCharm
 *.idea
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,8 +27,6 @@ Changes:
 - Remove automatic conversion of falsy/truthy ``string`` and ``integer`` type definitions to ``boolean`` type
   to align with OpenAPI ``boolean`` type definitions. Non explicit ``boolean`` values will not be automatically
   converted to ``bool`` anymore. They will require explicit ``false|true`` values.
-- Add support for inputs under mapping for inline values and arrays in process execution
-  (relates to `#265 <https://github.com/crim-ca/weaver/issues/265>`_).
 
 Fixes:
 ------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,8 @@ Changes
 
 Changes:
 --------
-- No change.
+- Add support for inputs under mapping for inline values and arrays in process execution
+  (relates to `#265 <https://github.com/crim-ca/weaver/issues/265>`_).
 
 Fixes:
 ------
@@ -26,8 +27,6 @@ Changes:
 - Remove automatic conversion of falsy/truthy ``string`` and ``integer`` type definitions to ``boolean`` type
   to align with OpenAPI ``boolean`` type definitions. Non explicit ``boolean`` values will not be automatically
   converted to ``bool`` anymore. They will require explicit ``false|true`` values.
-- Add support for inputs under mapping for inline values and arrays in process execution
-  (relates to `#265 <https://github.com/crim-ca/weaver/issues/265>`_).
 
 Fixes:
 ------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,8 @@ Changes:
 - Remove automatic conversion of falsy/truthy ``string`` and ``integer`` type definitions to ``boolean`` type
   to align with OpenAPI ``boolean`` type definitions. Non explicit ``boolean`` values will not be automatically
   converted to ``bool`` anymore. They will require explicit ``false|true`` values.
+- Add support for inputs under mapping for inline values and arrays in process execution
+  (relates to `#265 <https://github.com/crim-ca/weaver/issues/265>`_).
 
 Fixes:
 ------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,8 @@ Changes:
 - Remove automatic conversion of falsy/truthy ``string`` and ``integer`` type definitions to ``boolean`` type
   to align with OpenAPI ``boolean`` type definitions. Non explicit ``boolean`` values will not be automatically
   converted to ``bool`` anymore. They will require explicit ``false|true`` values.
+- Add support for inputs under mapping for inline values and arrays in process execution
+  (relates to `#265 <https://github.com/crim-ca/weaver/issues/265>`_).
 
 Fixes:
 ------

--- a/tests/functional/test_wps_package.py
+++ b/tests/functional/test_wps_package.py
@@ -1171,7 +1171,8 @@ class WpsPackageAppTest(WpsPackageConfigBase):
             self.fail("Test")
 
         assert desc["process"] is not None
-        json.dump({"value": {"ref": 1, "measurement": 10.3, "uom": "m"}}, open("/tmp/input_tmp.txt", "w"))
+        with open("/tmp/input_tmp.txt", "w") as f:
+            json.dump({"value": {"ref": 1, "measurement": 10.3, "uom": "m"}}, f)
 
         exec_body = {
             "mode": EXECUTE_MODE_ASYNC,
@@ -1216,7 +1217,8 @@ class WpsPackageAppTest(WpsPackageConfigBase):
         tmpfile = "{}/{}".format(self.settings["weaver.wps_output_dir"], job_output_file)
 
         try:
-            processed_values = json.load(open(tmpfile, "r"))
+            with open(tmpfile, "r") as f:
+                processed_values = json.load(f)
         except FileNotFoundError:
             self.fail("Output file [{}] was not found where it was expected to resume test".format(tmpfile))
         except Exception as exception:

--- a/weaver/processes/execution.py
+++ b/weaver/processes/execution.py
@@ -111,9 +111,15 @@ def execute_process(self, job_id, url, headers=None):
 
         try:
             wps_inputs = list()
-            for process_input in job.inputs:
-                input_id = get_any_id(process_input)
-                process_value = get_any_value(process_input)
+            # parse both dict and list type inputs
+            job_inputs = job.inputs.items() if isinstance(job.inputs, dict) else job.inputs
+            for process_input in job_inputs:
+                if isinstance(process_input, tuple):
+                    input_id = process_input[0]
+                    process_value = process_input[1]
+                else:
+                    input_id = get_any_id(process_input)
+                    process_value = get_any_value(process_input)
                 # in case of array inputs, must repeat (id,value)
                 input_values = process_value if isinstance(process_value, list) else [process_value]
 

--- a/weaver/processes/execution.py
+++ b/weaver/processes/execution.py
@@ -112,7 +112,7 @@ def execute_process(self, job_id, url, headers=None):
         try:
             wps_inputs = list()
             # parse both dict and list type inputs
-            job_inputs = job.inputs.items() if isinstance(job.inputs, dict) else job.inputs
+            job_inputs = job.inputs.items() if isinstance(job.inputs, dict) else job.get("inputs", [])
             for process_input in job_inputs:
                 if isinstance(process_input, tuple):
                     input_id = process_input[0]

--- a/weaver/wps_restapi/swagger_definitions.py
+++ b/weaver/wps_restapi/swagger_definitions.py
@@ -2177,7 +2177,7 @@ class ExecuteInputMap(PermissiveMappingSchema):
 
 
 class ExecuteInputList(ExtendedSequenceSchema):
-    input = Input(missing=drop, description="Received list input definition during job submission.")
+    input_item = Input(missing=drop, description="Received list input definition during job submission.")
 
 
 class ExecuteInputsDefinition(OneOfKeywordSchema):

--- a/weaver/wps_restapi/swagger_definitions.py
+++ b/weaver/wps_restapi/swagger_definitions.py
@@ -2190,7 +2190,7 @@ class ExecuteInputsDefinition(OneOfKeywordSchema):
 class Execute(ExtendedMappingSchema):
     # permit unspecified inputs for processes that could technically allow no-inputs definition (CWL),
     # but very unlikely/unusual in real world scenarios (possible case: constant endpoint fetcher?)
-    inputs = ExecuteInputsDefinition()
+    inputs = ExecuteInputsDefinition(missing=drop)
     outputs = OutputList()
     mode = JobExecuteModeEnum()
     notification_email = ExtendedSchemaNode(


### PR DESCRIPTION
Execute request with inline values and arrays under mapping according to [OGC-API](https://github.com/opengeospatial/ogcapi-processes/blob/master/core/openapi/schemas/execute.yaml)