### PR TITLE
add pyup ignore celery in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ billiard; sys_platform != "win32"
 billiard>3.2,<3.4; sys_platform == "win32"
 # celery 5 to be released in near future
 # celery >=4.4.3 breaks on 'future.utils' import
-celery[mongodb]==4.4.2; sys_platform != "win32"
+celery[mongodb]==4.4.2; sys_platform != "win32"  # pyup: ignore
 celery[mongodb]<4; sys_platform == "win32"
 cffi
 colander


### PR DESCRIPTION
pyup flags `celery` as out of date (#366)

While it is true, the corresponding tests in that PR are all failing due to missing package version `5.2.x`.

Since this is not critical, temporarily mark it as ignored to avoid recurrent issues from pyup and runners to test for nothing. 
This can be addressed at a later date when more critical component of `celery` are updated, such as in #348 