### PR TITLE
fix CLI arguments

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,9 @@ Changes:
 
 Fixes:
 ------
-- No change.
+- Fix help message of CLI arguments not properly grouped within intended sections.
+- Fix handling of mutually exclusive CLI arguments in distinct operation sub-parsers.
+- Fix requirement of ``--process`` and ``--job`` CLI arguments.
 
 `4.6.0 <https://github.com/crim-ca/weaver/tree/4.6.0>`_ (2021-12-15)
 ========================================================================

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -166,6 +166,11 @@ release = __meta__.__version__
 # Usually you set "language" from the command line for these cases.
 language = "en"
 
+# allow conversion of quotes and repeated dashes to other representation characters
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-smartquotes
+# disable to avoid problems with '--param' employed in document of CLI.
+smartquotes = False
+
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
 # today = ''


### PR DESCRIPTION
## Fixes

- Fix help message of CLI arguments not properly grouped within intended sections.
- Fix handling of mutually exclusive CLI arguments in distinct operation sub-parsers.
- Fix requirement of ``--process`` and ``--job`` CLI arguments.


