### PR TITLE
Fix file content disposition

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,11 +24,18 @@ Changes:
   relates to `#281 <https://github.com/crim-ca/weaver/issues/281>`_).
 - Add missing documentation details about `Data Source` and connect chapters with other relevant
   documentation details and updated ``Workflow`` tests.
+- Add handling of ``Content-Disposition`` header providing preferred ``filename`` or ``filename*`` parameters when
+  fetching file references instead of the last URL fragment employed by default
+  (resolves `#364 <https://github.com/crim-ca/weaver/issues/364>`_).
+- Add more security validation of the obtained file name from HTTP reference, whether generated from URL path fragment
+  or other header specification.
 
 Fixes:
 ------
 - Fix incorrect resolution of ``Process`` results endpoint to pass contents from one step to another
   during ``Workflow`` execution (resolves `#358 <https://github.com/crim-ca/weaver/issues/358>`_).
+- Fix logic of remotely and locally executed applications based on `CWL` requirements when attempting to resolve
+  whether an input file reference should be fetched.
 
 `4.3.0 <https://github.com/crim-ca/weaver/tree/4.3.0>`_ (2021-11-16)
 ========================================================================

--- a/docs/source/processes.rst
+++ b/docs/source/processes.rst
@@ -474,7 +474,7 @@ File Reference Types
 
 Most inputs can be categorized into two of the most commonly employed types, namely ``LiteralData`` and ``ComplexData``.
 The former represents basic values such as integers or strings, while the other represents a file reference.
-Files in `Weaver` (and :term:`WPS` in general) can be specified with any ``formats`` as MIME-type.
+Files in `Weaver` (and :term:`WPS` in general) can be specified with any ``formats`` as |media-types|_.
 
 .. seealso::
     - :ref:`cwl-wps-mapping`
@@ -499,18 +499,18 @@ package requirements. These use-cases are described below.
     operation that `Weaver` uses to provide the file locally to underlying :term:`CWL` application package to be
     executed.
 
-When `Weaver` is able to figure out that the process needs to be executed locally in :term:`ADES` mode, it will fetch
-all necessary files prior to process execution in order to make them available to the :term:`CWL` package. When `Weaver`
-is in :term:`EMS` configuration, it will **always** forward remote references (regardless of scheme) exactly as provided
-as input of the process execution request, since it assumes it needs to dispatch the execution to another :term:`ADES`
-remote server, and therefore only needs to verify that the file reference is reachable remotely. In this case, it
-becomes the responsibility of this remote instance to handle the reference appropriately. This also avoids potential
-problems such as if `Weaver` as :term:`EMS` doesn't have authorized access to a link that only the target :term:`ADES`
-would have access to.
+When `Weaver` is able to figure out that the :term:`Process` needs to be executed locally in :term:`ADES` mode, it
+will fetch all necessary files prior to process execution in order to make them available to the :term:`CWL` package.
+When `Weaver` is in :term:`EMS` configuration, it will **always** forward remote references (regardless of scheme)
+exactly as provided as input of the process execution request, since it assumes it needs to dispatch the execution
+to another :term:`ADES` remote server, and therefore only needs to verify that the file reference is reachable remotely.
+In this case, it becomes the responsibility of this remote instance to handle the reference appropriately. This also
+avoids potential problems such as if `Weaver` as :term:`EMS` doesn't have authorized access to a link that only the
+target :term:`ADES` would have access to.
 
 When :term:`CWL` package defines ``WPS1Requirement`` under ``hints`` for corresponding `WPS-1/2`_ remote processes being
 monitored by `Weaver`, it will skip fetching of ``http(s)``-based references since that would otherwise lead to useless
-double downloads (one on `Weaver` and the other on the :term:`WPS` side). It is the same in case of
+double downloads (one on `Weaver` and the other on the :term:`WPS` side). It is the same in situation for
 ``ESGF-CWTRequirement`` employed for `ESGF-CWT`_ processes. Because these processes do not always support :term:`S3`
 buckets, and because `Weaver` supports many variants of :term:`S3` reference formats, it will first fetch the :term:`S3`
 reference using its internal |aws-config|_, and then expose this downloaded file as ``https(s)`` reference
@@ -638,6 +638,31 @@ combinations.
 .. todo::
     add tests that validate each combination of operation
 
+.. _file_reference_names:
+
+File Reference Names
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When processing any of the previous :ref:`file_reference_types`, the resulting name of the file after retrieval can
+depend on the applicable scheme. In most cases, the file name is simply the last fragment of the path, whether it is
+an URL, an :term:`S3` bucket or plainly a file directory path. The following cases are exceptions.
+
+.. versionchanged:: 4.4.0
+    When using |http_scheme| references, the ``Content-Disposition`` header can be provided with ``filename``
+    and/or ``filename*`` as specified by :rfc:`2183`, :rfc:`5987` and :rfc:`6266` specifications in order to define a
+    staging file name. Note that `Weaver` takes this name only as a suggestion as will ignore the preferred name if it
+    does not conform to basic naming conventions for security reasons. As a general rule of thumb, common alphanumeric
+    characters and separators such as dash (``-``), underscores (``_``) or dots (``.``) should be employed to limit
+    chances of errors. If none of the suggested names are valid, `Weaver` falls back to the typical last fragment of
+    the URL as file name.
+
+When using |s3_scheme| references (or equivalent |http_scheme| referring to :term:`S3` bucket), the staged file names
+will depend on the stored object names within the bucket. In that regard, naming conventions from :term:`AWS` should be
+respected.
+
+.. seealso::
+    - |aws_s3_bucket_names|_
+    - |aws_s3_obj_key_names|_
 
 .. _opensearch_data_source:
 

--- a/docs/source/references.rst
+++ b/docs/source/references.rst
@@ -7,6 +7,10 @@
 .. _aws-credentials: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html
 .. |aws-config| replace:: AWS Configuration
 .. _aws-config: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html
+.. |aws_s3_bucket_names| replace:: AWS S3 bucket naming rules
+.. _aws_s3_bucket_names: https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
+.. |aws_s3_obj_key_names| replace:: AWS S3 object key naming guidelines
+.. _aws_s3_obj_key_names: https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html
 .. |cwl| replace:: Common Workflow Language
 .. _cwl: `cwl-home`_
 .. |cwl-home| replace:: CWL Homepage
@@ -81,6 +85,8 @@
 .. _MongoDB: https://www.mongodb.com/
 .. |mongodb-docs| replace:: MongoDB official documentation
 .. _mongodb-docs: https://docs.mongodb.com/manual
+.. |media-types| replace Media Types
+.. _media-types: https://www.iana.org/assignments/media-types/media-types.xhtml
 
 .. Weaver Configurations
 .. |weaver-config| replace:: ``weaver/config``

--- a/docs/source/references.rst
+++ b/docs/source/references.rst
@@ -85,7 +85,7 @@
 .. _MongoDB: https://www.mongodb.com/
 .. |mongodb-docs| replace:: MongoDB official documentation
 .. _mongodb-docs: https://docs.mongodb.com/manual
-.. |media-types| replace Media Types
+.. |media-types| replace:: Media Types
 .. _media-types: https://www.iana.org/assignments/media-types/media-types.xhtml
 
 .. Weaver Configurations

--- a/tests/functional/test_wps_package.py
+++ b/tests/functional/test_wps_package.py
@@ -12,7 +12,6 @@ import json
 import logging
 import os
 import tempfile
-import uuid
 from copy import deepcopy
 from inspect import cleandoc
 from typing import TYPE_CHECKING
@@ -1656,7 +1655,7 @@ class WpsPackageAppTest(WpsConfigBase):
             assert tmp_name_target in out_data and tmp_name_random not in out_data, (
                 "Expected input file fetched and staged with Content-Disposition preferred filename "
                 "to be printed into the output log file. Expected name was not found.\n"
-                f"Expected: [{tmp_name_target}]\n" 
+                f"Expected: [{tmp_name_target}]\n"
                 f"Original: [{tmp_name_random}]"
             )
 

--- a/tests/functional/test_wps_package.py
+++ b/tests/functional/test_wps_package.py
@@ -1339,8 +1339,9 @@ class WpsPackageAppTest(WpsConfigBase):
 
         test_http_ref = mocked_reference_test_file(
             "input_file_http.txt",
-            MOCK_HTTP_REF,  # converted to HTTP
-            "This is a generated file for http test"
+            "http",
+            "This is a generated file for http test",
+            MOCK_HTTP_REF  # hosted under mock endpoint to avoid missing location when fetching file
         )
 
         test_file_ref = mocked_reference_test_file(

--- a/tests/functional/test_wps_package.py
+++ b/tests/functional/test_wps_package.py
@@ -7,13 +7,12 @@ Local test web application is employed to run operations by mocking external req
 .. seealso::
     - :mod:`tests.processes.wps_package`.
 """
-import uuid
-
 import contextlib
 import json
 import logging
 import os
 import tempfile
+import uuid
 from copy import deepcopy
 from inspect import cleandoc
 from typing import TYPE_CHECKING

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
 # pylint: disable=C0103,invalid-name
+
 import contextlib
 import inspect
 import json
@@ -7,10 +8,11 @@ import shutil
 import tempfile
 import uuid
 from typing import Type
-from urllib.parse import urlparse
+from urllib.parse import urlparse, quote
 
 import mock
 import pytest
+import responses
 from pyramid.httpexceptions import (
     HTTPConflict,
     HTTPCreated,
@@ -26,6 +28,7 @@ from requests.exceptions import HTTPError as RequestsHTTPError
 
 from tests.utils import mocked_aws_credentials, mocked_aws_s3, mocked_aws_s3_bucket_test_file, mocked_file_response
 from weaver import status, xml_util
+from weaver.formats import CONTENT_TYPE_APP_JSON
 from weaver.utils import (
     NullType,
     assert_sane_name,
@@ -605,6 +608,87 @@ def test_fetch_file_remote_with_request():
             assert os.path.isfile(res_path), "File [{}] should be accessible under [{}]".format(tmp_http, res_path)
             assert m_request.call_count == 2, "Request method should have been called twice because of retries"
             assert json.load(open(res_path)) == tmp_data, "File should be properly generated from HTTP reference"
+        except Exception:
+            raise
+        finally:
+            shutil.rmtree(res_dir, ignore_errors=True)
+
+
+def test_fetch_file_http_content_disposition_filename():
+    tmp_dir = tempfile.gettempdir()
+    with contextlib.ExitStack() as stack:
+        tmp_json = stack.enter_context(tempfile.NamedTemporaryFile(dir=tmp_dir, mode="w", suffix=".json"))  # noqa
+        tmp_data = {"message": "fetch-file-request"}
+        tmp_text = json.dumps(tmp_data)
+        tmp_json.write(tmp_text)
+        tmp_json.seek(0)
+
+        tmp_random = "123456"
+        tmp_normal = "spécial.json"
+        tmp_escape = quote(tmp_normal)  # % characters
+        tmp_name = os.path.split(tmp_json.name)[-1]
+        tmp_http = "http://weaver.mock/{}".format(tmp_random)  # pseudo endpoint where file name is not directly visible
+
+        def mock_response(__request, test_headers):
+            test_headers.update({
+                "Content-Type": CONTENT_TYPE_APP_JSON,
+                "Content-Length": str(len(tmp_text))
+            })
+            return 200, headers, tmp_text
+
+        res_dir = os.path.join(tmp_dir, str(uuid.uuid4()))
+        req_mock = stack.enter_context(responses.RequestsMock())
+        try:
+            make_dirs(res_dir, exist_ok=True)
+            for target, headers in [
+                (tmp_name, {
+                    "Content-Disposition": f"attachment; filename=\"{tmp_name}\";filename*=UTF-8''{tmp_name}"
+                }),
+                (tmp_name, {  # unusual spacing/order does not matter
+                    "Content-Disposition": f" filename*=UTF-8''{tmp_name};   filename=\"{tmp_name}\";attachment;"
+                }),
+                (tmp_name, {
+                    "Content-Disposition": f"attachment; filename=\"{tmp_name}\""
+                }),
+                (tmp_name, {
+                    "Content-Disposition": f"attachment; filename={tmp_name}"
+                }),
+                (tmp_normal, {
+                    "Content-Disposition": f"attachment; filename=\"{tmp_normal}\";filename*=UTF-8''{tmp_escape}"
+                }),
+                (tmp_normal, {  # disallowed escape character in 'filename', but 'filename*' is valid and used first
+                    "Content-Disposition": f"attachment; filename=\"{tmp_escape}\";filename*=UTF-8''{tmp_normal}"
+                }),
+                (tmp_random, {  # disallowed escape character in 'filename', reject since no alternative
+                    "Content-Disposition": f"attachment; filename=\"{tmp_escape}\""
+                }),
+                (tmp_random, {  # empty header
+                    "Content-Disposition": ""
+                }),
+                (tmp_random, {  # missing header
+                }),
+                (tmp_random, {  # missing filename
+                    "Content-Disposition": "attachment"
+                }),
+                (tmp_random, {  # invalid filename
+                    "Content-Disposition": "attachment; filename*=UTF-8''exec%20'echo%20test'"
+                }),
+                (tmp_random, {  # invalid encoding
+                    "Content-Disposition": "attachment; filename*=random''%47%4F%4F%44.json"
+                }),
+                ("GOOD.json", {  # valid encoding and allowed characters after escape
+                    "Content-Disposition": "attachment; filename*=UTF-8''%47%4F%4F%44.json"
+                })
+            ]:
+                req_mock.remove("GET", tmp_http)  # reset previous iter
+                req_mock.add_callback("GET", tmp_http, callback=lambda req: mock_response(req, headers))
+                try:
+                    res_path = fetch_file(tmp_http, res_dir)
+                except Exception as exc:
+                    raise AssertionError(f"Unexpected exception when testing with: [{headers}]. Exception: [{exc}]")
+                assert res_path == os.path.join(res_dir, target), f"Not expected name when testing with: [{headers}]"
+                assert os.path.isfile(res_path), f"File [{tmp_http}] should be accessible under [{res_path}]"
+                assert json.load(open(res_path)) == tmp_data, "File should be properly generated from HTTP reference"
         except Exception:
             raise
         finally:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,7 +8,7 @@ import shutil
 import tempfile
 import uuid
 from typing import Type
-from urllib.parse import urlparse, quote
+from urllib.parse import quote, urlparse
 
 import mock
 import pytest

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -65,7 +65,7 @@ if TYPE_CHECKING:
     MockConfigWPS1 = Sequence[str, str, Optional[Sequence[str]], Optional[Sequence[str]]]
 
 MOCK_AWS_REGION = "us-central-1"
-MOCK_HTTP_REF = "http://mock.localhost"
+MOCK_HTTP_REF = "http://localhost.mock"
 
 
 def ignore_warning_regex(func, warning_message_regex, warning_categories=DeprecationWarning):
@@ -844,7 +844,7 @@ def mocked_aws_s3(test_func):
     return wrapped
 
 
-def mocked_aws_s3_bucket_test_file(bucket_name, file_name, file_content="Test file inside test S3 bucket"):
+def mocked_aws_s3_bucket_test_file(bucket_name, file_name, file_content="mock"):
     # type: (str, str, str) -> str
     """
     Mock a test file as if retrieved from an AWS-S3 bucket reference.
@@ -894,13 +894,19 @@ def mocked_http_file(test_func):
     return wrapped
 
 
-def mocked_reference_test_file(file_name_or_path, href_type, file_content=""):
-    # type: (str, str, str) -> str
+def mocked_reference_test_file(file_name_or_path, href_type, file_content="mock", href_prefix=None):
+    # type: (str, str, str, Optional[str]) -> str
     """
-    Generates a test file reference from dummy data for http and file href types.
+    Generates a test file reference from dummy data for HTTP and file href types.
 
     .. seealso::
         - :func:`mocked_http_file`
+
+    :param file_name_or_path: desired output file name, or full path to an existing file to fill with mock data.
+    :param href_type: scheme of the href location to generate.
+    :param file_content: text to write into the created temporary file or referenced file by path.
+    :param href_prefix: specific prefix to employ to generate the href location instead of href_type and temporary path.
+    :returns: generated temporary href location.
     """
     if os.path.isfile(file_name_or_path):
         path = file_name_or_path
@@ -910,4 +916,7 @@ def mocked_reference_test_file(file_name_or_path, href_type, file_content=""):
     with open(path, "w") as tmp_file:
         tmp_file.write(file_content)
         tmp_file.seek(0)
+    if href_prefix:
+        path = "{}{}".format(href_prefix, path)
+        href_type = None if "://" in path else href_type
     return "{}://{}".format(href_type, path) if href_type else path

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -338,7 +338,7 @@ def mocked_file_response(path, url):
 
 
 def mocked_sub_requests(app, method_function, *args, only_local=False, **kwargs):
-    # type: (TestApp, str, *Any, bool, Any) -> AnyResponseType
+    # type: (TestApp, str, Any, bool, Any) -> AnyResponseType
     """
     Mocks request calls under :class:`webTest.TestApp` to avoid sending real requests.
 

--- a/tests/wps/test_utils.py
+++ b/tests/wps/test_utils.py
@@ -1,11 +1,8 @@
-import tempfile
-
-import shutil
-
-import os
-
 import contextlib
 import copy
+import os
+import shutil
+import tempfile
 
 import mock
 import pytest

--- a/weaver/processes/constants.py
+++ b/weaver/processes/constants.py
@@ -26,6 +26,7 @@ CWL_REQUIREMENT_APP_DOCKER = "DockerRequirement"
 CWL_REQUIREMENT_APP_DOCKER_GPU = "DockerGpuRequirement"
 CWL_REQUIREMENT_APP_ESGF_CWT = "ESGF-CWTRequirement"
 CWL_REQUIREMENT_APP_WPS1 = "WPS1Requirement"
+
 CWL_REQUIREMENT_APP_TYPES = frozenset([
     CWL_REQUIREMENT_APP_BUILTIN,
     CWL_REQUIREMENT_APP_DOCKER,
@@ -36,8 +37,19 @@ CWL_REQUIREMENT_APP_TYPES = frozenset([
     CWL_REQUIREMENT_APP_ESGF_CWT,
     CWL_REQUIREMENT_APP_WPS1,
 ])
+"""
+Set of :term:`CWL` requirements consisting of known :term:`Application Package` by this `Weaver` instance.
+"""
+
+CWL_REQUIREMENT_APP_REMOTE = frozenset([
+    CWL_REQUIREMENT_APP_ESGF_CWT,
+    CWL_REQUIREMENT_APP_WPS1,
+])
+"""
+Set of :term:`CWL` requirements that correspond to remote execution of an :term:`Application Package`.
+"""
+
 CWL_REQUIREMENT_INIT_WORKDIR = "InitialWorkDirRequirement"
-CWL_REQUIREMENT_APP_DOCKER = "DockerRequirement"
 
 # CWL package types and extensions
 PACKAGE_SIMPLE_TYPES = frozenset(["string", "boolean", "float", "int", "integer", "long", "double"])

--- a/weaver/processes/wps_package.py
+++ b/weaver/processes/wps_package.py
@@ -56,6 +56,7 @@ from weaver.processes.constants import (
     CWL_REQUIREMENT_APP_BUILTIN,
     CWL_REQUIREMENT_APP_DOCKER,
     CWL_REQUIREMENT_APP_ESGF_CWT,
+    CWL_REQUIREMENT_APP_REMOTE,
     CWL_REQUIREMENT_APP_TYPES,
     CWL_REQUIREMENT_APP_WPS1,
     CWL_REQUIREMENT_INIT_WORKDIR,
@@ -1247,7 +1248,7 @@ class WpsPackage(Process):
         if self.remote_execution or self.package_type == PROCESS_WORKFLOW:
             return False
         app_req = get_application_requirement(self.package)
-        if app_req["class"] not in [CWL_REQUIREMENT_APP_BUILTIN, CWL_REQUIREMENT_APP_DOCKER]:
+        if app_req["class"] in CWL_REQUIREMENT_APP_REMOTE:
             if input_ref.startswith("s3://"):
                 return True
             return False

--- a/weaver/utils.py
+++ b/weaver/utils.py
@@ -12,7 +12,7 @@ import warnings
 from copy import deepcopy
 from datetime import datetime
 from typing import TYPE_CHECKING
-from urllib.parse import ParseResult, urlparse, urlunsplit
+from urllib.parse import ParseResult, unquote, urlparse, urlunsplit
 
 import boto3
 import colander
@@ -33,7 +33,6 @@ from requests import HTTPError as RequestsHTTPError, Response
 from requests.structures import CaseInsensitiveDict
 from requests_file import FileAdapter
 from urlmatch import urlmatch
-from urllib.parse import unquote
 from webob.headers import EnvironHeaders, ResponseHeaders
 from werkzeug.wrappers import Request as WerkzeugRequest
 

--- a/weaver/wps/utils.py
+++ b/weaver/wps/utils.py
@@ -201,11 +201,11 @@ def map_wps_output_location(reference, container, reverse=False, exists=True, fi
     if reverse and reference.startswith("file://"):
         reference = reference[7:]
     if reverse and reference.startswith(wps_out_dir):
-        wps_out_ref = reference.replace(wps_out_dir, wps_out_url)
-        if not exists or os.path.isfile(wps_out_ref):
+        wps_out_ref = reference.replace(wps_out_dir, wps_out_url, 1)
+        if not exists or os.path.isfile(reference):
             return wps_out_ref
     elif not reverse and reference.startswith(wps_out_url):
-        wps_out_ref = reference.replace(wps_out_url, wps_out_dir)
+        wps_out_ref = reference.replace(wps_out_url, wps_out_dir, 1)
         if not exists or os.path.isfile(wps_out_ref):
             if file_scheme:
                 return "file://" + wps_out_ref


### PR DESCRIPTION
## Changes 

- Add handling of ``Content-Disposition`` header providing preferred ``filename`` or ``filename*`` parameters when
  fetching file references instead of the last URL fragment employed by default
  (resolves `#364 <https://github.com/crim-ca/weaver/issues/364>`_).
- Add more security validation of the obtained file name from HTTP reference, whether generated from URL path fragment
  or other header specification.