### PR TITLE
Job output context + Job execution improvements

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,7 @@ Changes:
 - Support contextual WPS output location using ``X-WPS-Output-Context`` header to store ``Job`` results.
   When a ``Job`` is executed by providing this header with a sub-directory, the resulting outputs of the ``Job``
   will be placed and reported under the corresponding location relative to WPS outputs (path and URL).
+- Add ``weaver.wps_output_context`` setting as default contextual WPS output location when header is omitted.
 - Replace ``Job.execute_async`` getter/setter by simple property using more generic ``Job.execution_mode``
   for storage in database. Provide ``Job.execute_async`` and ``Job.execute_sync`` properties based on stored mode.
 - Simplify ``execute_process`` function executed by `Celery` task into sub-step functions where applicable.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,11 +10,17 @@ Changes
 
 Changes:
 --------
+- Support contextual WPS output location using ``X-WPS-Output-Context`` header to store ``Job`` results.
+  When a ``Job`` is executed by providing this header with a sub-directory, the resulting outputs of the ``Job``
+  will be placed and reported under the corresponding location relative to WPS outputs (path and URL).
 - Replace ``Job.execute_async`` getter/setter by simple property using more generic ``Job.execution_mode``
   for storage in database. Provide ``Job.execute_async`` and ``Job.execute_sync`` properties based on stored mode.
 - Simplify ``execute_process`` function executed by `Celery` task into sub-step functions where applicable.
 - Simplify forwarding of ``Job`` parameters between ``PyWPS`` service ``WorkerService.execute_job`` method
   and `Celery` task instantiating it by reusing the ``Job`` object.
+- Provide corresponding ``Job`` log URL along already reported log file path to facilitate retrieval from server side.
+- Avoid ``Job.progress`` updates following ``failed`` or ``dismissed`` statuses to keep track of the last real progress
+  percentage that was reached when that status was set.
 
 Fixes:
 ------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,7 +24,8 @@ Changes:
 
 Fixes:
 ------
-- No change.
+- Removes the need for specific configuration to handle public/private output directory settings using
+  provided ``X-WPS-Output-Context`` header (fixes `#110 <https://github.com/crim-ca/weaver/issues/110>`_).
 
 `4.2.1 <https://github.com/crim-ca/weaver/tree/4.2.1>`_ (2021-10-20)
 ========================================================================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -67,7 +67,8 @@ Changes:
   Report explicit ``running`` status in ``Job`` once it has been sent to the remote `WPS` endpoint.
   The API will report ``running`` in both cases in order to support `OGC API - Processes` naming conventions, but
   internal ``Job`` status will have more detail.
-- Add ``update`` timestamp to ``Job`` response to better track latest milestones saved to database.
+- Add ``updated`` timestamp to ``Job`` response to better track latest milestones saved to database
+  (resolves `#249 <https://github.com/crim-ca/weaver/issues/249>`_).
   This avoids users having to compare many fields (``created``, ``started``, ``finished``) depending on latest status.
 - Apply stricter ``Deploy`` body schema validation and employ deserialized result directly.
   This ensures that preserved fields in the submitted content for deployment contain only known data elements with

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,11 @@ Changes
 
 Changes:
 --------
-- No change.
+- Replace ``Job.execute_async`` getter/setter by simple property using more generic ``Job.execution_mode``
+  for storage in database. Provide ``Job.execute_async`` and ``Job.execute_sync`` properties based on stored mode.
+- Simplify ``execute_process`` function executed by `Celery` task into sub-step functions where applicable.
+- Simplify forwarding of ``Job`` parameters between ``PyWPS`` service ``WorkerService.execute_job`` method
+  and `Celery` task instantiating it by reusing the ``Job`` object.
 
 Fixes:
 ------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,8 @@ Fixes:
 ------
 - Removes the need for specific configuration to handle public/private output directory settings using
   provided ``X-WPS-Output-Context`` header (fixes `#110 <https://github.com/crim-ca/weaver/issues/110>`_).
+- Fix retrieval of `Pyramid` ``Registry`` and application settings when available *container* is `Werkzeug` ``Request``
+  instead of `Pyramid` ``Request``, as employed by underlying HTTP requests in `PyWPS` service.
 
 `4.2.1 <https://github.com/crim-ca/weaver/tree/4.2.1>`_ (2021-10-20)
 ========================================================================

--- a/config/weaver.ini.example
+++ b/config/weaver.ini.example
@@ -80,6 +80,7 @@ weaver.wps = true
 weaver.wps_url =
 weaver.wps_path = /ows/wps
 weaver.wps_output = true
+weaver.wps_output_context =
 weaver.wps_output_dir = /tmp/weaver/wps-outputs
 weaver.wps_output_url =
 weaver.wps_output_path = /wpsoutputs

--- a/docs/source/appendix.rst
+++ b/docs/source/appendix.rst
@@ -128,6 +128,9 @@ Glossary
           refers to attributes that are specific to typical :term:`Process` description, in contrast to specialized
           attributes introduced by other concepts, such as for example :term:`CWL`-specific implementation details.
 
+    WPS-REST
+        Alias employed to refer to :term:`OGC API - Processes` endpoints for corresponding :term:`WPS` definitions.
+
     XML
         | Extensible Markup Language
         | Alternative representation of some data object provided by the application. Requires appropriate ``Accept``

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -11,6 +11,7 @@ Configuration
 
 After you have installed `Weaver`, you can customize its behaviour using multiple configuration settings.
 
+.. _conf_settings:
 
 Configuration Settings
 =======================================
@@ -126,17 +127,22 @@ they are optional and which default value or operation is applied in each situat
 - | ``weaver.wps_output_dir = <directory-path>``
   | (default: ``/tmp``)
   |
-  | Location where WPS outputs (results from jobs) will be stored for stage-out.
+  | Location where WPS outputs (results from :term:`Job`) will be stored for stage-out.
   |
-  | When ``weaver.wps_output_s3_bucket`` is specified, only WPS XML status and log files are stored under this path.
-    Otherwise, job results are also located under this directory with a sub-directory named with the job ID.
-  | This directory should be mapped to `Weaver`'s WPS output URL to serve them externally as needed.
+  | When ``weaver.wps_output_s3_bucket`` is specified, only :term:`WPS` :term:`XML` status and log files are stored
+    under this path. Otherwise, :term:`Job` results are also located under this directory with a sub-directory named
+    with the :term:`Job` ID.
+  | This directory should be mapped to `Weaver`'s :term:`WPS` output URL to serve them externally as needed.
+
+.. versionchanged:: 4.3.0
+    The output directory could be nested under a contextual directory if requested during :term:`Job` submission.
+    See :ref:`exec_output_location` for more details.
 
 - | ``weaver.wps_output_path = <url-path>``
   | ``weaver.wps_output_url = <full-url>``
   | (default: *path* ``/wpsoutputs``)
   |
-  | Endpoint that will be employed as prefix to refer to WPS outputs (job results).
+  | Endpoint that will be employed as prefix to refer to :term:`WPS` outputs (:term:`Job` results).
   |
   | It can either be the explicit *full URL* to use or the *path* relative to ``weaver.url``.
   | Setting ``weaver.wps_output_path`` is ignored if its URL equivalent is defined.
@@ -195,6 +201,7 @@ they are optional and which default value or operation is applied in each situat
 .. |celery-mongo| replace:: configuration of MongoDB Backend
 .. _celery-mongo: https://docs.celeryproject.org/en/latest/userguide/configuration.html#mongodb-backend-settings
 
+.. _conf_s3_buckets:
 
 Configuration of AWS S3 Buckets
 =======================================

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -125,7 +125,7 @@ they are optional and which default value or operation is applied in each situat
     `Configuration of AWS S3 Buckets`_
 
 - | ``weaver.wps_output_dir = <directory-path>``
-  | (default: ``/tmp``)
+  | (default: *path* ``/tmp``)
   |
   | Location where WPS outputs (results from :term:`Job`) will be stored for stage-out.
   |
@@ -135,8 +135,22 @@ they are optional and which default value or operation is applied in each situat
   | This directory should be mapped to `Weaver`'s :term:`WPS` output URL to serve them externally as needed.
 
 .. versionchanged:: 4.3.0
-    The output directory could be nested under a contextual directory if requested during :term:`Job` submission.
-    See :ref:`exec_output_location` for more details.
+    The output directory could be nested under a *contextual directory* if requested during :term:`Job` submission.
+    See :ref:`exec_output_location` and below ``weaver.wps_output_context`` parameter for more details.
+
+- | ``weaver.wps_output_context = <sub-directory-path>``
+  | (default: ``None``)
+  |
+  | Default sub-directory hierarchy location to nest :term:`WPS` outputs (:term:`Job` results) under.
+  |
+  | If defined, this parameter is used as substitute *context* when ``X-WPS-Output-Context`` header is omitted.
+    When not defined, ``X-WPS-Output-Context`` header can still take effect, but omitting it will store results
+    directly under ``weaver.wps_output_dir`` instead of default *context* location.
+
+.. versionadded:: 4.3.0
+
+.. seealso::
+    See :ref:`exec_output_location` for more details about this feature and implications of this setting.
 
 - | ``weaver.wps_output_path = <url-path>``
   | ``weaver.wps_output_url = <full-url>``
@@ -148,6 +162,12 @@ they are optional and which default value or operation is applied in each situat
   | Setting ``weaver.wps_output_path`` is ignored if its URL equivalent is defined.
   | The *path* variant **SHOULD** start with ``/`` for appropriate concatenation with ``weaver.url``, although this is
     not strictly enforced.
+
+.. note::
+    The resulting ``weaver.wps_output_url`` endpoint, whether directly provided or indirectly
+    resolved by ``weaver.url`` and ``weaver.wps_output_path`` will not be served by `Weaver` itself.
+    This location is returned for reference in API responses, but it is up to the infrastructure that
+    hosts `Weaver` service to make this location available online as deemed necessary.
 
 - | ``weaver.wps_workdir = <directory-path>``
   | (default: uses automatically generated temporary directory if none specified)

--- a/docs/source/processes.rst
+++ b/docs/source/processes.rst
@@ -799,10 +799,10 @@ avoid conflicts. Therefore, outputs will be available with the following locatio
     Value ``WPS_OUTPUT_URL`` in above example is resolved accordingly with ``weaver.wps_output_url``,
     ``weaver.wps_output_path`` and ``weaver.url``, as per :ref:`conf_settings` details.
 
-When submitting a :term:`Job` for execution, it is also possible to provide the ``X-WPS-Output-Context`` header.
+When submitting a :term:`Job` for execution, it is possible to provide the ``X-WPS-Output-Context`` header.
 This modifies the output location to be nested under the specified directory or sub-directories.
 
-For example, providing ``X-WPS-Output-Context: project/test-1`` will result in outputs located at
+For example, providing ``X-WPS-Output-Context: project/test-1`` will result in outputs located at:
 
 .. code-block::
 
@@ -815,8 +815,13 @@ For example, providing ``X-WPS-Output-Context: project/test-1`` will result in o
     The path also **CANNOT** start by ``/``. In such cases, an HTTP error will be immediately raised indicating
     the symbols that where rejected when detected within ``X-WPS-Output-Context`` header.
 
+If desired, parameter ``weaver.wps_output_context`` can also be defined in the :ref:`conf_settings` in order to employ
+a default directory location nested under ``weaver.wps_output_dir`` when ``X-WPS-Output-Context`` header is omitted
+from the request. By default, this parameter is not defined (empty) in order to store :term:`Job` results directly under
+the configured :ter:`WPS` output directory.
+
 .. note::
-    Header ``X-WPS-Output-Context`` is ignored when using `S3` buckets as output location since they are stored
+    Header ``X-WPS-Output-Context`` is ignored when using `S3` buckets for output location since they are stored
     individually per :term:`Job` UUID, and hold no relevant *context* location. See also :ref:`conf_s3_buckets`.
 
 .. versionadded:: 4.3.0

--- a/docs/source/processes.rst
+++ b/docs/source/processes.rst
@@ -809,10 +809,11 @@ For example, providing ``X-WPS-Output-Context: project/test-1`` will result in o
     {WPS_OUTPUT_URL}/project/test-1/{JOB_UUID}/{output.ext}
 
 .. note::
-    Values provided by ``X-WPS-Output-Context`` can only contain alphanumeric, hyphens, underscores and path separators
-    that will result in a valid directory and URL locations. The path is assumed relative to the resolved :term:`WPS`
-    output directory, and will therefore reject any ``.`` or ``..`` path references.
-    The path must also **NOT** start by ``/``.
+    Values provided by ``X-WPS-Output-Context`` can only contain alphanumeric, hyphens, underscores and path
+    separators that will result in a valid directory and URL locations. The path is assumed relative by design to be
+    resolved under the :term:`WPS` output directory, and will therefore reject any ``.`` or ``..`` path references.
+    The path also **CANNOT** start by ``/``. In such cases, an HTTP error will be immediately raised indicating
+    the symbols that where rejected when detected within ``X-WPS-Output-Context`` header.
 
 .. note::
     Header ``X-WPS-Output-Context`` is ignored when using `S3` buckets as output location since they are stored

--- a/docs/source/processes.rst
+++ b/docs/source/processes.rst
@@ -6,6 +6,10 @@
 Processes
 **********
 
+.. contents::
+    :local:
+    :depth: 3
+
 Type of Processes
 =====================
 
@@ -376,6 +380,10 @@ to better illustrate the requirements.
 
 Basic Details
 ~~~~~~~~~~~~~~~~~
+
+.. todo::
+    Support ``sync`` mode.
+    Relates to https://github.com/crim-ca/weaver/issues/247.
 
 The first field is ``mode``, it basically tells whether to run the :term:`Process` in a blocking (``sync``) or
 non-blocking (``async``) manner. Note that support is currently limited for mode ``sync`` as this use case is often more
@@ -770,13 +778,56 @@ described in |pywps-multi-output|_.
 .. seealso::
     - :ref:`Multiple and Optional Values`
 
+.. _exec_output_location:
+
+Outputs Location
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+By default, :term:`Job` results will be hosted under the endpoint configured by ``weaver.wps_output_url`` and
+``weaver.wps_output_path``, and will be stored under directory defined by ``weaver.wps_output_dir`` setting.
+
+Each :term:`Job` will have its specific UUID employed for all of the outputs files, logs and status in order to
+avoid conflicts. Therefore, outputs will be available with the following location:
+
+.. code-block::
+
+    {WPS_OUTPUT_URL}/{JOB_UUID}.xml             # status location
+    {WPS_OUTPUT_URL}/{JOB_UUID}.log             # execution logs
+    {WPS_OUTPUT_URL}/{JOB_UUID}/{output.ext}    # results of the job if successful
+
+.. note::
+    Value ``WPS_OUTPUT_URL`` in above example is resolved accordingly with ``weaver.wps_output_url``,
+    ``weaver.wps_output_path`` and ``weaver.url``, as per :ref:`conf_settings` details.
+
+When submitting a :term:`Job` for execution, it is also possible to provide the ``X-WPS-Output-Context`` header.
+This modifies the output location to be nested under the specified directory or sub-directories.
+
+For example, providing ``X-WPS-Output-Context: project/test-1`` will result in outputs located at
+
+.. code-block::
+
+    {WPS_OUTPUT_URL}/project/test-1/{JOB_UUID}/{output.ext}
+
+.. note::
+    Values provided by ``X-WPS-Output-Context`` can only contain alphanumeric, hyphens, underscores and path separators
+    that will result in a valid directory and URL locations. The path is assumed relative to the resolved :term:`WPS`
+    output directory, and will therefore reject any ``.`` or ``..`` path references.
+    The path must also **NOT** start by ``/``.
+
+.. note::
+    Header ``X-WPS-Output-Context`` is ignored when using `S3` buckets as output location since they are stored
+    individually per :term:`Job` UUID, and hold no relevant *context* location. See also :ref:`conf_s3_buckets`.
+
+.. versionadded:: 4.3.0
+    Addition of the ``X-WPS-Output-Context`` header.
+
 Email Notification
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-When submitting a job for execution, it is possible to provide the ``notification_email`` field.
-Doing so will tell `Weaver` to send an email to the specified address with successful or failure details upon job
-completion. The format of the email is configurable from `weaver.ini.example`_ file with email-specific settings
-(see: :ref:`Configuration`).
+When submitting a :term:`Job` for execution, it is possible to provide the ``notification_email`` field.
+Doing so will tell `Weaver` to send an email to the specified address with successful or failure details
+upon :term:`Job` completion. The format of the email is configurable from `weaver.ini.example`_ file with
+email-specific settings (see: :ref:`Configuration`).
 
 
 .. _GetStatus:

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -136,6 +136,6 @@ Endpoint Content-Type
 Next Steps
 ================================
 
-Have a look to the :ref:`Processes`,  :ref:`Package` and :ref:`FAQ` sections.
+Have a look to the :ref:`Processes`, :ref:`Package` and :ref:`FAQ` sections.
 
 The full |oas|_ is also available for request details.

--- a/tests/functional/test_wps_package.py
+++ b/tests/functional/test_wps_package.py
@@ -1384,8 +1384,8 @@ class WpsPackageAppTest(WpsConfigBase):
 
         results = self.monitor_job(status_url)
 
-        job_output_file = results.get("output_test")["href"].split("/", 3)[-1]
-        tmp_file = "{}/{}".format(self.settings["weaver.wps_output_dir"], job_output_file)
+        job_output_path = results.get("output_test")["href"].split(self.settings["weaver.wps_output_path"])[-1]
+        tmp_file = "{}/{}".format(self.settings["weaver.wps_output_dir"], job_output_path)
 
         try:
             processed_values = json.load(open(tmp_file, "r"))
@@ -1519,8 +1519,8 @@ class WpsPackageAppTest(WpsConfigBase):
 
         results = self.monitor_job(status_url)
 
-        job_output_file = results.get("output_test")["href"].split("/", 3)[-1]
-        tmp_file = "{}/{}".format(self.settings["weaver.wps_output_dir"], job_output_file)
+        job_output_path = results.get("output_test")["href"].split(self.settings["weaver.wps_output_path"])[-1]
+        tmp_file = "{}/{}".format(self.settings["weaver.wps_output_dir"], job_output_path)
 
         try:
             with open(tmp_file, "r") as f:

--- a/tests/functional/test_wps_package.py
+++ b/tests/functional/test_wps_package.py
@@ -85,6 +85,7 @@ class WpsPackageAppTest(WpsConfigBase):
             "weaver.wps": True,
             "weaver.wps_path": "/ows/wps",
             "weaver.wps_restapi_path": "/",
+            "weaver.wps_output_path": "/wpsoutputs",
             "weaver.wps_output_dir": "/tmp",  # nosec: B108 # don't care hardcoded for test
         }
         super(WpsPackageAppTest, cls).setUpClass()
@@ -1538,6 +1539,53 @@ class WpsPackageAppTest(WpsConfigBase):
         assert processed_values["measureIntegerInput"] == 45
         assert processed_values["measureFloatInput"] == 10.2
         assert processed_values["measureFileInput"] == {"VALUE": {"REF": 1, "MEASUREMENT": 10.3, "UOM": "M"}}
+
+    def test_execute_job_with_context_output_dir(self):
+        cwl = {
+            "cwlVersion": "v1.0",
+            "class": "CommandLineTool",
+            "baseCommand": "echo",
+            "inputs": {"message": {"type": "string", "inputBinding": {"position": 1}}},
+            "outputs": {"output": {"type": "File", "outputBinding": {"glob": "stdout.log"}}}
+        }
+        body = {
+            "processDescription": {"process": {"id": self._testMethodName}},
+            "deploymentProfileName": "http://www.opengis.net/profiles/eoc/wpsApplication",
+            "executionUnit": [{"unit": cwl}],
+        }
+        self.deploy_process(body)
+        exec_body = {
+            "mode": EXECUTE_MODE_ASYNC,
+            "response": EXECUTE_RESPONSE_DOCUMENT,
+            "inputs": [{"id": "message", "value": "test"}],
+            "outputs": [{"id": "output", "transmissionMode": EXECUTE_TRANSMISSION_MODE_REFERENCE}]
+        }
+        headers = deepcopy(self.json_headers)
+
+        with contextlib.ExitStack() as stack_exec:
+            for mock_exec in mocked_execute_process():
+                stack_exec.enter_context(mock_exec)
+            proc_url = "/processes/{}/jobs".format(self._testMethodName)
+
+            wps_context_dirs = [None, "", "test", "sub/test"]
+            for ctx in wps_context_dirs:
+                if ctx is not None:
+                    headers["x-wps-output-context"] = ctx
+                resp = mocked_sub_requests(self.app, "post_json", proc_url, timeout=5,
+                                           data=exec_body, headers=headers, only_local=True)
+                code = resp.status_code
+                assert code in [200, 201], "Failed with: [{}]\nReason:\n{}".format(code, resp.json)
+                status_url = resp.json.get("location")
+                job_id = resp.json["jobID"]
+                results = self.monitor_job(status_url, timeout=5)
+                wps_dir = self.settings["weaver.wps_output_dir"]
+                ctx_dir = (wps_dir + "/" + ctx) if ctx else wps_dir
+                out_url = "https://localhost" + self.settings["weaver.wps_output_path"]
+                ctx_url = (out_url + "/" + ctx) if ctx else out_url
+                res_url = ctx_url + "/" + job_id + "/stdout.log"
+                res_path = os.path.join(ctx_dir, job_id, "stdout.log")
+                assert results["output"]["href"] == res_url, "Invalid output URL with context: {}".format(ctx)
+                assert os.path.isfile(res_path), "Invalid output path with context: {}".format(ctx)
 
     # FIXME: create a real async test (threading/multiprocess) to evaluate this correctly
     def test_dismiss_job(self):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -615,8 +615,8 @@ def mocked_execute_process():
 
     task = MockTask()
 
-    def mock_execute_process(job_id, url, headers):
-        real_execute_process(job_id, url, headers)
+    def mock_execute_process(job_id, wps_url, headers):
+        real_execute_process(job_id, wps_url, headers)
         return task
 
     return (

--- a/tests/wps/test_utils.py
+++ b/tests/wps/test_utils.py
@@ -76,6 +76,9 @@ def test_get_wps_output_context():
         ("test/test", "test/test"),
         ("test/test/", "test/test"),  # allow trailing slash auto-removed
         ("test/test/test/test", "test/test/test/test"),
+        ("test-test", "test-test"),
+        ("test_test", "test_test"),
+        ("test-test/test/test_test", "test-test/test/test_test"),
     ]
 
     header_names = [

--- a/weaver/datatype.py
+++ b/weaver/datatype.py
@@ -906,6 +906,24 @@ class Job(Base):
         self["access"] = visibility
 
     @property
+    def context(self):
+        # type: () -> Optional[str]
+        """
+        Job outputs context.
+        """
+        return self.get("context") or None
+
+    @context.setter
+    def context(self, context):
+        # type: (Optional[str]) -> None
+        """
+        Job outputs context.
+        """
+        if not (isinstance(context, str) or context is None):
+            raise TypeError("Type 'str' or 'None' is required for '{}.context'".format(type(self)))
+        self["context"] = context
+
+    @property
     def request(self):
         # type: () -> Optional[str]
         """

--- a/weaver/datatype.py
+++ b/weaver/datatype.py
@@ -22,6 +22,9 @@ from weaver.exceptions import ProcessInstanceError, ServiceParsingError
 from weaver.execute import (
     EXECUTE_CONTROL_OPTION_ASYNC,
     EXECUTE_CONTROL_OPTIONS,
+    EXECUTE_MODE_ASYNC,
+    EXECUTE_MODE_OPTIONS,
+    EXECUTE_MODE_SYNC,
     EXECUTE_TRANSMISSION_MODE_OPTIONS,
     EXECUTE_TRANSMISSION_MODE_REFERENCE
 )
@@ -702,14 +705,28 @@ class Job(Base):
     @property
     def execute_async(self):
         # type: () -> bool
-        return self.get("execute_async", True)
+        return self.execution_mode == EXECUTE_MODE_ASYNC
 
-    @execute_async.setter
-    def execute_async(self, execute_async):
-        # type: (bool) -> None
-        if not isinstance(execute_async, bool):
-            raise TypeError("Type 'bool' is required for '{}.execute_async'".format(type(self)))
-        self["execute_async"] = execute_async
+    @property
+    def execute_sync(self):
+        # type: () -> bool
+        return self.execution_mode == EXECUTE_MODE_SYNC
+
+    @property
+    def execution_mode(self):
+        # type: () -> str
+        return self.get("execution_mode", EXECUTE_MODE_ASYNC)
+
+    @execution_mode.setter
+    def execution_mode(self, mode):
+        # type: (str) -> None
+        if not isinstance(mode, str):
+            raise TypeError("Type 'str' is required for '{}.execution_mode'".format(type(self)))
+        if mode not in EXECUTE_MODE_OPTIONS:
+            raise ValueError("Invalid value for '{}.execution_mode'. Must be one of {}".format(
+                type(self), list(EXECUTE_MODE_OPTIONS)
+            ))
+        self["execution_mode"] = mode
 
     @property
     def is_local(self):
@@ -1075,7 +1092,7 @@ class Job(Base):
             "status": self.status,
             "status_message": self.status_message,
             "status_location": self.status_location,
-            "execute_async": self.execute_async,
+            "execution_mode": self.execution_mode,
             "is_workflow": self.is_workflow,
             "created": self.created,
             "started": self.started,
@@ -1087,6 +1104,7 @@ class Job(Base):
             "logs": self.logs,
             "tags": self.tags,
             "access": self.access,
+            "context": self.context,
             "request": self.request,
             "response": self.response,
             "notification_email": self.notification_email,

--- a/weaver/processes/execution.py
+++ b/weaver/processes/execution.py
@@ -263,7 +263,7 @@ def execute_process(self, job_id, wps_url, headers=None):
 
 def fetch_wps_process(job, wps_url, headers, settings):
     """
-    Retrieves the WPS process description from the
+    Retrieves the WPS process description from the local or remote WPS reference URL.
     """
     try:
         wps = get_wps_client(wps_url, settings, headers=headers, language=job.accept_language)

--- a/weaver/processes/wps_package.py
+++ b/weaver/processes/wps_package.py
@@ -37,10 +37,12 @@ from pywps import Process
 from pywps.inout import BoundingBoxInput, ComplexInput, LiteralInput
 from pywps.inout.basic import SOURCE_TYPE
 from pywps.inout.literaltypes import AnyValue
+from pywps.inout.storage.file import FileStorageBuilder
 from pywps.inout.storage.s3 import S3StorageBuilder
 from yaml.scanner import ScannerError
 
 from weaver.config import WEAVER_CONFIGURATION_HYBRID, WEAVER_CONFIGURATIONS_REMOTE, get_weaver_configuration
+from weaver.database import get_db
 from weaver.exceptions import (
     PackageException,
     PackageExecutionError,
@@ -83,6 +85,7 @@ from weaver.status import (
     STATUS_SUCCEEDED,
     map_status
 )
+from weaver.store.base import StoreJobs
 from weaver.utils import (
     SUPPORTED_FILE_SCHEMES,
     fetch_file,
@@ -769,6 +772,7 @@ class WpsPackage(Process):
     step_launched = None            # type: Optional[List[str]]
     request = None                  # type: Optional[WPSRequest]
     response = None                 # type: Optional[ExecuteResponse]
+    _job = None                     # type: Optional[Job]
 
     def __init__(self, **kw):
         """
@@ -1053,6 +1057,19 @@ class WpsPackage(Process):
         self.log_message(status=status, level=level,
                          message="{0}: {1}{2}".format(exception_type.__name__, message, exception_msg))
         return exception_type("{0}{1}".format(message, exception_msg))
+
+    @property
+    def job(self):
+        # type: () -> Job
+        """
+        Obtain the job associated to this package execution as specified by the provided UUID.
+
+        Process must be in "execute" state under :mod:`pywps` for this job to be available.
+        """
+        if self._job is None:
+            store = get_db(self.settings).get_store(StoreJobs)
+            self._job = store.fetch_by_id(self.uuid)
+        return self._job
 
     @classmethod
     def map_step_progress(cls, step_index, steps_total):
@@ -1394,23 +1411,45 @@ class WpsPackage(Process):
         .. seealso::
             - :func:`weaver.wps.load_pywps_config`
         """
-        wps_out_dir = self.workdir  # pywps will resolve file paths for us using its WPS request UUID
         s3_bucket = self.settings.get("weaver.wps_output_s3_bucket")
         result_loc = cwl_result[output_id]["location"].replace("file://", "")
         result_path = os.path.split(result_loc)[-1]
 
+        # PyWPS internally sets a new FileStorage (default) inplace when generating the JSON definition of the output.
+        # This is done such that the generated XML status document in WPS response can obtain the output URL location.
+        # Call Stack:
+        #   - self.update_status (the one called right after 'self.make_outputs' is called)
+        #   - self.response._update_status
+        #   - pywps.response.execute.ExecuteResponse._update_status_doc
+        #   - pywps.response.execute.ExecuteResponse._construct_doc
+        #   - pywps.response.execute.ExecuteResponse.json
+        #   - pywps.response.execute.ExecuteResponse.process.json
+        #   - pywps.app.Process.Process.json
+        #   - pywps.inout.outputs.ComplexOutput.json  (for each output in Process)
+        #   - pywps.inout.outputs.ComplexOutput._json_reference
+        # Which sets:
+        #   - pywps.inout.outputs.ComplexOutput.storage = FileStorageBuilder().build()
+        # Followed by:
+        #   - pywps.inout.outputs.ComplexOutput.get_url()
+        #   - pywps.inout.outputs.ComplexOutput.storage.store()
+        # But, setter "pywps.inout.basic.ComplexOutput.storage" doesn't override predefined 'storage'.
+        # Therefore, preemptively override "ComplexOutput._storage" to whichever location according to use case.
         if s3_bucket:
-            # result_wps = "s3://{}/{}".format(s3_bucket, result_fn)
             # when 'url' is directly enforced, 'ComplexOutput.json' will use it instead of 'file' from temp workdir
-            # self.response.outputs[output_id].url = result_wps
-
             # override builder only here so that only results are uploaded to S3, and not XML status
-            # using this storage builder, settings are retrieved from PyWPS server config
+            # using this storage builder, other settings (bucket, region, etc.) are retrieved from PyWPS server config
             self.response.outputs[output_id]._storage = S3StorageBuilder().build()  # noqa: W0212
-            self.response.outputs[output_id].storage.prefix = str(self.response.uuid)
+            self.response.outputs[output_id].storage.prefix = str(self.response.uuid)  # job UUID
+        elif self.job.context:
+            storage = FileStorageBuilder().build()
+            storage.target = os.path.join(storage.target, self.job.context)
+            storage.output_url = os.path.join(storage.output_url, self.job.context)
+            os.makedirs(storage.target, exist_ok=True)  # pywps handles UUID-dir creation, but not nested context-dir
+            self.response.outputs[output_id]._storage = storage  # noqa: W0212
 
-        os.makedirs(wps_out_dir, exist_ok=True)
-        result_wps = os.path.join(wps_out_dir, result_path)
+        # pywps will resolve file paths for us using its WPS request UUID
+        os.makedirs(self.workdir, exist_ok=True)
+        result_wps = os.path.join(self.workdir, result_path)
 
         if os.path.realpath(result_loc) != os.path.realpath(result_wps):
             self.logger.info("Moving [%s]: [%s] -> [%s]", output_id, result_loc, result_wps)

--- a/weaver/processes/wps_package.py
+++ b/weaver/processes/wps_package.py
@@ -96,7 +96,7 @@ from weaver.utils import (
     request_extra,
     setup_loggers
 )
-from weaver.wps.utils import get_wps_output_dir
+from weaver.wps.utils import get_wps_output_dir, get_wps_output_url
 from weaver.wps_restapi.swagger_definitions import process_service
 
 if TYPE_CHECKING:
@@ -1207,7 +1207,10 @@ class WpsPackage(Process):
                 raise self.exception_message(PackageExecutionError, exc, "Failed to save package outputs.")
         except Exception:
             # return log file location by status message since outputs are not obtained by WPS failed process
-            error_msg = "Package completed with errors. Server logs: {}".format(self.log_file)
+            log_url = "{}/{}.log".format(get_wps_output_url(self.settings), self.uuid)
+            error_msg = "Package completed with errors. Server logs: [{}], Available at [{}]:".format(
+                self.log_file, log_url
+            )
             self.update_status(error_msg, self.percent, STATUS_FAILED)
             raise
         else:

--- a/weaver/processes/wps_package.py
+++ b/weaver/processes/wps_package.py
@@ -131,9 +131,6 @@ if TYPE_CHECKING:
     CWLResultEntry = Union[Dict[str, CWLResultValue], CWLResultFile, List[CWLResultFile]]
     CWLResults = Dict[str, CWLResultEntry]
 
-    # cwl_result[output_id]["location"]
-    # cwl_result[output_id][i]["location"]
-
 # NOTE:
 #   Only use this logger for 'utility' methods (not residing under WpsPackage).
 #   In that case, employ 'self.logger' instead so that the executed process has its self-contained job log entries.
@@ -1395,7 +1392,6 @@ class WpsPackage(Process):
             - :func:`weaver.wps.load_pywps_config`
         """
         wps_out_dir = self.workdir  # pywps will resolve file paths for us using its WPS request UUID
-        wps_out_cxt = get_wps_output_context(self.request.http_request)
         s3_bucket = self.settings.get("weaver.wps_output_s3_bucket")
         result_loc = cwl_result[output_id]["location"].replace("file://", "")
         result_path = os.path.split(result_loc)[-1]
@@ -1409,9 +1405,6 @@ class WpsPackage(Process):
             # using this storage builder, settings are retrieved from PyWPS server config
             self.response.outputs[output_id]._storage = S3StorageBuilder().build()  # noqa: W0212
             self.response.outputs[output_id].storage.prefix = str(self.response.uuid)
-
-        elif wps_out_cxt:
-            wps_out_dir = os.path.join(wps_out_dir, wps_out_cxt)
 
         os.makedirs(wps_out_dir, exist_ok=True)
         result_wps = os.path.join(wps_out_dir, result_path)

--- a/weaver/store/base.py
+++ b/weaver/store/base.py
@@ -106,10 +106,11 @@ class StoreJobs(StoreInterface):
                  inputs=None,               # type: Optional[List[Any]]
                  is_workflow=False,         # type: bool
                  is_local=False,            # type: bool
-                 user_id=None,              # type: Optional[int]
                  execute_async=True,        # type: bool
                  custom_tags=None,          # type: Optional[List[str]]
+                 user_id=None,              # type: Optional[int]
                  access=None,               # type: Optional[str]
+                 context=None,              # type: Optional[str]
                  notification_email=None,   # type: Optional[str]
                  accept_language=None,      # type: Optional[str]
                  created=None,              # type: Optional[datetime.datetime]

--- a/weaver/store/mongodb.py
+++ b/weaver/store/mongodb.py
@@ -443,10 +443,11 @@ class MongodbJobStore(StoreJobs, MongodbStore):
                  inputs=None,               # type: Optional[List[Any]]
                  is_workflow=False,         # type: bool
                  is_local=False,            # type: bool
-                 user_id=None,              # type: Optional[int]
                  execute_async=True,        # type: bool
                  custom_tags=None,          # type: Optional[List[str]]
+                 user_id=None,              # type: Optional[int]
                  access=None,               # type: Optional[str]
+                 context=None,              # type: Optional[str]
                  notification_email=None,   # type: Optional[str]
                  accept_language=None,      # type: Optional[str]
                  created=None,              # type: Optional[datetime.datetime]
@@ -482,6 +483,7 @@ class MongodbJobStore(StoreJobs, MongodbStore):
                 "updated": now(),
                 "tags": list(set(tags)),  # remove duplicates
                 "access": access,
+                "context": context,
                 "notification_email": notification_email,
                 "accept_language": accept_language,
             })

--- a/weaver/typedefs.py
+++ b/weaver/typedefs.py
@@ -89,7 +89,7 @@ if TYPE_CHECKING:
     KVP_Item = Union[ValueType, Sequence[ValueType]]
     KVP = Union[Sequence[Tuple[str, KVP_Item]], Dict[str, KVP_Item]]
 
-    AnyContainer = Union[Configurator, Registry, PyramidRequest, Celery]
+    AnyContainer = Union[Configurator, Registry, PyramidRequest, WerkzeugRequest, Celery]
     SettingValue = Optional[Union[JSON, AnyValue]]
     SettingsType = Dict[str, SettingValue]
     AnySettingsContainer = Union[AnyContainer, SettingsType]

--- a/weaver/utils.py
+++ b/weaver/utils.py
@@ -23,7 +23,7 @@ from celery.app import Celery
 from pyramid.config import Configurator
 from pyramid.httpexceptions import HTTPError as PyramidHTTPError, HTTPGatewayTimeout, HTTPTooManyRequests
 from pyramid.registry import Registry
-from pyramid.request import Request
+from pyramid.request import Request as PyramidRequest
 from pyramid.settings import asbool, aslist
 from pyramid.threadlocal import get_current_registry
 from pyramid_beaker import set_cache_regions_from_settings
@@ -32,6 +32,7 @@ from requests.structures import CaseInsensitiveDict
 from requests_file import FileAdapter
 from urlmatch import urlmatch
 from webob.headers import EnvironHeaders, ResponseHeaders
+from werkzeug.wrappers import Request as WerkzeugRequest
 
 from weaver.status import map_status
 from weaver.warning import TimeZoneInfoAlreadySetWarning
@@ -157,16 +158,18 @@ def get_any_message(info):
 
 
 def get_registry(container, nothrow=False):
-    # type: (AnyRegistryContainer, bool) -> Optional[Registry]
+    # type: (Optional[AnyRegistryContainer], bool) -> Optional[Registry]
     """
     Retrieves the application ``registry`` from various containers referencing to it.
     """
     if isinstance(container, Celery):
         return container.conf.get("PYRAMID_REGISTRY", {})
-    if isinstance(container, (Configurator, Request)):
+    if isinstance(container, (Configurator, PyramidRequest)):
         return container.registry
     if isinstance(container, Registry):
         return container
+    if isinstance(container, WerkzeugRequest) or container is None:
+        return get_current_registry()
     if nothrow:
         return None
     raise TypeError("Could not retrieve registry from container object of type [{}].".format(type(container)))
@@ -177,14 +180,12 @@ def get_settings(container=None):
     """
     Retrieves the application ``settings`` from various containers referencing to it.
     """
-    if isinstance(container, (Celery, Configurator, Request)):
+    if isinstance(container, (Celery, Configurator, PyramidRequest, WerkzeugRequest)) or container is None:
         container = get_registry(container)
     if isinstance(container, Registry):
         return container.settings
     if isinstance(container, dict):
         return container
-    if container is None:
-        return get_current_registry().settings
     raise TypeError("Could not retrieve settings from container object of type [{}]".format(type(container)))
 
 

--- a/weaver/wps/service.py
+++ b/weaver/wps/service.py
@@ -30,6 +30,8 @@ from weaver.wps_restapi import swagger_definitions as sd
 LOGGER = logging.getLogger(__name__)
 if TYPE_CHECKING:
     from typing import Any, Dict, List, Optional, Union
+
+    from weaver.datatype import Job
     from weaver.processes.convert import WPS_Input_Type, WPS_Output_Type
     from weaver.typedefs import HTTPValid, JSON, SettingsType
 
@@ -124,7 +126,9 @@ class WorkerService(ServiceWPS):
     def get_capabilities(self, wps_request, *_, **__):
         # type: (WPSRequest, Any, Any) -> Union[WPSResponse, HTTPValid]
         """
-        Redirect to WPS-REST endpoint if requested ``Content-Type`` is JSON or handle ``GetCapabilities`` normally.
+        Handles the ``GetCapabilities`` KVP/XML request submitted on the WPS endpoint.
+
+        Redirects to WPS-REST endpoint if requested ``Content-Type`` is JSON or handle ``GetCapabilities`` normally.
         """
         resp = self._get_capabilities_redirect(wps_request, *_, **__)
         return resp or super(WorkerService, self).get_capabilities(wps_request, *_, **__)
@@ -153,6 +157,8 @@ class WorkerService(ServiceWPS):
     def describe(self, wps_request, *_, **__):
         # type: (WPSRequest, Any, Any) -> Union[WPSResponse, HTTPValid]
         """
+        Handles the ``DescribeProcess`` KVP/XML request submitted on the WPS endpoint.
+
         Redirect to WPS-REST endpoint if requested ``Content-Type`` is JSON or handle ``DescribeProcess`` normally.
         """
         resp = self._describe_process_redirect(wps_request, *_, **__)
@@ -163,6 +169,8 @@ class WorkerService(ServiceWPS):
         # type: (WPSRequest) -> Union[WPSResponse, HTTPValid, JSON]
         """
         Dispatch operation to WPS-REST endpoint, which in turn should call back the real Celery Worker for execution.
+
+        Returns the status response as is if XML, or convert it to JSON, according to request ``Accept`` header.
         """
         req = wps_request.http_request
         pid = wps_request.identifier
@@ -215,10 +223,12 @@ class WorkerService(ServiceWPS):
     def execute(self, identifier, wps_request, uuid):
         # type: (str, WPSRequest, str) -> Union[WPSResponse, HTTPValid]
         """
+        Handles the ``Execute`` KVP/XML request submitted on the WPS endpoint.
+
         Submit WPS request to corresponding WPS-REST endpoint and convert back for requested ``Accept`` content-type.
 
-        Overrides the original execute operation, that instead will get handled by :meth:`execute_job` following
-        callback from Celery Worker that handles process job creation and monitoring.
+        Overrides the original execute operation, that will instead be handled by :meth:`execute_job` following
+        callback from Celery Worker, which handles process job creation and monitoring.
 
         If ``Accept`` is JSON, the result is directly returned from :meth:`_submit_job`.
         If ``Accept`` is XML or undefined, :class:`WorkerExecuteResponse` converts the received JSON with XML template.
@@ -241,16 +251,17 @@ class WorkerService(ServiceWPS):
             message = "Failed building XML response from WPS Execute result. Error [{!r}]".format(ex)
             raise OWSNoApplicableCode(message, locator=job_id)
 
-    def execute_job(self, process_id, wps_inputs, wps_outputs, mode, job_uuid, remote_process, language):
-        # type: (str, List[WPS_Input_Type], List[WPS_Output_Type], str, str, Optional[Process], str) -> WPSExecution
+    def execute_job(self, job, wps_inputs, wps_outputs, remote_process):
+        # type: (Job, List[WPS_Input_Type], List[WPS_Output_Type], Optional[Process]) -> WPSExecution
         """
         Real execution of the process by active Celery Worker.
         """
+        process_id = job.process
         execution = WPSExecution(version="2.0", url="localhost")
-        xml_request = execution.buildRequest(process_id, wps_inputs, wps_outputs, mode=mode, lineage=True)
+        xml_request = execution.buildRequest(process_id, wps_inputs, wps_outputs, mode=job.execution_mode, lineage=True)
         wps_request = WPSRequest()
         wps_request.identifier = process_id
-        wps_request.check_and_set_language(language)
+        wps_request.check_and_set_language(job.accept_language)
         wps_request.set_version("2.0.0")
         request_parser = wps_request._post_request_parser(wps_request.WPS.Execute().tag)  # noqa: W0212
         request_parser(xml_request)  # parses the submitted inputs/outputs data and request parameters
@@ -264,8 +275,7 @@ class WorkerService(ServiceWPS):
         # NOTE:
         #  Setting 'status = false' will disable async execution of 'pywps.app.Process.Process'
         #  but this is needed since this job is running within Celery worker already async
-        #  (daemon process can't have children processes)
-        #  Because if how the code in PyWPS is made, we have to re-enable creation of status file
+        #  (daemon process can't have children processes).
         wps_request.status = "false"
 
         # When 'execute' is called, pywps will in turn call 'prepare_process_for_execution',
@@ -275,9 +285,11 @@ class WorkerService(ServiceWPS):
         if not remote_process:
             worker_process_id = process_id
         else:
-            worker_process_id = "wps_package-{}-{}".format(process_id, job_uuid)
+            worker_process_id = "wps_package-{}-{}".format(process_id, job.uuid)
             self.dispatched_processes[worker_process_id] = remote_process
-        wps_response = super(WorkerService, self).execute(worker_process_id, wps_request, job_uuid)
+
+        wps_response = super(WorkerService, self).execute(worker_process_id, wps_request, job.uuid)
+        # re-enable creation of status file so we can find it since we disabled 'status' earlier for sync execution
         wps_response.store_status_file = True
         # update execution status with actual status file and apply required references
         execution = check_wps_status(location=wps_response.process.status_location, settings=self.settings)

--- a/weaver/wps/utils.py
+++ b/weaver/wps/utils.py
@@ -126,7 +126,7 @@ def get_wps_output_context(request):
     ctx = get_header("X-WPS-Output-Context", headers)
     if not ctx:
         return None
-    cxt_found = re.match(r"^(?=\w+)(\w+/?)+$", ctx)
+    cxt_found = re.match(r"^(?=[\w-]+)([\w-]+/?)+$", ctx)
     if cxt_found and cxt_found[0] == ctx:
         return ctx[:-1] if ctx.endswith("/") else ctx
     raise HTTPUnprocessableEntity(json={

--- a/weaver/wps/utils.py
+++ b/weaver/wps/utils.py
@@ -125,10 +125,17 @@ def get_wps_output_context(request):
     headers = getattr(request, "headers", {})
     ctx = get_header("X-WPS-Output-Context", headers)
     if not ctx:
-        return None
+        settings = get_settings(request)
+        ctx_default = settings.get("weaver.wps_output_context", None)
+        if not ctx_default:
+            return None
+        LOGGER.debug("Using default 'wps.wps_output_context': %s", ctx_default)
+        ctx = ctx_default
     cxt_found = re.match(r"^(?=[\w-]+)([\w-]+/?)+$", ctx)
     if cxt_found and cxt_found[0] == ctx:
-        return ctx[:-1] if ctx.endswith("/") else ctx
+        ctx_matched = ctx[:-1] if ctx.endswith("/") else ctx
+        LOGGER.debug("Using request 'X-WPS-Output-Context': %s", ctx_matched)
+        return ctx_matched
     raise HTTPUnprocessableEntity(json={
         "code": "InvalidHeaderValue",
         "name": "X-WPS-Output-Context",

--- a/weaver/wps/utils.py
+++ b/weaver/wps/utils.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import re
 import tempfile
 from configparser import ConfigParser
 from typing import TYPE_CHECKING
@@ -7,7 +8,7 @@ from urllib.parse import urlparse
 
 from beaker.cache import cache_region
 from owslib.wps import WebProcessingService, WPSExecution
-from pyramid.httpexceptions import HTTPNotFound
+from pyramid.httpexceptions import HTTPNotFound, HTTPUnprocessableEntity
 from pywps import configuration as pywps_config
 from webob.acceptparse import create_accept_language_header
 
@@ -111,6 +112,30 @@ def get_wps_output_url(container):
         container, "weaver.wps_output_url", "server", "outputurl", wps_output_default, "WPS output url"
     )
     return wps_output_config or wps_output_default
+
+
+def get_wps_output_context(request):
+    # type: (AnyRequestType) -> Optional[str]
+    """
+    Obtains and validates allowed values for sub-directory context of WPS outputs in header ``X-WPS-Output-Context``.
+
+    :raises HTTPUnprocessableEntity: if the header was provided an contains invalid or illegal value.
+    :returns: validated context or None if not specified.
+    """
+    headers = getattr(request, "headers", {})
+    ctx = get_header("X-WPS-Output-Context", headers)
+    if not ctx:
+        return None
+    cxt_found = re.match(r"^(?=\w+)(\w+/?)+$", ctx)
+    if cxt_found and cxt_found[0] == ctx:
+        return ctx[:-1] if ctx.endswith("/") else ctx
+    raise HTTPUnprocessableEntity(json={
+        "code": "InvalidHeaderValue",
+        "name": "X-WPS-Output-Context",
+        "description": "Provided value for 'X-WPS-Output-Context' request header is invalid.",
+        "cause": "Value must be an alphanumeric context directory or tree hierarchy of sub-directory names.",
+        "value": str(ctx)
+    })
 
 
 def get_wps_local_status_location(url_status_location, container, must_exist=True):

--- a/weaver/wps_restapi/swagger_definitions.py
+++ b/weaver/wps_restapi/swagger_definitions.py
@@ -3486,8 +3486,28 @@ class PostProcessesEndpoint(ExtendedMappingSchema):
     body = Deploy(title="Deploy")
 
 
+class WpsOutputContextHeader(ExtendedSchemaNode):
+    # ok to use 'name' in this case because target 'key' in the mapping must
+    # be that specific value but cannot have a field named with this format
+    name = "X-WPS-Output-Context"
+    description = (
+        "Contextual location where to store WPS output results from job execution. ",
+        "When provided, value must be a directory or sub-directories slug. ",
+        "Resulting contextual location will be relative to server WPS outputs when no context is provided.",
+    )
+    schema_type = String
+    missing = drop
+    example = "my-directory/sub-project"
+    default = None
+
+
+class ExecuteHeaders(RequestHeaders):
+    description = "Request headers supported for job execution."
+    x_wps_output_context = WpsOutputContextHeader()
+
+
 class PostProcessJobsEndpoint(ProcessPath):
-    header = AcceptLanguageHeader()
+    header = ExecuteHeaders()
     body = Execute()
 
 
@@ -3641,7 +3661,7 @@ class PostProviderProcessJobRequest(ExtendedMappingSchema):
     """
     Launching a new process request definition.
     """
-    header = RequestHeaders()
+    header = ExecuteHeaders()
     querystring = LaunchJobQuerystring()
     body = Execute()
 


### PR DESCRIPTION
# Changes

- Support contextual WPS output location using ``X-WPS-Output-Context`` header to store ``Job`` results.
  When a ``Job`` is executed by providing this header with a sub-directory, the resulting outputs of the ``Job``
  will be placed and reported under the corresponding location relative to WPS outputs (path and URL).
- Replace ``Job.execute_async`` getter/setter by simple property using more generic ``Job.execution_mode``
  for storage in database. Provide ``Job.execute_async`` and ``Job.execute_sync`` properties based on stored mode.
- Simplify ``execute_process`` function executed by `Celery` task into sub-step functions where applicable.
- Simplify forwarding of ``Job`` parameters between ``PyWPS`` service ``WorkerService.execute_job`` method
  and `Celery` task instantiating it by reusing the ``Job`` object.
- Provide corresponding ``Job`` log URL along already reported log file path to facilitate retrieval from server side.
- Avoid ``Job.progress`` updates following ``failed`` or ``dismissed`` statuses to keep track of the last real progress
  percentage that was reached when that status was set.

# Fixes

- Provide requirement for https://www.crim.ca/jira/browse/DAC-170
- Provide requirement for https://www.crim.ca/jira/browse/DAC-188
- closes #110 
  Context should be provided by external method rather than relying on Weaver which holds no knowledge about the user. 