### PR TITLE
Fix deploy io dict

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,6 +36,9 @@ Fixes:
   during ``Workflow`` execution (resolves `#358 <https://github.com/crim-ca/weaver/issues/358>`_).
 - Fix logic of remotely and locally executed applications based on `CWL` requirements when attempting to resolve
   whether an input file reference should be fetched.
+- Fix resolution of `WPS` I/O provided as mapping instead of listing during deployment in order to properly parse
+  them and merge their metadata with corresponding `CWL` I/O definitions.
+- Fix `DataSource` and `OpenSearch` typing definitions to more rapidly detect incorrect data structures during parsing.
 
 `4.3.0 <https://github.com/crim-ca/weaver/tree/4.3.0>`_ (2021-11-16)
 ========================================================================

--- a/tests/processes/test_convert.py
+++ b/tests/processes/test_convert.py
@@ -1,6 +1,8 @@
 """
 Unit tests of functions within :mod:`weaver.processes.convert`.
 """
+# pylint: disable=R1729  # ignore non-generator representation employed for displaying test log results
+
 from collections import OrderedDict
 from copy import deepcopy
 

--- a/tests/processes/test_wps_package.py
+++ b/tests/processes/test_wps_package.py
@@ -18,12 +18,12 @@ from pywps.app import WPSRequest
 
 from weaver.datatype import Process
 from weaver.exceptions import PackageExecutionError
-from weaver.processes.wps_package import WpsPackage, _check_package_file, _get_package_ordered_io  # noqa: W0212
+from weaver.processes.wps_package import WpsPackage, _check_package_file, _normalize_ordered_io  # noqa: W0212
 
 # pylint: disable=R1729  # ignore non-generator representation employed for displaying test log results
 
 
-def test_get_package_ordered_io_with_builtin_dict_and_hints():
+def test_normalize_ordered_io_with_builtin_dict_and_hints():
     """
     Validate that I/O are all still there in the results with their respective contents.
 
@@ -59,7 +59,7 @@ def test_get_package_ordered_io_with_builtin_dict_and_hints():
         {"id": "id-array-type", "type": {"type": "array", "items": "float"}},
         {"id": "id-literal-array", "type": "string[]"}
     ]
-    result = _get_package_ordered_io(test_inputs, test_wps_hints)
+    result = _normalize_ordered_io(test_inputs, test_wps_hints)
     assert isinstance(result, list) and len(result) == len(expected_result)
     # *maybe* not same order, so validate values accordingly
     for expect in expected_result:
@@ -72,7 +72,7 @@ def test_get_package_ordered_io_with_builtin_dict_and_hints():
             raise AssertionError("expected '{}' was not validated against any result value".format(expect["id"]))
 
 
-def test_get_package_ordered_io_with_ordered_dict():
+def test_normalize_ordered_io_with_ordered_dict():
     test_inputs = OrderedDict([
         ("id-literal-type", "float"),
         ("id-dict-details", {"type": "string"}),
@@ -90,12 +90,12 @@ def test_get_package_ordered_io_with_ordered_dict():
         {"id": "id-array-type", "type": {"type": "array", "items": "float"}},
         {"id": "id-literal-array", "type": "string[]"}
     ]
-    result = _get_package_ordered_io(test_inputs)
+    result = _normalize_ordered_io(test_inputs)
     assert isinstance(result, list) and len(result) == len(expected_result)
     assert result == expected_result
 
 
-def test_get_package_ordered_io_with_list():
+def test_normalize_ordered_io_with_list():
     """
     Everything should remain the same as list variant is only allowed to have I/O objects.
 
@@ -107,7 +107,7 @@ def test_get_package_ordered_io_with_list():
         {"id": "id-array-type", "type": {"type": "array", "items": "float"}},
         {"id": "id-literal-array", "type": "string[]"}
     ]
-    result = _get_package_ordered_io(deepcopy(expected_result))
+    result = _normalize_ordered_io(deepcopy(expected_result))
     assert isinstance(result, list) and len(result) == len(expected_result)
     assert result == expected_result
 
@@ -153,12 +153,12 @@ def test_check_package_file_with_windows_path():
     assert is_url is False
 
 
-def test_get_package_ordered_io_when_direct_type_string():
+def test_normalize_ordered_io_when_direct_type_string():
     inputs_as_strings = {
         "input-1": "File[]",
         "input-2": "float"
     }
-    result = _get_package_ordered_io(inputs_as_strings)
+    result = _normalize_ordered_io(inputs_as_strings)
     assert isinstance(result, list)
     assert len(result) == len(inputs_as_strings)
     assert all([isinstance(res_i, dict) for res_i in result])

--- a/tests/processes/test_wps_package.py
+++ b/tests/processes/test_wps_package.py
@@ -9,8 +9,6 @@ import os
 import shutil
 import sys
 import tempfile
-from collections import OrderedDict
-from copy import deepcopy
 
 import mock
 import pytest
@@ -18,98 +16,9 @@ from pywps.app import WPSRequest
 
 from weaver.datatype import Process
 from weaver.exceptions import PackageExecutionError
-from weaver.processes.wps_package import WpsPackage, _check_package_file, _normalize_ordered_io  # noqa: W0212
+from weaver.processes.wps_package import WpsPackage, _check_package_file  # noqa: W0212
 
 # pylint: disable=R1729  # ignore non-generator representation employed for displaying test log results
-
-
-def test_normalize_ordered_io_with_builtin_dict_and_hints():
-    """
-    Validate that I/O are all still there in the results with their respective contents.
-
-    Literal types should be modified to a dictionary with ``type`` key.
-    All dictionary contents should then remain as is, except with added ``id``.
-
-    .. note::
-        Ordering is not mandatory, so we don't validate this.
-        Also actually hard to test since employed python version running the test changes the behaviour.
-    """
-    test_inputs = {
-        "id-literal-type": "float",
-        "id-dict-details": {
-            "type": "string"
-        },
-        "id-array-type": {
-            "type": {
-                "type": "array",
-                "items": "float"
-            }
-        },
-        "id-literal-array": "string[]"
-    }
-    test_wps_hints = [
-        {"id": "id-literal-type"},
-        {"id": "id-array-type"},
-        {"id": "id-dict-with-more-stuff"},
-        {"id": "id-dict-details"},
-    ]
-    expected_result = [
-        {"id": "id-literal-type", "type": "float"},
-        {"id": "id-dict-details", "type": "string"},
-        {"id": "id-array-type", "type": {"type": "array", "items": "float"}},
-        {"id": "id-literal-array", "type": "string[]"}
-    ]
-    result = _normalize_ordered_io(test_inputs, test_wps_hints)
-    assert isinstance(result, list) and len(result) == len(expected_result)
-    # *maybe* not same order, so validate values accordingly
-    for expect in expected_result:
-        validated = False
-        for res in result:
-            if res["id"] == expect["id"]:
-                assert res == expect
-                validated = True
-        if not validated:
-            raise AssertionError("expected '{}' was not validated against any result value".format(expect["id"]))
-
-
-def test_normalize_ordered_io_with_ordered_dict():
-    test_inputs = OrderedDict([
-        ("id-literal-type", "float"),
-        ("id-dict-details", {"type": "string"}),
-        ("id-array-type", {
-            "type": {
-                "type": "array",
-                "items": "float"
-            }
-        }),
-        ("id-literal-array", "string[]"),
-    ])
-    expected_result = [
-        {"id": "id-literal-type", "type": "float"},
-        {"id": "id-dict-details", "type": "string"},
-        {"id": "id-array-type", "type": {"type": "array", "items": "float"}},
-        {"id": "id-literal-array", "type": "string[]"}
-    ]
-    result = _normalize_ordered_io(test_inputs)
-    assert isinstance(result, list) and len(result) == len(expected_result)
-    assert result == expected_result
-
-
-def test_normalize_ordered_io_with_list():
-    """
-    Everything should remain the same as list variant is only allowed to have I/O objects.
-
-    (i.e.: not allowed to have both objects and literal string-type simultaneously as for dictionary variant).
-    """
-    expected_result = [
-        {"id": "id-literal-type", "type": "float"},
-        {"id": "id-dict-details", "type": "string"},
-        {"id": "id-array-type", "type": {"type": "array", "items": "float"}},
-        {"id": "id-literal-array", "type": "string[]"}
-    ]
-    result = _normalize_ordered_io(deepcopy(expected_result))
-    assert isinstance(result, list) and len(result) == len(expected_result)
-    assert result == expected_result
 
 
 class MockResponseOk(object):
@@ -151,19 +60,6 @@ def test_check_package_file_with_windows_path():
         mock_isfile.assert_called_with(test_file)
     assert res_path == test_file
     assert is_url is False
-
-
-def test_normalize_ordered_io_when_direct_type_string():
-    inputs_as_strings = {
-        "input-1": "File[]",
-        "input-2": "float"
-    }
-    result = _normalize_ordered_io(inputs_as_strings)
-    assert isinstance(result, list)
-    assert len(result) == len(inputs_as_strings)
-    assert all([isinstance(res_i, dict) for res_i in result])
-    assert all([i in [res_i["id"] for res_i in result] for i in inputs_as_strings])
-    assert all(["type" in res_i and res_i["type"] == inputs_as_strings[res_i["id"]] for res_i in result])
 
 
 class MockWpsPackage(WpsPackage):

--- a/weaver/processes/sources.py
+++ b/weaver/processes/sources.py
@@ -14,7 +14,9 @@ from weaver.wps_restapi.utils import get_wps_restapi_base_url
 if TYPE_CHECKING:
     from typing import Optional, Text
 
-DATA_SOURCES = {}
+    from weaver.typedefs import DataSource, DataSourceConfig
+
+DATA_SOURCES = {}  # type: DataSourceConfig
 """Data sources configuration.
 
 Unless explicitly overridden, the configuration will be loaded from file as specified by``weaver.data_sources`` setting.
@@ -52,6 +54,7 @@ Following JSON schema format is expected (corresponding YAML also supported):
 
 
 def fetch_data_sources():
+    # type: () -> DataSourceConfig
     global DATA_SOURCES  # pylint: disable=W0603,global-statement
 
     if DATA_SOURCES:
@@ -75,6 +78,8 @@ def fetch_data_sources():
 
 
 def get_default_data_source(data_sources):
+    # type: (DataSourceConfig) -> str
+
     # Check for a data source with the default property
     for src, val in data_sources.items():
         if asbool(val.get("default", False)):
@@ -85,7 +90,7 @@ def get_default_data_source(data_sources):
 
 
 def retrieve_data_source_url(data_source):
-    # type: (Optional[Text]) -> Text
+    # type: (Optional[Text]) -> str
     """
     Finds the data source URL using the provided data source identifier.
 
@@ -99,6 +104,7 @@ def retrieve_data_source_url(data_source):
 
 
 def get_data_source_from_url(data_url):
+    # type: (str) -> str
     data_sources = fetch_data_sources()
     try:
         parsed = urlparse(data_url)

--- a/weaver/typedefs.py
+++ b/weaver/typedefs.py
@@ -119,3 +119,21 @@ if TYPE_CHECKING:
     # others
     DatetimeIntervalType = TypedDict("DatetimeIntervalType",
                                      {"before": datetime, "after": datetime, "match": datetime}, total=False)
+
+    # data source configuration
+    DataSourceFileRef = TypedDict("DataSourceFileRef", {
+        "ades": str,                # target ADES to dispatch
+        "netloc": str,              # definition to match file references against
+        "default": Optional[bool],  # default ADES when no match was possible (single one allowed in config)
+    }, total=True)
+    DataSourceOpenSearch = TypedDict("DataSourceOpenSearch", {
+        "ades": str,                     # target ADES to dispatch
+        "netloc": str,                   # where to send OpenSearch request
+        "collection_id": Optional[str],  # OpenSearch collection ID to match against
+        "default": Optional[bool],       # default ADES when no match was possible (single one allowed)
+        "accept_schemes": List[str],     # URL schemes (http, https, etc.)
+        "rootdir": str,                  # root position of the data to retrieve
+        "osdd_url": str,                 # global OpenSearch description document to employ
+    }, total=True)
+    DataSource = Union[DataSourceFileRef, DataSourceOpenSearch]
+    DataSourceConfig = Dict[str, DataSource]  # JSON/YAML file contents

--- a/weaver/wps_restapi/swagger_definitions.py
+++ b/weaver/wps_restapi/swagger_definitions.py
@@ -131,6 +131,7 @@ PROCESS_DESCRIPTION_FIELD_FIRST = [
     "id",
     "title",
     "version",
+    "abstract",  # backward compat for deployment
     "description",
     "keywords",
     "metadata",
@@ -1099,7 +1100,7 @@ class DescribeInputType(AllOfKeywordSchema):
 
 
 class DescribeInputTypeWithID(InputIdentifierType, DescribeInputType):
-    pass
+    title = "DescribeInputTypeWithID"
 
 
 # Different definition than 'Describe' such that nested 'complex' type 'formats' can be validated and backward
@@ -2475,6 +2476,9 @@ class ProcessDeployment(ProcessSummary, ProcessContext, ProcessDeployMeta):
                     "overrides (see '{}/package.html#correspondence-between-cwl-and-wps-fields')".format(DOC_URL))
     visibility = VisibilityValue(missing=drop)
 
+    _sort_first = PROCESS_DESCRIPTION_FIELD_FIRST
+    _sort_after = PROCESS_DESCRIPTION_FIELD_AFTER
+
 
 class JobStatusInfo(ExtendedMappingSchema):
     jobID = UUID(example="a9d14bf4-84e0-449a-bac8-16e598efe807", description="ID of the job.")
@@ -3484,8 +3488,8 @@ class ProcessDescriptionChoiceType(OneOfKeywordSchema):
 
 class Deploy(ExtendedMappingSchema):
     processDescription = ProcessDescriptionChoiceType()
-    immediateDeployment = ExtendedSchemaNode(Boolean(), missing=drop, default=True)
     executionUnit = ExecutionUnitList()
+    immediateDeployment = ExtendedSchemaNode(Boolean(), missing=drop, default=True)
     deploymentProfileName = URL(missing=drop)
     owsContext = OWSContext(missing=drop)
 


### PR DESCRIPTION
- Fix resolution of `WPS` I/O provided as mapping instead of listing during deployment in order to properly parse
  them and merge their metadata with corresponding `CWL` I/O definitions.
- Fix `DataSource` and `OpenSearch` typing definitions to more rapidly detect incorrect data structures during parsing.