### PR TITLE
resolve UUID db handling

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,11 +10,12 @@ Changes
 
 Changes:
 --------
-- No change.
+- Add database revision number for traceability of migration procedures as needed.
+- Add first database revision with conversion of UUID-like strings to literal UUID objects.
 
 Fixes:
 ------
-- No change.
+- Fix resolution of unspecified UUID representation format in `MongoDB`.
 
 `4.5.0 <https://github.com/crim-ca/weaver/tree/4.5.0>`_ (2021-11-25)
 ========================================================================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@ Changes:
 Fixes:
 ------
 - Fix resolution of unspecified UUID representation format in `MongoDB`.
+- Fix conformance with error type reporting of missing `Job` or `Process`
+  (resolves `#320 <https://github.com/crim-ca/weaver/issues/320>`_).
 
 `4.5.0 <https://github.com/crim-ca/weaver/tree/4.5.0>`_ (2021-11-25)
 ========================================================================

--- a/tests/functional/test_docker_app.py
+++ b/tests/functional/test_docker_app.py
@@ -75,7 +75,7 @@ class WpsPackageDockerAppTest(WpsConfigBase):
 
     def validate_outputs(self, job_id, result_payload, outputs_payload, result_file_content):
         # get generic details
-        wps_uuid = self.job_store.fetch_by_id(job_id).wps_id
+        wps_uuid = str(self.job_store.fetch_by_id(job_id).wps_id)
         wps_out_path = "{}{}".format(self.settings["weaver.url"], self.settings["weaver.wps_output_path"])
         wps_output = "{}/{}/{}".format(wps_out_path, wps_uuid, self.out_file)
 

--- a/tests/functional/test_wps_package.py
+++ b/tests/functional/test_wps_package.py
@@ -2324,7 +2324,7 @@ class WpsPackageAppWithS3BucketTest(WpsConfigBase):
         # check that outputs are S3 bucket references
         output_values = {out["id"]: get_any_value(out) for out in outputs["outputs"]}
         output_bucket = self.settings["weaver.wps_output_s3_bucket"]
-        wps_uuid = self.job_store.fetch_by_id(job_id).wps_id
+        wps_uuid = str(self.job_store.fetch_by_id(job_id).wps_id)
         for out_key, out_file in [("output_from_s3", input_file_s3), ("output_from_http", input_file_http)]:
             output_ref = "{}/{}/{}".format(output_bucket, wps_uuid, out_file)
             output_ref_abbrev = "s3://{}".format(output_ref)

--- a/tests/wps_restapi/test_processes.py
+++ b/tests/wps_restapi/test_processes.py
@@ -319,7 +319,7 @@ class WpsRestApiProcessesTest(unittest.TestCase):
         process_data_tests[8]["executionUnit"] = list()
         process_data_tests[9]["executionUnit"][0] = {"unit": "something"}  # unit as string instead of package
         process_data_tests[10]["executionUnit"][0] = {"href": {}}  # noqa  # href as package instead of URL
-        process_data_tests[11]["executionUnit"][0] = {"unit": {}, "href": ""}  # can"t have both unit/href together
+        process_data_tests[11]["executionUnit"][0] = {"unit": {}, "href": ""}  # can't have both unit/href together
 
         with contextlib.ExitStack() as stack:
             for pkg in package_mock:

--- a/tests/wps_restapi/test_processes.py
+++ b/tests/wps_restapi/test_processes.py
@@ -605,7 +605,7 @@ class WpsRestApiProcessesTest(unittest.TestCase):
                 job = self.job_store.fetch_by_id(resp.json["jobID"])
             except JobNotFound:
                 self.fail("Job should have been created and be retrievable.")
-            assert job.id == resp.json["jobID"]
+            assert str(job.id) == resp.json["jobID"]
             assert job.task_id == STATUS_ACCEPTED  # temporary value until processed by celery
 
     def test_execute_process_language(self):
@@ -625,7 +625,7 @@ class WpsRestApiProcessesTest(unittest.TestCase):
                 job = self.job_store.fetch_by_id(resp.json["jobID"])
             except JobNotFound:
                 self.fail("Job should have been created and be retrievable.")
-            assert job.id == resp.json["jobID"]
+            assert str(job.id) == resp.json["jobID"]
             assert job.accept_language == ACCEPT_LANGUAGE_FR_CA
 
     def test_execute_process_no_json_body(self):

--- a/tests/wps_restapi/test_status_codes.py
+++ b/tests/wps_restapi/test_status_codes.py
@@ -1,5 +1,5 @@
-import uuid
 import unittest
+import uuid
 
 import pytest
 

--- a/tests/wps_restapi/test_status_codes.py
+++ b/tests/wps_restapi/test_status_codes.py
@@ -1,3 +1,4 @@
+import uuid
 import unittest
 
 import pytest
@@ -17,7 +18,7 @@ TEST_FORBIDDEN_ROUTES = [
     sd.provider_jobs_service.path,  # could be 401
 ]
 TEST_NOTFOUND_ROUTES = [
-    sd.job_service.path.format(job_id="not-found"),
+    sd.job_service.path.format(job_id=str(uuid.uuid4())),  # if not UUID, 400 instead
     sd.provider_service.path.format(provider_id="not-found"),
 ]
 

--- a/weaver/app.py
+++ b/weaver/app.py
@@ -10,6 +10,7 @@ import yaml
 from pyramid.config import Configurator
 
 from weaver.config import WEAVER_DEFAULT_REQUEST_OPTIONS_CONFIG, get_weaver_config_file, get_weaver_configuration
+from weaver.database import get_db
 from weaver.processes.builtin import register_builtin_processes
 from weaver.processes.utils import register_wps_processes_from_config
 from weaver.utils import get_settings, parse_extra_options, setup_cache, setup_loggers
@@ -57,6 +58,10 @@ def main(global_config, **settings):
         local_config.include("pyramid_celery")
         local_config.configure_celery(global_config["__file__"])
     local_config.include("weaver")
+
+    LOGGER.info("Running database migration...")
+    db = get_db(settings)
+    db.run_migration()
 
     if settings.get("weaver.celery", False):
         LOGGER.info("Celery runner detected. Skipping process registration.")

--- a/weaver/exceptions.py
+++ b/weaver/exceptions.py
@@ -161,7 +161,7 @@ class JobException(WeaverException):
 
 class JobNotFound(HTTPNotFound, OWSNotFound, JobException):
     """
-    Error related to a non existant job definition.
+    Error related to a non existing job definition.
 
     Error indicating that a job could not be read from the
     storage backend by an instance of :class:`weaver.store.JobStore`.

--- a/weaver/processes/execution.py
+++ b/weaver/processes/execution.py
@@ -399,8 +399,8 @@ def map_locations(job, settings):
         return
     base_dir, status_xml = os.path.split(local_path)
     job.wps_id = os.path.splitext(status_xml)[0]
-    wps_loc = os.path.join(base_dir, job.wps_id)
-    job_loc = os.path.join(base_dir, job.id)
+    wps_loc = os.path.join(base_dir, str(job.wps_id))
+    job_loc = os.path.join(base_dir, str(job.id))
     if wps_loc == job_loc:
         LOGGER.debug("Job already refers to WPS locations.")
         return

--- a/weaver/processes/utils.py
+++ b/weaver/processes/utils.py
@@ -91,7 +91,13 @@ def get_process(process_id=None, request=None, settings=None, store=None):
     except ProcessNotAccessible:
         raise HTTPForbidden("Process with ID '{!s}' is not accessible.".format(process_id))
     except ProcessNotFound:
-        raise HTTPNotFound("Process with ID '{!s}' does not exist.".format(process_id))
+        raise ProcessNotFound(json={
+            "title": "NoSuchProcess",
+            "type": "http://www.opengis.net/def/exceptions/ogcapi-processes-1/1.0/no-such-process",
+            "detail": "Process with specified reference identifier does not exist.",
+            "status": ProcessNotFound.code,
+            "cause": str(process_id)
+        })
     except colander.Invalid as ex:
         raise HTTPBadRequest("Invalid schema:\n[{0!r}].".format(ex))
 

--- a/weaver/store/base.py
+++ b/weaver/store/base.py
@@ -4,10 +4,12 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     import datetime
     from typing import Any, Dict, List, Optional, Tuple, Union
+
     from pyramid.request import Request
     from pywps import Process as ProcessWPS
+
     from weaver.datatype import Bill, Job, Process, Quote, Service
-    from weaver.typedefs import DatetimeIntervalType, TypedDict
+    from weaver.typedefs import AnyUUID, DatetimeIntervalType, TypedDict
 
     JobGroupCategory = TypedDict("JobGroupCategory",
                                  {"category": Dict[str, Optional[str]], "count": int, "jobs": List[Job]})
@@ -129,7 +131,7 @@ class StoreJobs(StoreInterface):
 
     @abc.abstractmethod
     def fetch_by_id(self, job_id):
-        # type: (str) -> Job
+        # type: (AnyUUID) -> Job
         raise NotImplementedError
 
     @abc.abstractmethod
@@ -173,7 +175,7 @@ class StoreQuotes(StoreInterface):
 
     @abc.abstractmethod
     def fetch_by_id(self, quote_id):
-        # type: (str) -> Quote
+        # type: (AnyUUID) -> Quote
         raise NotImplementedError
 
     @abc.abstractmethod
@@ -197,7 +199,7 @@ class StoreBills(StoreInterface):
 
     @abc.abstractmethod
     def fetch_by_id(self, bill_id):
-        # type: (str) -> Bill
+        # type: (AnyUUID) -> Bill
         raise NotImplementedError
 
     @abc.abstractmethod

--- a/weaver/store/mongodb.py
+++ b/weaver/store/mongodb.py
@@ -3,6 +3,7 @@ Stores to read/write data to from/to `MongoDB` using pymongo.
 """
 
 import logging
+import uuid
 from typing import TYPE_CHECKING
 
 import pymongo
@@ -54,7 +55,7 @@ if TYPE_CHECKING:
     from pymongo.collection import Collection
 
     from weaver.store.base import DatetimeIntervalType, JobGroupCategory, JobSearchResult
-    from weaver.typedefs import AnyProcess, AnyProcessType, AnyValue
+    from weaver.typedefs import AnyProcess, AnyProcessType, AnyUUID, AnyValue
 
     MongodbValue = Union[AnyValue, datetime.datetime]
     MongodbSearchFilter = Dict[str, Union[MongodbValue, List[MongodbValue], Dict[str, AnyValue]]]
@@ -442,7 +443,7 @@ class MongodbJobStore(StoreJobs, MongodbStore):
         MongodbStore.__init__(self, *db_args, **db_kwargs)
 
     def save_job(self,
-                 task_id,                   # type: str
+                 task_id,                   # type: AnyUUID
                  process,                   # type: str
                  service=None,              # type: Optional[str]
                  inputs=None,               # type: Optional[List[Any]]
@@ -525,10 +526,12 @@ class MongodbJobStore(StoreJobs, MongodbStore):
         return True
 
     def fetch_by_id(self, job_id):
-        # type: (str) -> Job
+        # type: (AnyUUID) -> Job
         """
         Gets job for given ``job_id`` from `MongoDB` storage.
         """
+        if isinstance(job_id, str):
+            job_id = uuid.UUID(job_id)
         job = self.collection.find_one({"id": job_id})
         if not job:
             raise JobNotFound("Could not find job matching: '{}'".format(job_id))
@@ -894,10 +897,12 @@ class MongodbQuoteStore(StoreQuotes, MongodbStore):
         return quote
 
     def fetch_by_id(self, quote_id):
-        # type: (str) -> Quote
+        # type: (AnyUUID) -> Quote
         """
         Gets quote for given ``quote_id`` from `MongoDB` storage.
         """
+        if isinstance(quote_id, str):
+            quote_id = uuid.UUID(quote_id)
         quote = self.collection.find_one({"id": quote_id})
         if not quote:
             raise QuoteNotFound("Could not find quote matching: '{}'".format(quote_id))
@@ -972,6 +977,8 @@ class MongodbBillStore(StoreBills, MongodbStore):
         """
         Gets bill for given ``bill_id`` from `MongoDB` storage.
         """
+        if isinstance(bill_id, str):
+            bill_id = uuid.UUID(bill_id)
         bill = self.collection.find_one({"id": bill_id})
         if not bill:
             raise BillNotFound("Could not find bill matching: '{}'".format(bill_id))

--- a/weaver/typedefs.py
+++ b/weaver/typedefs.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     import os
     import typing
+    import uuid
     from datetime import datetime
     from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Type, Union
     if hasattr(typing, "TypedDict"):
@@ -41,6 +42,7 @@ if TYPE_CHECKING:
     AnyValue = Optional[ValueType]
     AnyValueType = AnyValue  # alias
     AnyKey = Union[str, int]
+    AnyUUID = Union[str, uuid.UUID]
     # add more levels of explicit definitions than necessary to simulate JSON recursive structure better than 'Any'
     # amount of repeated equivalent definition makes typing analysis 'work well enough' for most use cases
     _JsonObjectItem = Dict[str, Union["JSON", "_JsonListItem"]]

--- a/weaver/wps_restapi/api.py
+++ b/weaver/wps_restapi/api.py
@@ -352,12 +352,8 @@ def api_conformance(request):  # noqa: F811
         ogcapi_processes + "/req/core/conformance-success",
         ogcapi_processes + "/req/core/http",
         ogcapi_processes + "/req/core/job",
-        # FIXME: process/job error details (for all below: https://github.com/crim-ca/weaver/issues/320)
-        #   https://github.com/opengeospatial/ogcapi-processes/blob/master/core/requirements/core/REQ_job-exception-no-such-job.adoc
-        #   https://raw.githubusercontent.com/opengeospatial/ogcapi-processes/master/core/openapi/schemas/exception.yaml
-        #   type of exception SHALL be: "http://www.opengis.net/def/exceptions/ogcapi-processes-1/1.0/no-such-job"
-        # ogcapi_processes + "/req/core/job-exception-no-such-job",
-        # ogcapi_processes + "/req/core/job-results-exception/no-such-job",
+        ogcapi_processes + "/req/core/job-exception-no-such-job",
+        ogcapi_processes + "/req/core/job-results-exception/no-such-job",
         ogcapi_processes + "/req/job-list/links",
         ogcapi_processes + "/rec/job-list/job-list-landing-page",
         ogcapi_processes + "/req/job-list/job-list-op",
@@ -384,7 +380,6 @@ def api_conformance(request):  # noqa: F811
         ogcapi_processes + "/req/core/pl-links",
         ogcapi_processes + "/req/core/process",
         ogcapi_processes + "/req/core/process-success",
-        # FIXME: process error details (for all below: https://github.com/crim-ca/weaver/issues/320)
         ogcapi_processes + "/req/core/process-exception/no-such-process",
         # FIXME: https://github.com/crim-ca/weaver/issues/247 (Prefer header)
         # ogcapi_processes + "/req/core/process-execute-auto-execution-mode",

--- a/weaver/wps_restapi/examples/job_not_found.json
+++ b/weaver/wps_restapi/examples/job_not_found.json
@@ -1,5 +1,6 @@
 {
   "description": "Could not find job with specified 'job_id'.",
+  "type": "http://www.opengis.net/def/exceptions/ogcapi-processes-1/1.0/no-such-job",
   "code": "NoSuchJob",
   "error": {
     "code": 404,

--- a/weaver/wps_restapi/swagger_definitions.py
+++ b/weaver/wps_restapi/swagger_definitions.py
@@ -15,7 +15,6 @@ on `Weaver`'s `ReadTheDocs` page.
 # pylint: disable=C0103,invalid-name
 
 import os
-import uuid
 from copy import copy
 from typing import TYPE_CHECKING
 
@@ -3986,6 +3985,12 @@ class OkGetJobStatusResponse(ExtendedMappingSchema):
     body = JobStatusInfo()
 
 
+class InvalidJobResponseSchema(ExtendedMappingSchema):
+    description = "Job reference is not a valid UUID."
+    header = ResponseHeaders()
+    body = ErrorJsonResponseBodySchema()
+
+
 class NotFoundJobResponseSchema(ExtendedMappingSchema):
     description = "Job reference UUID cannot be found."
     examples = {
@@ -4248,6 +4253,7 @@ get_single_job_status_responses = {
             "value": EXAMPLES["job_status_failed.json"],
         }
     }),
+    "400": InvalidJobResponseSchema(),
     "404": NotFoundJobResponseSchema(),
     "500": InternalServerErrorResponseSchema(),
 }
@@ -4257,6 +4263,7 @@ get_prov_single_job_status_responses.update({
 })
 delete_job_responses = {
     "200": OkDismissJobResponse(description="success"),
+    "400": InvalidJobResponseSchema(),
     "404": NotFoundJobResponseSchema(),
     "410": GoneJobResponseSchema(),
     "500": InternalServerErrorResponseSchema(),
@@ -4272,6 +4279,7 @@ get_job_inputs_responses = {
             "value": EXAMPLES["job_inputs.json"],
         }
     }),
+    "400": InvalidJobResponseSchema(),
     "404": NotFoundJobResponseSchema(),
     "500": InternalServerErrorResponseSchema(),
 }
@@ -4286,6 +4294,7 @@ get_job_outputs_responses = {
             "value": EXAMPLES["job_outputs.json"],
         }
     }),
+    "400": InvalidJobResponseSchema(),
     "404": NotFoundJobResponseSchema(),
     "410": GoneJobResponseSchema(),
     "500": InternalServerErrorResponseSchema(),
@@ -4304,6 +4313,7 @@ get_job_results_responses = {
             "value": EXAMPLES["job_results.json"],
         }
     }),
+    "400": InvalidJobResponseSchema(),
     "404": NotFoundJobResponseSchema(),
     "410": GoneJobResponseSchema(),
     "500": InternalServerErrorResponseSchema(),
@@ -4319,6 +4329,7 @@ get_exceptions_responses = {
             "value": EXAMPLES["job_exceptions.json"],
         }
     }),
+    "400": InvalidJobResponseSchema(),
     "404": NotFoundJobResponseSchema(),
     "410": GoneJobResponseSchema(),
     "500": InternalServerErrorResponseSchema(),
@@ -4334,6 +4345,7 @@ get_logs_responses = {
             "value": EXAMPLES["job_logs.json"],
         }
     }),
+    "400": InvalidJobResponseSchema(),
     "404": NotFoundJobResponseSchema(),
     "410": GoneJobResponseSchema(),
     "500": InternalServerErrorResponseSchema(),

--- a/weaver/wps_restapi/swagger_definitions.py
+++ b/weaver/wps_restapi/swagger_definitions.py
@@ -15,6 +15,7 @@ on `Weaver`'s `ReadTheDocs` page.
 # pylint: disable=C0103,invalid-name
 
 import os
+import uuid
 from copy import copy
 from typing import TYPE_CHECKING
 


### PR DESCRIPTION
## Changes

- add db revision operations
- replace str UUID-like field in db to actual UUID object
- resolve issue parsing unspecified UUID format

## Cause

With the addition of `X-Auth-Docker` header, an UUID was stored as-is. 
With more recent versions of `pymongo`, the unspecified representation type directly raises when reading the object.
