### PR TITLE
weaver-worker task events

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ Changes:
 
 Fixes:
 ------
-- No change.
+- Add ``celery worker`` task events flag (``-E``) to Docker command (``weaver-worker``) to help detect submitted
+  delayed tasks when requesting job executions.
 
 `4.1.1 <https://github.com/crim-ca/weaver/tree/4.1.1>`_ (2021-10-12)
 ========================================================================

--- a/docker/Dockerfile-worker
+++ b/docker/Dockerfile-worker
@@ -18,4 +18,4 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/*
 
 # run app
-CMD celery worker -A pyramid_celery.celery_app --ini "${APP_CONFIG_DIR}/weaver.ini"
+CMD celery worker -E -A pyramid_celery.celery_app --ini "${APP_CONFIG_DIR}/weaver.ini"


### PR DESCRIPTION
Add tasks event flag to celery worker in docker weaver-worker to better detect jobs to execute. 
When events are not active, celery seems to have trouble picking up jobs in the birdhouse-deploy stack.