### PR TITLE
fix typings

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -326,7 +326,7 @@ def mocked_file_response(path, url):
 
 
 def mocked_sub_requests(app, function, *args, only_local=False, **kwargs):
-    # type: (TestApp, str, *Any, bool, **Any) -> AnyResponseType
+    # type: (TestApp, str, Any, bool, Any) -> AnyResponseType
     """
     Mocks request calls under :class:`webTest.TestApp` to avoid sending real requests.
 

--- a/weaver/database/base.py
+++ b/weaver/database/base.py
@@ -36,27 +36,27 @@ class DatabaseInterface(metaclass=abc.ABCMeta):
 
     @overload
     def get_store(self, store_type, *store_args, **store_kwargs):
-        # type: (Type[StoreBills], *Any, **Any) -> StoreBills
+        # type: (Type[StoreBills], Any, Any) -> StoreBills
         ...
 
     @overload
     def get_store(self, store_type, *store_args, **store_kwargs):
-        # type: (Type[StoreQuotes], *Any, **Any) -> StoreQuotes
+        # type: (Type[StoreQuotes], Any, Any) -> StoreQuotes
         ...
 
     @overload
     def get_store(self, store_type, *store_args, **store_kwargs):
-        # type: (Type[StoreJobs], *Any, **Any) -> StoreJobs
+        # type: (Type[StoreJobs], Any, Any) -> StoreJobs
         ...
 
     @overload
     def get_store(self, store_type, *store_args, **store_kwargs):
-        # type: (Type[StoreProcesses], *Any, **Any) -> StoreProcesses
+        # type: (Type[StoreProcesses], Any, Any) -> StoreProcesses
         ...
 
     @overload
     def get_store(self, store_type, *store_args, **store_kwargs):
-        # type: (Type[StoreServices], *Any, **Any) -> StoreServices
+        # type: (Type[StoreServices], Any, Any) -> StoreServices
         ...
 
     @abc.abstractmethod

--- a/weaver/database/mongodb.py
+++ b/weaver/database/mongodb.py
@@ -68,31 +68,31 @@ class MongoDatabase(DatabaseInterface):
 
     @overload
     def get_store(self, store_type, *store_args, **store_kwargs):
-        # type: (Type[StoreBills], *Any, **Any) -> MongodbBillStore
+        # type: (Type[StoreBills], Any, Any) -> MongodbBillStore
         ...
 
     @overload
     def get_store(self, store_type, *store_args, **store_kwargs):
-        # type: (Type[StoreQuotes], *Any, **Any) -> MongodbQuoteStore
+        # type: (Type[StoreQuotes], Any, Any) -> MongodbQuoteStore
         ...
 
     @overload
     def get_store(self, store_type, *store_args, **store_kwargs):
-        # type: (Type[StoreJobs], *Any, **Any) -> MongodbJobStore
+        # type: (Type[StoreJobs], Any, Any) -> MongodbJobStore
         ...
 
     @overload
     def get_store(self, store_type, *store_args, **store_kwargs):
-        # type: (Type[StoreProcesses], *Any, **Any) -> MongodbProcessStore
+        # type: (Type[StoreProcesses], Any, Any) -> MongodbProcessStore
         ...
 
     @overload
     def get_store(self, store_type, *store_args, **store_kwargs):
-        # type: (Type[StoreServices], *Any, **Any) -> MongodbServiceStore
+        # type: (Type[StoreServices], Any, Any) -> MongodbServiceStore
         ...
 
     def get_store(self, store_type, *store_args, **store_kwargs):
-        # type: (Union[str, Type[StoreInterface], AnyMongodbStoreType], *Any, **Any) -> AnyMongodbStore
+        # type: (Union[str, Type[StoreInterface], AnyMongodbStoreType], Any, Any) -> AnyMongodbStore
         """
         Retrieve a store from the database.
 

--- a/weaver/datatype.py
+++ b/weaver/datatype.py
@@ -1526,7 +1526,7 @@ class Process(Base):
 
     @staticmethod
     def from_wps(wps_process, **extra_params):
-        # type: (ProcessWPS, **Any) -> Process
+        # type: (ProcessWPS, Any) -> Process
         """
         Converts a :mod:`pywps` Process into a :class:`weaver.datatype.Process` using provided parameters.
         """

--- a/weaver/processes/builtin/__init__.py
+++ b/weaver/processes/builtin/__init__.py
@@ -170,7 +170,7 @@ class BuiltinProcessJobBase(CommandLineJob):
 
     # pylint: disable=W0221,arguments-differ    # naming using python like arguments
     def run(self, runtime_context, **kwargs):
-        # type: (RuntimeContext, **Any) -> None
+        # type: (RuntimeContext, Any) -> None
         try:
             self._validate_process()
             super(BuiltinProcessJobBase, self).run(runtime_context, **kwargs)

--- a/weaver/store/mongodb.py
+++ b/weaver/store/mongodb.py
@@ -78,7 +78,7 @@ class MongodbStore(object):
 
     @classmethod
     def get_args_kwargs(cls, *args, **kwargs):
-        # type: (*Any, **Any) -> Tuple[Tuple, Dict]
+        # type: (Any, Any) -> Tuple[Tuple, Dict]
         """
         Filters :class:`MongodbStore`-specific arguments to safely pass them down its ``__init__``.
         """

--- a/weaver/utils.py
+++ b/weaver/utils.py
@@ -964,7 +964,7 @@ def request_extra(method,                       # type: str
 
 
 def fetch_file(file_reference, file_outdir, settings=None, **request_kwargs):
-    # type: (str, str, Optional[AnySettingsContainer], **Any) -> str
+    # type: (str, str, Optional[AnySettingsContainer], Any) -> str
     """
     Fetches a file from local path, AWS-S3 bucket or remote URL, and dumps it's content to the output directory.
 


### PR DESCRIPTION
Fix incorrect use of `*` characters in typing that are supposed to refer to "one of the values" args and kwargs can take.