### PR TITLE
Job min max duration

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
     services:
       # Label used to access the service container
       mongodb:
-        image: mongo:3.4.23  # DockerHub
+        image: mongo:5.0  # DockerHub
         ports:
           - "27017:27017"
     strategy:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,11 @@ Changes:
   (resolves `#351 <https://github.com/crim-ca/weaver/issues/351>`_).
 - Add `OGC-API - Processes` conformance references regarding supported operations for ``Job`` listing and filtering.
 
+- Add ``minDuration`` and ``maxDuration`` parameters to query ``Job`` listing filtered by specific execution time range
+  (resolves ``, relates to ).
+- Require minimally ``pymongo==3.12.0`` and corresponding `MongoDB` ``5.0`` instance to process new filtering queries
+  of ``minDuration`` and ``maxDuration``.
+
 Fixes:
 ------
 - Allow ``group`` query parameter to handle ``Job`` category listing with ``provider`` as ``service`` alias.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,7 +16,9 @@ Changes:
   (resolves `#351 <https://github.com/crim-ca/weaver/issues/351>`_).
 - Add `OGC-API - Processes` conformance references regarding supported operations for ``Job`` listing and filtering.
 - Add ``minDuration`` and ``maxDuration`` parameters to query ``Job`` listing filtered by specific execution time range
-  (resolves ``, relates to ).
+  (resolves `#268 <https://github.com/crim-ca/weaver/issues/268>`_).
+  Range duration parameters are limited to single values each
+  (relates to `opengeospatial/ogcapi-processes#261 <https://github.com/opengeospatial/ogcapi-processes/issues/261>`_).
 - Require minimally ``pymongo==3.12.0`` and corresponding `MongoDB` ``5.0`` instance to process new filtering queries
   of ``minDuration`` and ``maxDuration``.
 - Refactor ``Job`` search method to facilitate its extension in the event of future filter parameters.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,11 +15,11 @@ Changes:
 - Add ``type`` field to ``Job`` status information
   (resolves `#351 <https://github.com/crim-ca/weaver/issues/351>`_).
 - Add `OGC-API - Processes` conformance references regarding supported operations for ``Job`` listing and filtering.
-
 - Add ``minDuration`` and ``maxDuration`` parameters to query ``Job`` listing filtered by specific execution time range
   (resolves ``, relates to ).
 - Require minimally ``pymongo==3.12.0`` and corresponding `MongoDB` ``5.0`` instance to process new filtering queries
   of ``minDuration`` and ``maxDuration``.
+- Refactor ``Job`` search method to facilitate its extension in the event of future filter parameters.
 
 Fixes:
 ------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,7 +20,8 @@ Changes:
   Range duration parameters are limited to single values each
   (relates to `opengeospatial/ogcapi-processes#261 <https://github.com/opengeospatial/ogcapi-processes/issues/261>`_).
 - Require minimally ``pymongo==3.12.0`` and corresponding `MongoDB` ``5.0`` instance to process new filtering queries
-  of ``minDuration`` and ``maxDuration``.
+  of ``minDuration`` and ``maxDuration``. Please refer to :ref:`database_migration`
+  and `MongoDB official documentation <https://docs.mongodb.com/manual>`_ for migration methods.
 - Refactor ``Job`` search method to facilitate its extension in the event of future filter parameters.
 
 Fixes:

--- a/docker/docker-compose.yml.example
+++ b/docker/docker-compose.yml.example
@@ -112,7 +112,7 @@ services:
     #    constraints: [node.role == manager]
 
   mongodb:
-    image: mongo:3.4.0
+    image: mongo:5.0
     container_name: mongodb
     volumes:
       - /data/mongodb_persist:/data/db

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -69,3 +69,36 @@ Known issues
 
 
 Please refer to :ref:`Configuration` and :ref:`Running` sections for following steps.
+
+.. _database_migration:
+
+=====================
+Database Migration
+=====================
+
+.. versionadded:: 4.3.0
+
+Previous versions of `Weaver` did not require any specific version of `MongoDB`_.
+Features were working using version as early as ``mongo==3.4`` if not even older.
+Due to more recent search capabilities, performance improvements and security fixes,
+minimum requirement of ``mongo==5.0`` has been made mandatory.
+
+In terms of data itself, there should be no difference, unless more advanced usage (e.g.: Replica Sets) were configured
+on your side. See relevant |mongodb-docs|_ as needed in this case. Otherwise, employed ``mongodb`` instance simply needs
+to be updated with the relevant versions.
+
+To simplify to process, the following procedure is recommended to avoid installing `MongoDB` libraries.
+Assuming the current version is ``3.4``, below operations must be executed iteratively for every migration step of
+versions ``3.6``, ``4.0``, ``4.2``, ``4.4`` and ``5.0``, where ``VERSION`` is the new version above the current one.
+
+.. code-block:: shell
+
+    docker run --name mongo -v <DB_DATA_PATH>:/data/db -d mongo:<VERSION>
+    docker exec -ti mongo mongo
+
+    # in docker, should answer with: { "ok" : 1 }
+    db.adminCommand( { setFeatureCompatibilityVersion: "<VERSION>" } )
+    exit
+
+    # back in shell
+    docker stop mongo && docker rm mongo

--- a/docs/source/references.rst
+++ b/docs/source/references.rst
@@ -79,6 +79,8 @@
 .. _Gunicorn: https://gunicorn.org/
 .. _Miniconda: https://docs.conda.io/en/latest/miniconda.html
 .. _MongoDB: https://www.mongodb.com/
+.. |mongodb-docs| replace:: MongoDB official documentation
+.. _mongodb-docs: https://docs.mongodb.com/manual
 
 .. Weaver Configurations
 .. |weaver-config| replace:: ``weaver/config``

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,7 @@ mako
 # esgf-compute-api (cwt) needs oauthlib but doesn't add it in their requirements
 oauthlib
 owslib==0.25.0
-pymongo
+pymongo>=3.12.0
 # pyproj>=2 employed by OWSLib, but make requirements stricter
 pyproj>=3
 pyramid>=1.7.3

--- a/tests/wps_restapi/test_jobs.py
+++ b/tests/wps_restapi/test_jobs.py
@@ -52,7 +52,7 @@ if TYPE_CHECKING:
 
 
 class WpsRestApiJobsTest(unittest.TestCase):
-    settings = None
+    settings = {}
     config = None
 
     @classmethod

--- a/tests/wps_restapi/test_jobs.py
+++ b/tests/wps_restapi/test_jobs.py
@@ -37,7 +37,7 @@ from weaver.status import (
     STATUS_RUNNING,
     STATUS_SUCCEEDED
 )
-from weaver.utils import get_path_kvp
+from weaver.utils import get_path_kvp, now
 from weaver.visibility import VISIBILITY_PRIVATE, VISIBILITY_PUBLIC
 from weaver.warning import TimeZoneInfoAlreadySetWarning
 from weaver.wps_restapi import swagger_definitions as sd
@@ -52,6 +52,9 @@ if TYPE_CHECKING:
 
 
 class WpsRestApiJobsTest(unittest.TestCase):
+    settings = None
+    config = None
+
     @classmethod
     def setUpClass(cls):
         warnings.simplefilter("ignore", TimeZoneInfoAlreadySetWarning)
@@ -101,36 +104,44 @@ class WpsRestApiJobsTest(unittest.TestCase):
 
         # create jobs accessible by index
         self.job_info = []  # type: List[Job]
-        self.make_job(task_id="0000-0000-0000-0000", process=self.process_public.identifier, service=None,
+        self.make_job(task_id="0000-0000-0000-0000",
+                      process=self.process_public.identifier, service=None,
                       user_id=self.user_editor1_id, status=STATUS_SUCCEEDED, progress=100, access=VISIBILITY_PUBLIC)
-        self.make_job(task_id="1111-1111-1111-1111", process=self.process_unknown, service=self.service_public.name,
+        self.make_job(task_id="1111-1111-1111-1111",
+                      process=self.process_unknown, service=self.service_public.name,
                       user_id=self.user_editor1_id, status=STATUS_FAILED, progress=99, access=VISIBILITY_PUBLIC)
-        self.make_job(task_id="2222-2222-2222-2222", process=self.process_private.identifier, service=None,
+        self.make_job(task_id="2222-2222-2222-2222",
+                      process=self.process_private.identifier, service=None,
                       user_id=self.user_editor1_id, status=STATUS_FAILED, progress=55, access=VISIBILITY_PUBLIC)
         # same process as job 0, but private (ex: job ran with private process, then process made public afterwards)
-        self.make_job(task_id="3333-3333-3333-3333", process=self.process_public.identifier, service=None,
+        self.make_job(task_id="3333-3333-3333-3333",
+                      process=self.process_public.identifier, service=None,
                       user_id=self.user_editor1_id, status=STATUS_FAILED, progress=55, access=VISIBILITY_PRIVATE)
         # job ran by admin
-        self.make_job(task_id="4444-4444-4444-4444", process=self.process_public.identifier, service=None,
+        self.make_job(task_id="4444-4444-4444-4444",
+                      process=self.process_public.identifier, service=None,
                       user_id=self.user_admin_id, status=STATUS_FAILED, progress=55, access=VISIBILITY_PRIVATE)
         # job public/private service/process combinations
-        self.make_job(task_id="5555-5555-5555-5555", process=self.process_public.identifier,
-                      service=self.service_public.name, created=self.datetime_interval[0], duration=20,
+        self.make_job(task_id="5555-5555-5555-5555", created=self.datetime_interval[0], duration=20,
+                      process=self.process_public.identifier, service=self.service_public.name,
                       user_id=self.user_editor1_id, status=STATUS_FAILED, progress=99, access=VISIBILITY_PUBLIC)
-        self.make_job(task_id="6666-6666-6666-6666", process=self.process_private.identifier,
-                      service=self.service_public.name, created=self.datetime_interval[1], duration=30,
+        self.make_job(task_id="6666-6666-6666-6666", created=self.datetime_interval[1], duration=30,
+                      process=self.process_private.identifier, service=self.service_public.name,
                       user_id=self.user_editor1_id, status=STATUS_FAILED, progress=99, access=VISIBILITY_PUBLIC)
-        self.make_job(task_id="7777-7777-7777-7777", process=self.process_public.identifier,
-                      service=self.service_private.name, created=self.datetime_interval[2], duration=40,
+        self.make_job(task_id="7777-7777-7777-7777", created=self.datetime_interval[2], duration=40,
+                      process=self.process_public.identifier, service=self.service_private.name,
                       user_id=self.user_editor1_id, status=STATUS_FAILED, progress=99, access=VISIBILITY_PUBLIC)
-        self.make_job(task_id="8888-8888-8888-8888", process=self.process_private.identifier,
-                      service=self.service_private.name, created=self.datetime_interval[3], duration=50,
+        self.make_job(task_id="8888-8888-8888-8888", created=self.datetime_interval[3], duration=50,
+                      process=self.process_private.identifier, service=self.service_private.name,
                       user_id=self.user_editor1_id, status=STATUS_FAILED, progress=99, access=VISIBILITY_PUBLIC)
         # jobs with duplicate 'process' identifier, but under a different 'service' name
-        self.make_job(task_id="9999-9999-9999-9999", process=self.process_other.identifier,
-                      service=self.service_one.name, created=datetime.datetime.now(), duration=20,
+        # WARNING:
+        #   For tests that use minDuration/maxDuration, following two jobs could 'eventually' become more/less than
+        #   expected test values while debugging (code breakpoints) since their duration is dynamic (current - started)
+        self.make_job(task_id="9999-9999-9999-9999", created=now(), duration=20,
+                      process=self.process_other.identifier, service=self.service_one.name,
                       user_id=self.user_editor1_id, status=STATUS_RUNNING, progress=99, access=VISIBILITY_PUBLIC)
-        self.make_job(task_id="1010-1010-1010-1010", created=datetime.datetime.now(), duration=25,
+        self.make_job(task_id="1010-1010-1010-1010", created=now(), duration=25,
                       process=self.process_other.identifier, service=self.service_two.name,
                       user_id=self.user_editor1_id, status=STATUS_RUNNING, progress=99, access=VISIBILITY_PUBLIC)
 
@@ -158,13 +169,15 @@ class WpsRestApiJobsTest(unittest.TestCase):
         mapping = OrderedDict(sorted((j.task_id, j.id) for j in self.job_store.list_jobs()))
         return message + "\nMapping Task-ID/Job-ID:\n{}".format(json.dumps(mapping, indent=indent))
 
-    def message_with_jobs_diffs(self, jobs_result, jobs_expect, test_values=None, message="", indent=2, index=None):
-        return (message if message else "Different jobs returned than expected") + \
-               (" (index: {})".format(index) if index is not None else "") + \
-               ("\nResponse: {}".format(json.dumps(sorted(jobs_result), indent=indent))) + \
-               ("\nExpected: {}".format(json.dumps(sorted(jobs_expect), indent=indent))) + \
-               ("\nTesting: {}".format(test_values) if test_values else "") + \
-               (self.message_with_jobs_mapping())
+    def assert_equal_with_jobs_diffs(self, jobs_result, jobs_expect,
+                                     test_values=None, message="", indent=2, index=None):
+        assert len(jobs_result) == len(jobs_expect) and all(job in jobs_expect for job in jobs_result), \
+            (message if message else "Different jobs returned than expected") + \
+            (" (index: {})".format(index) if index is not None else "") + \
+            ("\nResponse: {}".format(json.dumps(sorted(jobs_result), indent=indent))) + \
+            ("\nExpected: {}".format(json.dumps(sorted(jobs_expect), indent=indent))) + \
+            ("\nTesting: {}".format(test_values) if test_values else "") + \
+            (self.message_with_jobs_mapping())
 
     def get_job_request_auth_mock(self, user_id):
         is_admin = self.user_admin_id == user_id
@@ -516,9 +529,8 @@ class WpsRestApiJobsTest(unittest.TestCase):
         self.check_basic_jobs_info(resp)
         expect_jobs = [self.job_info[i].id for i in [0, 2]]  # idx=2 & idx>4 have 'service', only 0,2 are public
         result_jobs = resp.json["jobs"]
-        assert len(resp.json["jobs"]) == len(expect_jobs)
+        self.assert_equal_with_jobs_diffs(result_jobs, expect_jobs)
         assert resp.json["total"] == len(expect_jobs)
-        assert all(job in expect_jobs for job in result_jobs), self.message_with_jobs_diffs(result_jobs, expect_jobs)
 
     def test_get_jobs_by_type_process_and_specific_process_id(self):
         path = get_path_kvp(sd.jobs_service.path, type="process", process=self.process_public.identifier)
@@ -547,9 +559,8 @@ class WpsRestApiJobsTest(unittest.TestCase):
         self.check_basic_jobs_info(resp)
         expect_jobs = [self.job_info[i].id for i in [1, 5, 6, 7, 8, 9]]  # has 'service' & public access
         result_jobs = resp.json["jobs"]
-        assert len(resp.json["jobs"]) == len(expect_jobs)
+        self.assert_equal_with_jobs_diffs(result_jobs, expect_jobs)
         assert resp.json["total"] == len(expect_jobs)
-        assert all(job in expect_jobs for job in result_jobs), self.message_with_jobs_diffs(result_jobs, expect_jobs)
 
     def template_get_jobs_by_type_service(self):
         self.template_get_jobs_by_type_service_provider("service")
@@ -563,9 +574,8 @@ class WpsRestApiJobsTest(unittest.TestCase):
         self.check_basic_jobs_info(resp)
         expect_jobs = [self.job_info[i].id for i in [1, 5, 6]]  # has 'service' & public access, others not same name
         result_jobs = resp.json["jobs"]
-        assert len(resp.json["jobs"]) == len(expect_jobs)
+        self.assert_equal_with_jobs_diffs(result_jobs, expect_jobs)
         assert resp.json["total"] == len(expect_jobs)
-        assert all(job in expect_jobs for job in result_jobs), self.message_with_jobs_diffs(result_jobs, expect_jobs)
 
     def test_get_jobs_by_type_provider_and_specific_process_id(self):
         """
@@ -587,12 +597,10 @@ class WpsRestApiJobsTest(unittest.TestCase):
         path = get_path_kvp(sd.jobs_service.path, type="provider", process=self.process_other.identifier, detail=True)
         resp = self.app.get(path, headers=self.json_headers)
         self.check_basic_jobs_info(resp)
-        assert len(resp.json["jobs"]) == 2
         expect_jobs = [self.job_info[i].id for i in [9, 10]]
         result_jobs = [job["jobID"] for job in resp.json["jobs"]]
-        assert len(result_jobs) == len(expect_jobs)
+        self.assert_equal_with_jobs_diffs(result_jobs, expect_jobs)
         assert resp.json["total"] == len(expect_jobs)
-        assert all(job in expect_jobs for job in result_jobs), self.message_with_jobs_diffs(result_jobs, expect_jobs)
         for job in resp.json["jobs"]:
             assert job["processID"] == self.process_other.identifier
             if job["jobID"] == self.job_info[9].id:
@@ -733,6 +741,7 @@ class WpsRestApiJobsTest(unittest.TestCase):
             return list(filter(lambda j: j.process == self.process_public.identifier, jobs))
 
         def filter_service(jobs):  # type: (Iterable[Job]) -> List[Job]
+            jobs = filter_process(jobs)  # nested process under service must also be public to be accessible
             return list(filter(lambda j: j.service == self.service_public.name, jobs))
 
         # test variations of [paths, query, user-id, expected-job-ids]
@@ -757,7 +766,7 @@ class WpsRestApiJobsTest(unittest.TestCase):
             (uri_process_jobs,  VISIBILITY_PRIVATE, self.user_admin_id,     filter_process(admin_private_jobs)),        # noqa: E241,E501
             (uri_process_jobs,  VISIBILITY_PUBLIC,  None,                   filter_process(public_jobs)),               # noqa: E241,E501
             (uri_process_jobs,  VISIBILITY_PUBLIC,  self.user_editor1_id,   filter_process(editor1_public_jobs)),       # noqa: E241,E501
-            (uri_process_jobs,  VISIBILITY_PUBLIC,  self.user_admin_id,     filter_process(self.job_info)),             # noqa: E241,E501
+            (uri_process_jobs,  VISIBILITY_PUBLIC,  self.user_admin_id,     filter_process(public_jobs)),               # noqa: E241,E501
             # ---
             (uri_provider_jobs, None,               None,                   filter_service(public_jobs)),               # noqa: E241,E501
             (uri_provider_jobs, None,               self.user_editor1_id,   filter_service(editor1_all_jobs)),          # noqa: E241,E501
@@ -767,7 +776,7 @@ class WpsRestApiJobsTest(unittest.TestCase):
             (uri_provider_jobs, VISIBILITY_PRIVATE, self.user_admin_id,     filter_service(admin_private_jobs)),        # noqa: E241,E501
             (uri_provider_jobs, VISIBILITY_PUBLIC,  None,                   filter_service(public_jobs)),               # noqa: E241,E501
             (uri_provider_jobs, VISIBILITY_PUBLIC,  self.user_editor1_id,   filter_service(editor1_public_jobs)),       # noqa: E241,E501
-            (uri_provider_jobs, VISIBILITY_PUBLIC,  self.user_admin_id,     filter_service(self.job_info)),             # noqa: E241,E501
+            (uri_provider_jobs, VISIBILITY_PUBLIC,  self.user_admin_id,     filter_service(public_jobs)),               # noqa: E241,E501
 
         ]   # type: List[Tuple[str, str, Union[None, int], List[Job]]]
 
@@ -777,13 +786,13 @@ class WpsRestApiJobsTest(unittest.TestCase):
                     stack.enter_context(patch)
                 for patch in mocked_remote_wps([self.process_public]):
                     stack.enter_context(patch)
-                test = get_path_kvp(path, access=access, limit=1000) if access else path
+                test = get_path_kvp(path, access=access, limit=1000) if access else get_path_kvp(path, limit=1000)
                 resp = self.app.get(test, headers=self.json_headers)
                 self.check_basic_jobs_info(resp)
-                job_ids = [job.id for job in expected_jobs]
-                job_match = all(job in job_ids for job in resp.json["jobs"])
+                job_expect = [job.id for job in expected_jobs]
+                job_result = resp.json["jobs"]
                 test_values = dict(path=path, access=access, user_id=user_id)
-                assert job_match, self.message_with_jobs_diffs(resp.json["jobs"], job_ids, test_values, index=i)
+                self.assert_equal_with_jobs_diffs(job_result, job_expect, test_values, index=i)
 
     def test_jobs_list_with_limit_api(self):
         """
@@ -965,94 +974,116 @@ class WpsRestApiJobsTest(unittest.TestCase):
         assert resp.status_code == 200
         result_jobs = resp.json["jobs"]
         expect_jobs = [self.job_info[i].id for i in [7, 8]]
-        assert len(result_jobs) == len(expect_jobs)
-        match_jobs = all(job in expect_jobs for job in result_jobs)
-        assert match_jobs, self.message_with_jobs_diffs(result_jobs, expect_jobs, test)
+        self.assert_equal_with_jobs_diffs(result_jobs, expect_jobs, test)
 
-        test = {"minDuration": 24}
+        test = {"minDuration": 25}
         path = get_path_kvp(sd.jobs_service.path, **test)
         resp = self.app.get(path, headers=self.json_headers)
         assert resp.status_code == 200
         result_jobs = resp.json["jobs"]
-        expect_jobs = [self.job_info[i].id for i in [6, 7, 8, 10]]
-        assert len(result_jobs) == len(expect_jobs)
-        match_jobs = all(job in expect_jobs for job in result_jobs)
-        assert match_jobs, self.message_with_jobs_diffs(result_jobs, expect_jobs, test)
+        expect_idx = [6, 7, 8]  # although 10 has duration=25, it is dynamic. Delay until here is reached becomes >25
+        expect_jobs = [self.job_info[i].id for i in expect_idx]
+        self.assert_equal_with_jobs_diffs(result_jobs, expect_jobs, test)
 
-    def test_get_jobs_duration_max_only(self):
-        path = get_path_kvp(sd.jobs_service.path, maxDuration=30)
-        resp = self.app.get(path, headers=self.json_headers)
-        assert resp.status_code == 200
-        result_jobs = resp.json["jobs"]
-        expect_jobs = [self.job_info[i].id for i in [5, 6, 10]]
-        assert len(result_jobs) == len(expect_jobs)
-        assert all(job in expect_jobs for job in result_jobs)
-
-        path = get_path_kvp(sd.jobs_service.path, maxDuration=49)
+        test = {"minDuration": 49}
+        path = get_path_kvp(sd.jobs_service.path, **test)
         resp = self.app.get(path, headers=self.json_headers)
         assert resp.status_code == 200
         result_jobs = resp.json["jobs"]
         expect_jobs = [self.job_info[i].id for i in [8]]
-        assert len(result_jobs) == len(expect_jobs)
-        assert all(job in expect_jobs for job in result_jobs)
+        self.assert_equal_with_jobs_diffs(result_jobs, expect_jobs, test)
+
+    def test_get_jobs_duration_max_only(self):
+        test = {"maxDuration": 30}
+        path = get_path_kvp(sd.jobs_service.path, **test)
+        resp = self.app.get(path, headers=self.json_headers)
+        assert resp.status_code == 200
+        result_jobs = resp.json["jobs"]
+        expect_idx = [0, 1, 2, 5, 6, 9, 10]  # 3, 4 are private, 9, 10 dynamic since running, others fixed < 30
+        expect_jobs = [self.job_info[i].id for i in expect_idx]
+        self.assert_equal_with_jobs_diffs(result_jobs, expect_jobs, test)
+
+        test = {"maxDuration": 49}
+        path = get_path_kvp(sd.jobs_service.path, **test)
+        resp = self.app.get(path, headers=self.json_headers)
+        assert resp.status_code == 200
+        result_jobs = resp.json["jobs"]
+        expect_idx = [0, 1, 2, 5, 6, 7, 9, 10]  # everything except 3, 4 that are private, and 8 that is == 50
+        expect_jobs = [self.job_info[i].id for i in expect_idx]
+        self.assert_equal_with_jobs_diffs(result_jobs, expect_jobs, test)
 
     def test_get_jobs_duration_min_max(self):
-        path = get_path_kvp(sd.jobs_service.path, minDuration=19, maxDuration=31)
+        # note: avoid range <35s for this test to avoid sudden dynamic duration of 9, 10 becoming within min/max
+        test = {"minDuration": 35, "maxDuration": 60}
+        path = get_path_kvp(sd.jobs_service.path, **test)
         resp = self.app.get(path, headers=self.json_headers)
         assert resp.status_code == 200
         result_jobs = resp.json["jobs"]
-        expect_jobs = [self.job_info[i].id for i in [5, 6, 9, 10]]
-        assert len(result_jobs) == len(expect_jobs)
-        assert all(job in expect_jobs for job in result_jobs)
+        expect_jobs = [self.job_info[i].id for i in [7, 8]]
+        self.assert_equal_with_jobs_diffs(result_jobs, expect_jobs, test)
 
-        path = get_path_kvp(sd.jobs_service.path, minDuration=23, maxDuration=28)
+        test = {"minDuration": 38, "maxDuration": 42}
+        path = get_path_kvp(sd.jobs_service.path, **test)
         resp = self.app.get(path, headers=self.json_headers)
         assert resp.status_code == 200
         result_jobs = resp.json["jobs"]
-        expect_jobs = [self.job_info[i].id for i in [10]]
-        assert len(result_jobs) == len(expect_jobs)
-        assert all(job in expect_jobs for job in result_jobs)
+        expect_jobs = [self.job_info[i].id for i in [7]]
+        self.assert_equal_with_jobs_diffs(result_jobs, expect_jobs, test)
 
-        path = get_path_kvp(sd.jobs_service.path, minDuration=35, maxDuration=37)
+        test = {"minDuration": 35, "maxDuration": 37}
+        path = get_path_kvp(sd.jobs_service.path, **test)
         resp = self.app.get(path, headers=self.json_headers)
         assert resp.status_code == 200
         result_jobs = resp.json["jobs"]
         assert len(result_jobs) == 0
 
     def test_get_jobs_duration_min_max_invalid(self):
-        path = get_path_kvp(sd.jobs_service.path, minDuration=19, maxDuration=31)
+        test = {"minDuration": 30, "maxDuration": 20}
+        path = get_path_kvp(sd.jobs_service.path, **test)
         resp = self.app.get(path, headers=self.json_headers, expect_errors=True)
-        assert resp.status_code == 200
-        result_jobs = resp.json["jobs"]
-        expect_jobs = [self.job_info[i].id for i in [5, 6, 9, 10]]
-        assert len(result_jobs) == len(expect_jobs)
-        assert all(job in expect_jobs for job in result_jobs)
+        assert resp.status_code in [400, 422]
+
+        test = {"minDuration": -1}
+        path = get_path_kvp(sd.jobs_service.path, **test)
+        resp = self.app.get(path, headers=self.json_headers, expect_errors=True)
+        assert resp.status_code in [400, 422]
+
+        test = {"maxDuration": -20}
+        path = get_path_kvp(sd.jobs_service.path, **test)
+        resp = self.app.get(path, headers=self.json_headers, expect_errors=True)
+        assert resp.status_code in [400, 422]
+
+        test = {"minDuration": -10, "maxDuration": 10}
+        path = get_path_kvp(sd.jobs_service.path, **test)
+        resp = self.app.get(path, headers=self.json_headers, expect_errors=True)
+        assert resp.status_code in [400, 422]
 
     def test_get_jobs_by_status_single(self):
-        path = get_path_kvp(sd.jobs_service.path, status=STATUS_SUCCEEDED)
+        test = {"status": STATUS_SUCCEEDED}
+        path = get_path_kvp(sd.jobs_service.path, **test)
         resp = self.app.get(path, headers=self.json_headers)
         assert resp.status_code == 200
         result_jobs = resp.json["jobs"]
-        assert len(result_jobs) == 1
-        assert result_jobs[0] == self.job_info[0].id
+        expect_jobs = [self.job_info[0].id]
+        self.assert_equal_with_jobs_diffs(result_jobs, expect_jobs, test)
 
-        path = get_path_kvp(sd.jobs_service.path, status=STATUS_FAILED)
+        test = {"status": STATUS_FAILED}
+        path = get_path_kvp(sd.jobs_service.path, **test)
         resp = self.app.get(path, headers=self.json_headers)
         assert resp.status_code == 200
         expect_jobs = [self.job_info[i].id for i in [1, 2, 5, 6, 7, 8]]  # 8 total, but only 6 visible
         result_jobs = resp.json["jobs"]
-        assert len(result_jobs) == len(expect_jobs)
-        assert all(job in expect_jobs for job in result_jobs)
+        self.assert_equal_with_jobs_diffs(result_jobs, expect_jobs, test)
 
     @pytest.mark.xfail(reason="Multiple statuses not supported")  # FIXME: support comma-separated list of statuses
     def test_get_jobs_by_status_multi(self):
-        path = get_path_kvp(sd.jobs_service.path, status="{},{}".format(STATUS_SUCCEEDED, STATUS_RUNNING))
+        test = {"status": "{},{}".format(STATUS_SUCCEEDED, STATUS_RUNNING)}
+        path = get_path_kvp(sd.jobs_service.path, **test)
         resp = self.app.get(path, headers=self.json_headers)
         assert resp.status_code == 200
         result_jobs = resp.json["jobs"]
         expect_jobs = [self.job_info[i].id for i in [0, 9, 10]]
-        assert len(result_jobs) == 3
-        assert all(job in expect_jobs for job in result_jobs)
+        self.assert_equal_with_jobs_diffs(result_jobs, expect_jobs, test)
 
     def test_get_jobs_by_status_invalid(self):
         path = get_path_kvp(sd.jobs_service.path, status="random")

--- a/tests/wps_restapi/test_jobs.py
+++ b/tests/wps_restapi/test_jobs.py
@@ -1,6 +1,5 @@
-import datetime
-
 import contextlib
+import datetime
 import json
 import unittest
 import warnings

--- a/tests/wps_restapi/test_jobs.py
+++ b/tests/wps_restapi/test_jobs.py
@@ -139,7 +139,7 @@ class WpsRestApiJobsTest(unittest.TestCase):
                                       user_id=user_id, execute_async=True, access=access, created=created)
         job.status = status
         if status in JOB_STATUS_CATEGORIES[JOB_STATUS_CATEGORY_FINISHED]:
-            job["finished"] = created + datetime.timedelta(seconds=duration if duration else 10)
+            job["finished"] = job.created + datetime.timedelta(seconds=duration if duration else 10)
         job.progress = progress
         job = self.job_store.update_job(job)
         self.job_info.append(job)

--- a/weaver/datatype.py
+++ b/weaver/datatype.py
@@ -798,7 +798,7 @@ class Job(Base):
                 updated = self.finished
             else:
                 updated = self.started
-            updated = updated or now()
+            updated = localize_datetime(updated or now())
             self.updated = updated  # apply to remain static until saved
         return localize_datetime(updated)
 

--- a/weaver/store/base.py
+++ b/weaver/store/base.py
@@ -7,12 +7,11 @@ if TYPE_CHECKING:
     from pyramid.request import Request
     from pywps import Process as ProcessWPS
     from weaver.datatype import Bill, Job, Process, Quote, Service
-    from weaver.typedefs import AnyValue, DatetimeIntervalType, TypedDict
+    from weaver.typedefs import DatetimeIntervalType, TypedDict
 
-    JobListAndCount = Tuple[List[Job], int]
     JobGroupCategory = TypedDict("JobGroupCategory",
                                  {"category": Dict[str, Optional[str]], "count": int, "jobs": List[Job]})
-    JobCategoriesAndCount = Tuple[List[JobGroupCategory], int]
+    JobSearchResult = Tuple[Union[List[Job], JobGroupCategory], int]
 
 
 class StoreInterface(object, metaclass=abc.ABCMeta):

--- a/weaver/store/base.py
+++ b/weaver/store/base.py
@@ -153,7 +153,7 @@ class StoreJobs(StoreInterface):
                   datetime_interval=None,   # type: Optional[DatetimeIntervalType]
                   group_by=None,            # type: Optional[Union[str, List[str]]]
                   request=None,             # type: Optional[Request]
-                  ):                        # type: (...) -> Union[JobListAndCount, JobCategoriesAndCount]
+                  ):                        # type: (...) -> JobSearchResult
         raise NotImplementedError
 
     @abc.abstractmethod

--- a/weaver/store/base.py
+++ b/weaver/store/base.py
@@ -141,7 +141,7 @@ class StoreJobs(StoreInterface):
     def find_jobs(self,
                   process=None,             # type: Optional[str]
                   service=None,             # type: Optional[str]
-                  type=None,                # type: Optional[str]
+                  job_type=None,            # type: Optional[str]
                   tags=None,                # type: Optional[List[str]]
                   access=None,              # type: Optional[str]
                   notification_email=None,  # type: Optional[str]
@@ -151,7 +151,7 @@ class StoreJobs(StoreInterface):
                   limit=10,                 # type: int
                   min_duration=None,        # type: Optional[int]
                   max_duration=None,        # type: Optional[int]
-                  datetime=None,            # type: Optional[DatetimeIntervalType]
+                  datetime_interval=None,   # type: Optional[DatetimeIntervalType]
                   group_by=None,            # type: Optional[Union[str, List[str]]]
                   request=None,             # type: Optional[Request]
                   ):                        # type: (...) -> Union[JobListAndCount, JobCategoriesAndCount]

--- a/weaver/store/base.py
+++ b/weaver/store/base.py
@@ -149,6 +149,8 @@ class StoreJobs(StoreInterface):
                   sort=None,                # type: Optional[str]
                   page=0,                   # type: int
                   limit=10,                 # type: int
+                  min_duration=None,        # type: Optional[int]
+                  max_duration=None,        # type: Optional[int]
                   datetime=None,            # type: Optional[DatetimeIntervalType]
                   group_by=None,            # type: Optional[Union[str, List[str]]]
                   request=None,             # type: Optional[Request]

--- a/weaver/store/mongodb.py
+++ b/weaver/store/mongodb.py
@@ -727,7 +727,7 @@ class MongodbJobStore(StoreJobs, MongodbStore):
         if not request:
             search_filters["access"] = VISIBILITY_PUBLIC
         else:
-            if request.has_permission("admin"):
+            if request.authenticated_userid is not None and request.has_permission("admin"):
                 if access in VISIBILITY_VALUES:  # otherwise any
                     search_filters["access"] = access
             else:

--- a/weaver/store/mongodb.py
+++ b/weaver/store/mongodb.py
@@ -663,7 +663,7 @@ class MongodbJobStore(StoreJobs, MongodbStore):
             for group_result in items:
                 group_service = group_result["category"].pop("service", None)
                 group_result["category"]["provider"] = group_service
-        total = found[0]["totalPipeline"][0]["total"]
+        total = found[0]["totalPipeline"][0]["total"] if items else 0
         return items, total
 
     def _find_jobs_paging(self, pipeline, page, limit):
@@ -677,7 +677,7 @@ class MongodbJobStore(StoreJobs, MongodbStore):
 
         found = list(self.collection.aggregate(pipeline))
         items = [Job(item) for item in found[0]["itemsPipeline"]]
-        total = found[0]["totalPipeline"][0]["total"]
+        total = found[0]["totalPipeline"][0]["total"] if items else 0
         return items, total
 
     @staticmethod

--- a/weaver/store/mongodb.py
+++ b/weaver/store/mongodb.py
@@ -44,7 +44,7 @@ from weaver.sort import (
 )
 from weaver.status import JOB_STATUS_CATEGORIES, STATUS_ACCEPTED, map_status
 from weaver.store.base import StoreBills, StoreJobs, StoreProcesses, StoreQuotes, StoreServices
-from weaver.utils import get_base_url, get_sane_name, get_weaver_url, repr_json, islambda, now
+from weaver.utils import get_base_url, get_sane_name, get_weaver_url, islambda, now, repr_json
 from weaver.visibility import VISIBILITY_PRIVATE, VISIBILITY_PUBLIC, VISIBILITY_VALUES
 from weaver.wps.utils import get_wps_url
 

--- a/weaver/store/mongodb.py
+++ b/weaver/store/mongodb.py
@@ -691,9 +691,9 @@ class MongodbJobStore(StoreJobs, MongodbStore):
         # minimal operation, only search for matches and sort them
         pipeline = [{"$match": search_filters}, {"$sort": sort_criteria}]
 
-        duration_filter = {}
-        # if min_duration is not None or max_duration is not None:
-        if duration_filter:
+        if min_duration is not None or max_duration is not None:
+            duration_filter = {}
+
             pipeline.append(duration_filter)
 
         # results by group categories

--- a/weaver/store/mongodb.py
+++ b/weaver/store/mongodb.py
@@ -554,6 +554,8 @@ class MongodbJobStore(StoreJobs, MongodbStore):
                   sort=None,                # type: Optional[str]
                   page=0,                   # type: int
                   limit=10,                 # type: int
+                  min_duration=None,        # type: Optional[int]
+                  max_duration=None,        # type: Optional[int]
                   datetime=None,            # type: Optional[DatetimeIntervalType]
                   group_by=None,            # type: Optional[Union[str, List[str]]]
                   request=None,             # type: Optional[Request]
@@ -596,6 +598,8 @@ class MongodbJobStore(StoreJobs, MongodbStore):
         :param sort: field which is used for sorting results (default: creation date, descending).
         :param page: page number to return when using result paging (only when not using ``group_by``).
         :param limit: number of jobs per page when using result paging (only when not using ``group_by``).
+        :param min_duration: minimal duration (seconds) between started time and current/finished time of jobs to find.
+        :param max_duration: maximum duration (seconds) between started time and current/finished time of jobs to find.
         :param datetime: field used for filtering data by creation date with a given date or interval of date.
         :param group_by: one or many fields specifying categories to form matching groups of jobs (paging disabled).
         :returns: (list of jobs matching paging OR list of {categories, list of jobs, count}) AND total of matched job.
@@ -686,6 +690,11 @@ class MongodbJobStore(StoreJobs, MongodbStore):
 
         # minimal operation, only search for matches and sort them
         pipeline = [{"$match": search_filters}, {"$sort": sort_criteria}]
+
+        duration_filter = {}
+        # if min_duration is not None or max_duration is not None:
+        if duration_filter:
+            pipeline.append(duration_filter)
 
         # results by group categories
         if group_by:

--- a/weaver/utils.py
+++ b/weaver/utils.py
@@ -306,8 +306,8 @@ def now_secs():
     return int(time.time())
 
 
-def repr_json(data, **kwargs):
-    # type: (Any, Any) -> Union[JSON, str, None]
+def repr_json(data, force_str=True, **kwargs):
+    # type: (Any, bool, Any) -> Union[JSON, str, None]
     """
     Ensure that the input data can be serialized as JSON to return it formatted representation as such.
 
@@ -316,7 +316,8 @@ def repr_json(data, **kwargs):
     if data is None:
         return None
     try:
-        return json.dumps(data, **kwargs)
+        data_str = json.dumps(data, **kwargs)
+        return data_str if force_str else data
     except Exception:  # noqa: W0703 # nosec: B110
         return str(data)
 

--- a/weaver/utils.py
+++ b/weaver/utils.py
@@ -1,6 +1,7 @@
 import errno
 import functools
 import inspect
+import json
 import logging
 import os
 import re
@@ -303,6 +304,21 @@ def now_secs():
     Return the current time in seconds since the Epoch.
     """
     return int(time.time())
+
+
+def repr_json(data, **kwargs):
+    # type: (Any, Any) -> Union[JSON, str, None]
+    """
+    Ensure that the input data can be serialized as JSON to return it formatted representation as such.
+
+    If formatting as JSON fails, returns the data as string representation or ``None`` accordingly.
+    """
+    if data is None:
+        return None
+    try:
+        return json.dumps(data, **kwargs)
+    except Exception:  # noqa: W0703 # nosec: B110
+        return str(data)
 
 
 def wait_secs(run_step=-1):

--- a/weaver/wps_restapi/jobs/jobs.py
+++ b/weaver/wps_restapi/jobs/jobs.py
@@ -341,6 +341,7 @@ def get_queried_jobs(request):
     filters["service"] = filters.pop("provider", None)
     filters["min_duration"] = filters.pop("minDuration", None)
     filters["max_duration"] = filters.pop("maxDuration", None)
+    filters["job_type"] = filters.pop("type", None)
 
     dti = datetime_interval_parser(filters["datetime"]) if filters.get("datetime", False) else None
     if dti and dti.get("before", False) and dti.get("after", False) and dti["after"] > dti["before"]:

--- a/weaver/wps_restapi/swagger_definitions.py
+++ b/weaver/wps_restapi/swagger_definitions.py
@@ -3511,6 +3511,12 @@ class GetJobsQueries(ExtendedMappingSchema):
                                 default=False, example="process,service", missing=drop)
     page = ExtendedSchemaNode(Integer(allow_string=True), missing=0, default=0, validator=Range(min=0))
     limit = ExtendedSchemaNode(Integer(allow_string=True), missing=10, default=10, validator=Range(min=0, max=10000))
+    min_duration = ExtendedSchemaNode(
+        Integer(allow_string=True), missing=drop, default=null, validator=Range(min=0),
+        description="Minimal duration (seconds) between started time and current/finished time of jobs to find.")
+    max_duration = ExtendedSchemaNode(
+        Integer(allow_string=True), missing=drop, default=null, validator=Range(min=0),
+        description="Maximum duration (seconds) between started time and current/finished time of jobs to find.")
     datetime = DateTimeInterval(missing=drop, default=None)
     status = JobStatusEnum(missing=drop, default=None)
     processID = ProcessIdentifier(missing=drop, default=null, description="Alias to 'process' for OGC-API compliance.")

--- a/weaver/wps_restapi/swagger_definitions.py
+++ b/weaver/wps_restapi/swagger_definitions.py
@@ -3512,10 +3512,10 @@ class GetJobsQueries(ExtendedMappingSchema):
     page = ExtendedSchemaNode(Integer(allow_string=True), missing=0, default=0, validator=Range(min=0))
     limit = ExtendedSchemaNode(Integer(allow_string=True), missing=10, default=10, validator=Range(min=0, max=10000))
     min_duration = ExtendedSchemaNode(
-        Integer(allow_string=True), missing=drop, default=null, validator=Range(min=0),
+        Integer(allow_string=True), name="minDuration", missing=drop, default=null, validator=Range(min=0),
         description="Minimal duration (seconds) between started time and current/finished time of jobs to find.")
     max_duration = ExtendedSchemaNode(
-        Integer(allow_string=True), missing=drop, default=null, validator=Range(min=0),
+        Integer(allow_string=True), name="maxDuration", missing=drop, default=null, validator=Range(min=0),
         description="Maximum duration (seconds) between started time and current/finished time of jobs to find.")
     datetime = DateTimeInterval(missing=drop, default=None)
     status = JobStatusEnum(missing=drop, default=None)


### PR DESCRIPTION
# Changes

- resolve #268 
- enforce `mongo==5.0` to used improved search
- improve job search function by separating filters into distinct methods and extendable pipeline 

Depends on https://github.com/crim-ca/weaver/pull/355 for part of the job search refactoring