### PR TITLE
Add missing processID and providerID details in job status info response

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,8 @@ Changes
 
 Changes:
 --------
-- No change.
+- Add missing processID detail in job status info response 
+  (relates to `#270 <https://github.com/crim-ca/weaver/issues/270>`_).
 
 Fixes:
 ------
@@ -26,8 +27,6 @@ Changes:
 - Remove automatic conversion of falsy/truthy ``string`` and ``integer`` type definitions to ``boolean`` type
   to align with OpenAPI ``boolean`` type definitions. Non explicit ``boolean`` values will not be automatically
   converted to ``bool`` anymore. They will require explicit ``false|true`` values.
-- Add missing processID detail in job status info response 
-  (relates to `#270 <https://github.com/crim-ca/weaver/issues/270>`_).
 
 Fixes:
 ------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,8 @@ Changes:
 - Remove automatic conversion of falsy/truthy ``string`` and ``integer`` type definitions to ``boolean`` type
   to align with OpenAPI ``boolean`` type definitions. Non explicit ``boolean`` values will not be automatically
   converted to ``bool`` anymore. They will require explicit ``false|true`` values.
+- Add missing processID detail in job status info response 
+  (relates to `#270 <https://github.com/crim-ca/weaver/issues/270>`_).
 
 Fixes:
 ------

--- a/tests/functional/test_wps_package.py
+++ b/tests/functional/test_wps_package.py
@@ -41,7 +41,6 @@ from weaver.formats import (
     IANA_NAMESPACE,
     get_cwl_file_format
 )
-
 from weaver.processes.constants import CWL_REQUIREMENT_APP_DOCKER, CWL_REQUIREMENT_INIT_WORKDIR
 from weaver.utils import get_any_value
 

--- a/tests/wps_restapi/test_jobs.py
+++ b/tests/wps_restapi/test_jobs.py
@@ -682,3 +682,20 @@ class WpsRestApiJobsTest(unittest.TestCase):
         path = get_path_kvp(sd.jobs_service.path, datetime=datetime_before)
         resp = self.app.get(path, headers=self.json_headers, expect_errors=True)
         assert resp.status_code == 422
+
+    def test_job_status_response(self):
+        """ Verify the processID value in the job status response """
+        body = {
+            "outputs": [],
+            "mode": EXECUTE_MODE_ASYNC,
+            "response": EXECUTE_RESPONSE_DOCUMENT,
+        }
+        with contextlib.ExitStack() as stack:
+            for runner in mocked_process_job_runner():
+                stack.enter_context(runner)
+            path = "/processes/{}/jobs".format(self.process_public.identifier)
+            resp = self.app.post_json(path, params=body, headers=self.json_headers)
+            assert resp.status_code == 201
+            assert resp.content_type == CONTENT_TYPE_APP_JSON
+
+        assert resp.json["processID"] == "process-public"

--- a/tests/wps_restapi/test_jobs.py
+++ b/tests/wps_restapi/test_jobs.py
@@ -684,7 +684,7 @@ class WpsRestApiJobsTest(unittest.TestCase):
         assert resp.status_code == 422
 
     def test_job_status_response(self):
-        """ Verify the processID value in the job status response """
+        """Verify the processID value in the job status response"""
         body = {
             "outputs": [],
             "mode": EXECUTE_MODE_ASYNC,

--- a/weaver/processes/execution.py
+++ b/weaver/processes/execution.py
@@ -434,5 +434,5 @@ def submit_job_handler(payload,             # type: JSON
         "status": map_status(STATUS_ACCEPTED),
         "location": location
     }
-    body_data = body_data.update({"providerId": provider_id}) if provider_id else body_data
+    body_data = body_data.update({"providerID": provider_id}) if provider_id else body_data
     return body_data

--- a/weaver/processes/execution.py
+++ b/weaver/processes/execution.py
@@ -430,7 +430,9 @@ def submit_job_handler(payload,             # type: JSON
         job_id=job.id)
     body_data = {
         "jobID": job.id,
+        "processID": job.process,
         "status": map_status(STATUS_ACCEPTED),
         "location": location
     }
+    body_data = body_data.update({"providerId": provider_id}) if provider_id else body_data
     return body_data


### PR DESCRIPTION
Add missing processID and providerID details in job status info response as per opengeospatial/ogcapi-processes#234 (fixes #270)