### PR TITLE
CLI JSON-like body and CWL parameters

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,13 +10,13 @@ Changes
 
 Changes:
 --------
-- No change.
+- Add CLI ``--body`` and ``--cwl`` arguments support of literal JSON string for ``deploy`` operation.
 
 Fixes:
 ------
 - Fix help message of CLI arguments not properly grouped within intended sections.
 - Fix handling of mutually exclusive CLI arguments in distinct operation sub-parsers.
-- Fix requirement of ``--process`` and ``--job`` CLI arguments.
+- Fix CLI requirement of ``--process`` and ``--job`` arguments.
 
 `4.6.0 <https://github.com/crim-ca/weaver/tree/4.6.0>`_ (2021-12-15)
 ========================================================================

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -401,8 +401,8 @@ class TestWeaverCLI(TestWeaverClientBase):
             entrypoint=weaver_cli,
             only_local=True,
         )
-        assert any(f"\"id\": \"Echo\"" in line for line in lines)
-        assert any(f"\"deploymentDone\": true" in line for line in lines)
+        assert any("\"id\": \"Echo\"" in line for line in lines)
+        assert any("\"deploymentDone\": true" in line for line in lines)
 
     def test_deploy_payload_body_cwl_embedded(self):
         test_id = f"{self.test_process_prefix}-deploy-body-no-cwl"
@@ -424,7 +424,7 @@ class TestWeaverCLI(TestWeaverClientBase):
             only_local=True,
         )
         assert any(f"\"id\": \"{test_id}\"" in line for line in lines)
-        assert any(f"\"deploymentDone\": true" in line for line in lines)
+        assert any("\"deploymentDone\": true" in line for line in lines)
 
     def test_deploy_payload_file_cwl_embedded(self):
         test_id = f"{self.test_process_prefix}-deploy-file-no-cwl"
@@ -451,7 +451,7 @@ class TestWeaverCLI(TestWeaverClientBase):
                 only_local=True,
             )
             assert any(f"\"id\": \"{test_id}\"" in line for line in lines)
-            assert any(f"\"deploymentDone\": true" in line for line in lines)
+            assert any("\"deploymentDone\": true" in line for line in lines)
 
     def test_deploy_payload_inject_cwl_body(self):
         test_id = f"{self.test_process_prefix}-deploy-body-with-cwl-body"
@@ -474,7 +474,7 @@ class TestWeaverCLI(TestWeaverClientBase):
             only_local=True,
         )
         assert any(f"\"id\": \"{test_id}\"" in line for line in lines)
-        assert any(f"\"deploymentDone\": true" in line for line in lines)
+        assert any("\"deploymentDone\": true" in line for line in lines)
 
     def test_deploy_payload_inject_cwl_file(self):
         test_id = f"{self.test_process_prefix}-deploy-body-with-cwl-file"
@@ -497,7 +497,7 @@ class TestWeaverCLI(TestWeaverClientBase):
             only_local=True,
         )
         assert any(f"\"id\": \"{test_id}\"" in line for line in lines)
-        assert any(f"\"deploymentDone\": true" in line for line in lines)
+        assert any("\"deploymentDone\": true" in line for line in lines)
 
     def test_describe(self):
         # prints formatted JSON ProcessDescription over many lines

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -70,7 +70,7 @@ class TestWeaverClientBase(WpsConfigBase):
 
     @classmethod
     def load_resource_file(cls, name):
-        with open(cls.get_resource_file(APP_PKG_ROOT, name)) as echo_file:
+        with open(cls.get_resource_file(name)) as echo_file:
             return yaml.safe_load(echo_file)
 
 

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -65,8 +65,12 @@ class TestWeaverClientBase(WpsConfigBase):
             shutil.rmtree(tmp_wps_out, ignore_errors=True)
 
     @staticmethod
-    def load_resource_file(name):
-        with open(os.path.join(APP_PKG_ROOT, name)) as echo_file:
+    def get_resource_file(name):
+        return os.path.join(APP_PKG_ROOT, name)
+
+    @classmethod
+    def load_resource_file(cls, name):
+        with open(cls.get_resource_file(APP_PKG_ROOT, name)) as echo_file:
             return yaml.safe_load(echo_file)
 
 

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -108,7 +108,7 @@ class TestWeaverClient(TestWeaverClientBase):
     def test_deploy_payload_file_cwl_embedded(self):
         test_id = f"{self.test_process_prefix}-deploy-file-no-cwl"
         payload = self.load_resource_file("DeployProcess_Echo.yml")
-        package = os.path.abspath(os.path.join(APP_PKG_ROOT, "echo.cwl"))
+        package = self.get_resource_file("echo.cwl")
         payload["executionUnit"][0] = {"href": package}
 
         with tempfile.NamedTemporaryFile(mode="w", suffix=".cwl") as body_file:
@@ -140,7 +140,7 @@ class TestWeaverClient(TestWeaverClientBase):
     def test_deploy_payload_inject_cwl_file(self):
         test_id = f"{self.test_process_prefix}-deploy-body-with-cwl-file"
         payload = self.load_resource_file("DeployProcess_Echo.yml")
-        package = os.path.abspath(os.path.join(APP_PKG_ROOT, "echo.cwl"))
+        package = self.get_resource_file("echo.cwl")
         payload.pop("executionUnit", None)
 
         result = mocked_sub_requests(self.app, self.client.deploy, test_id, payload, package)
@@ -384,6 +384,120 @@ class TestWeaverCLI(TestWeaverClientBase):
                 only_local=True,
             )
             assert any(f"\"id\": \"{self.test_process}\"" in line for line in lines)
+
+    def test_deploy_no_process_id_option(self):
+        payload = self.get_resource_file("DeployProcess_Echo.yml")
+        package = self.get_resource_file("echo.cwl")
+        lines = mocked_sub_requests(
+            self.app, run_command,
+            [
+                # weaver
+                "deploy",
+                "--body", payload,  # no --process/--id, but available through --body
+                "--cwl", package,
+                self.url
+            ],
+            trim=False,
+            entrypoint=weaver_cli,
+            only_local=True,
+        )
+        assert any(f"\"id\": \"Echo\"" in line for line in lines)
+        assert any(f"\"deploymentDone\": true" in line for line in lines)
+
+    def test_deploy_payload_body_cwl_embedded(self):
+        test_id = f"{self.test_process_prefix}-deploy-body-no-cwl"
+        payload = self.load_resource_file("DeployProcess_Echo.yml")
+        package = self.load_resource_file("echo.cwl")
+        payload["executionUnit"][0] = {"unit": package}
+
+        lines = mocked_sub_requests(
+            self.app, run_command,
+            [
+                # weaver
+                "deploy",
+                "-p", test_id,
+                "-b", json.dumps(payload),  # literal JSON string accepted for CLI
+                self.url
+            ],
+            trim=False,
+            entrypoint=weaver_cli,
+            only_local=True,
+        )
+        assert any(f"\"id\": \"{test_id}\"" in line for line in lines)
+        assert any(f"\"deploymentDone\": true" in line for line in lines)
+
+    def test_deploy_payload_file_cwl_embedded(self):
+        test_id = f"{self.test_process_prefix}-deploy-file-no-cwl"
+        payload = self.load_resource_file("DeployProcess_Echo.yml")
+        package = self.get_resource_file("echo.cwl")
+        payload["executionUnit"][0] = {"href": package}
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".cwl") as body_file:
+            json.dump(payload, body_file)
+            body_file.flush()
+            body_file.seek(0)
+
+            lines = mocked_sub_requests(
+                self.app, run_command,
+                [
+                    # weaver
+                    "deploy",
+                    "-p", test_id,
+                    "-b", body_file.name,
+                    self.url
+                ],
+                trim=False,
+                entrypoint=weaver_cli,
+                only_local=True,
+            )
+            assert any(f"\"id\": \"{test_id}\"" in line for line in lines)
+            assert any(f"\"deploymentDone\": true" in line for line in lines)
+
+    def test_deploy_payload_inject_cwl_body(self):
+        test_id = f"{self.test_process_prefix}-deploy-body-with-cwl-body"
+        payload = self.load_resource_file("DeployProcess_Echo.yml")
+        package = self.load_resource_file("echo.cwl")
+        payload.pop("executionUnit", None)
+
+        lines = mocked_sub_requests(
+            self.app, run_command,
+            [
+                # weaver
+                "deploy",
+                "-p", test_id,
+                "--body", json.dumps(payload),  # literal JSON string accepted for CLI
+                "--cwl", json.dumps(package),   # literal JSON string accepted for CLI
+                self.url
+            ],
+            trim=False,
+            entrypoint=weaver_cli,
+            only_local=True,
+        )
+        assert any(f"\"id\": \"{test_id}\"" in line for line in lines)
+        assert any(f"\"deploymentDone\": true" in line for line in lines)
+
+    def test_deploy_payload_inject_cwl_file(self):
+        test_id = f"{self.test_process_prefix}-deploy-body-with-cwl-file"
+        payload = self.load_resource_file("DeployProcess_Echo.yml")
+        package = self.get_resource_file("echo.cwl")
+        payload.pop("executionUnit", None)
+
+        lines = mocked_sub_requests(
+            self.app, run_command,
+            [
+                # weaver
+                "deploy",
+                "-p", test_id,
+                "--body", json.dumps(payload),  # literal JSON string accepted for CLI
+                "--cwl", package,
+                self.url
+            ],
+            trim=False,
+            entrypoint=weaver_cli,
+            only_local=True,
+        )
+        assert any(f"\"id\": \"{test_id}\"" in line for line in lines)
+        assert any(f"\"deploymentDone\": true" in line for line in lines)
 
     def test_describe(self):
         # prints formatted JSON ProcessDescription over many lines

--- a/weaver/cli.py
+++ b/weaver/cli.py
@@ -759,9 +759,11 @@ def make_parser():
     op_deploy_app_pkg.add_argument(
         "--cwl", dest="cwl",
         help="Application Package of the process defined using Common Workflow Language (CWL) as JSON or YAML "
-             "format when provide by file reference. It will be inserted into an automatically generated request "
-             "deploy body or into the provided if '--body' was specified. "
-             "Can be provided either with a local file, an URL or literal string contents formatted as JSON."
+             "format when provided by file reference. File reference can be a local file or URL location. "
+             "Can also be provided as literal string contents formatted as JSON. "
+             "Provided contents will be inserted into an automatically generated request deploy body if none was "
+             "specified with '--body' option (note: '--process' must be specified instead in that case). "
+             "Otherwise, it will override the appropriate execution unit section within the provided deploy body."
     )
     op_deploy_app_pkg.add_argument(
         "--wps", dest="wps",


### PR DESCRIPTION
- add support of JSON-like string as input to CLI --body and --cwl options of deploy operation
- fix previous ``--process`` enforced requirement invalid during  ``deploy`` if provided via ``--body`` 