### PR TITLE
disable set_type_checking_flag since comments are used anyway

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -126,7 +126,7 @@ autoapi_python_class_content = "both"   # class|both|init
 autoapi_template_dir = "../_templates/autoapi"
 
 # sphinx_autodoc_typehints
-set_type_checking_flag = True
+set_type_checking_flag = False
 typehints_fully_qualified = True
 always_document_param_types = True
 


### PR DESCRIPTION
workaround https://github.com/ashb/sphinx-argparse/issues/7