### PR TITLE
avoid DuplicateKeyError during initial builtin process registration

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,11 @@ Fixes:
 - Fix copy of headers when generating the WPS clients created for listing providers capabilities and processes.
 - Fix ``weaver.datatype`` objects auto-resolution of fields using either attributes (accessed as ``dict``)
   or properties (accessed as ``class``) to ensure correct handling of additional operations on them.
+- Fix ``DuplicateKeyError`` that could sporadically arise during initial ``processes`` storage creation
+  when ``builtin`` processes get inserted/updated on launch by parallel worker/threads running the application.
+  Operation is relaxed only for default ``builtin`` to allow equivalent process replacement (``upsert``) instead
+  of only explicit inserts, as they should be pre-validated for duplicate entries, and only new definitions should
+  be registered during this operation (fixes `#246 <https://github.com/crim-ca/weaver/issues/246>`_).
 
 `3.4.0 <https://github.com/crim-ca/weaver/tree/3.4.0>`_ (2021-08-11)
 ========================================================================

--- a/weaver/store/mongodb.py
+++ b/weaver/store/mongodb.py
@@ -255,13 +255,15 @@ class MongodbProcessStore(StoreProcesses, MongodbStore):
                 result = self.collection.replace_one(search, new_process.params(), upsert=True)
                 if result.matched_count != 0 and result.modified_count != 0:
                     LOGGER.warning(
-                        "Duplicate key in collection: {} index: {} ".format(self.collection.full_name, search) +
-                        "was detected during replace with upsert, but permitted for process without modification."
+                        "Duplicate key in collection: %s index: %s "
+                        "was detected during replace with upsert, but permitted for process without modification.",
+                        self.collection.full_name, search
                     )
             except DuplicateKeyError:
                 LOGGER.warning(
-                    "Duplicate key in collection: {} index: {} ".format(self.collection.full_name, search) +
-                    "was detected during internal insert retry, but ignored for process without modification."
+                    "Duplicate key in collection: %s index: %s "
+                    "was detected during internal insert retry, but ignored for process without modification.",
+                    self.collection.full_name, search
                 )
         else:
             self.collection.insert_one(new_process.params())


### PR DESCRIPTION
## Changes

add upsert/replace operation instead of insert during builtin process initial registration

Fixes #246