### PR TITLE
fix get_wps_client headers copy - serialize error

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,14 +14,14 @@ Changes:
 
 Fixes:
 ------
-- No change.
+- Fix copy of headers when generating the WPS clients created for listing providers capabilities and processes.
 
 `3.4.0 <https://github.com/crim-ca/weaver/tree/3.4.0>`_ (2021-08-11)
 ========================================================================
 
 Changes:
 --------
-- Add missing processID detail in job status info response 
+- Add missing processID detail in job status info response
   (relates to `#270 <https://github.com/crim-ca/weaver/issues/270>`_).
 - Add support for inputs under mapping for inline values and arrays in process execution
   (relates to `#265 <https://github.com/crim-ca/weaver/issues/265>`_).

--- a/weaver/wps/utils.py
+++ b/weaver/wps/utils.py
@@ -182,7 +182,9 @@ def get_wps_client(url, container=None, verify=None, headers=None, language=None
         headers = headers or {}
     # remove invalid values that should be recomputed by the client as needed
     # employ the provided headers instead of making new ones in order to forward any language/authorization definition
-    headers = deepcopy(headers)  # don't modify original headers for sub-requests for next steps that could use them
+    # copy to avoid modify original headers for sub-requests for next steps that could use them
+    # employ dict() rather than deepcopy since headers that can be an instance of EnvironHeaders cannot be serialized
+    headers = dict(headers)
     for header in ["Accept", "Content-Length", "Content-Type", "Content-Transfer-Encoding"]:
         hdr_low = header.lower()
         for hdr in [header, hdr_low, header.replace("-", "_"), hdr_low.replace("-", "_")]:

--- a/weaver/wps/utils.py
+++ b/weaver/wps/utils.py
@@ -2,7 +2,6 @@ import logging
 import os
 import tempfile
 from configparser import ConfigParser
-from copy import deepcopy
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 


### PR DESCRIPTION
## Changes

Replace explicit `deepcopy()` call by basic `dict()` copy from conversion of input headers in `get_wps_client` has `EnvironHeaders` instance raises serialize error with TextIO field with `deepcopy()`. 