### PR TITLE
Update README.rst to provide YouTube embedded-like view on GitHub

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -134,17 +134,22 @@ Applications
 The video shares the fundamental ideas behind the architecture, illustrates how application stores for Earth
 Observation data processing can evolve, and illustrates the advantages with applications based on machine learning.
 
-.. following renders only in ReadTheDocs/Sphinx generated build
+.. Tag iframe renders the embedded video in ReadTheDocs/Sphinx generated build,
+   but it is filtered out by GitHub (https://github.github.com/gfm/#disallowed-raw-html-extension-).
+   The following div displays instead video thumbnail with an external link only for GitHub.
+   When iframe properly renders, the image/link div is masked under it to avoid seeing two "video displays".
 .. raw:: html
 
-    <div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; height: auto;"
+    <div style="position: relative; padding-bottom: 21.5%; height: 0; overflow: hidden; height: auto; max-width: 50em;"
     >
         <iframe src="https://www.youtube.com/embed/no3REyoxE38" frameborder="0" allowfullscreen
                 alt="Watch the Application video: http://www.youtube.com/watch?v=v=no3REyoxE3"
                 style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;">
 
         </iframe>
-        <div>
+        <div style="max-width: 50em;"> <!-- alternate view for GitHub -->
+            <b>Watch the Application video on YouTube</b>
+            <br>
             <a href="https://www.youtube.com/watch?v=no3REyoxE38">
                 <img src="https://img.youtube.com/vi/no3REyoxE38/mqdefault.jpg"
                      alt="Watch the Application video: http://www.youtube.com/watch?v=v=no3REyoxE3"
@@ -154,43 +159,32 @@ Observation data processing can evolve, and illustrates the advantages with appl
     </div>
     <br>
 
-
-.. ..
-    <div>
-        <a href="https://www.youtube.com/watch?v=no3REyoxE38">
-            <img src="https://img.youtube.com/vi/no3REyoxE38/mqdefault.jpg"
-                 alt="Watch the Application video: http://www.youtube.com/watch?v=v=no3REyoxE3"
-            />
-        </a>
-    </div>
-
 Platform
 ~~~~~~~~~~~~~~~~
 
 The video shares the fundamental ideas behind the architecture, illustrates how platform managers can benefit from
 application stores, and shows the potential for multidisciplinary workflows in thematic platforms.
 
+.. see other video comment
 .. raw:: html
 
-    <div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; height: auto;"
+    <div style="position: relative; padding-bottom: 21.5%; height: 0; overflow: hidden; height: auto; max-width: 50em;"
     >
         <iframe src="https://www.youtube.com/embed/QkdDFGEfIAY" frameborder="0" allowfullscreen
                 alt="Watch the Platform video: http://www.youtube.com/watch?v=v=QkdDFGEfIAY"
                 style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;">
         </iframe>
+        <div style="max-width: 50em;"> <!-- alternate view for GitHub -->
+            <b>Watch the Platform video on YouTube</b>
+            <br>
+            <a href="https://www.youtube.com/watch?v=QkdDFGEfIAY">
+                <img src="https://img.youtube.com/vi/QkdDFGEfIAY/mqdefault.jpg"
+                     alt="Watch the Platform video: http://www.youtube.com/watch?v=v=QkdDFGEfIAY"
+                />
+            </a>
+        </div>
     </div>
     <br>
-
-
-.. raw:: html
-
-    <div>
-        <a href="https://www.youtube.com/watch?v=QkdDFGEfIAY">
-            <img src="https://img.youtube.com/vi/QkdDFGEfIAY/mqdefault.jpg"
-                 alt="Watch the Platform video: http://www.youtube.com/watch?v=v=QkdDFGEfIAY"
-            />
-        </a>
-    </div>
 
 ----------------
 Links

--- a/README.rst
+++ b/README.rst
@@ -134,22 +134,33 @@ Applications
 The video shares the fundamental ideas behind the architecture, illustrates how application stores for Earth
 Observation data processing can evolve, and illustrates the advantages with applications based on machine learning.
 
+.. following renders only in ReadTheDocs/Sphinx generated build
 .. raw:: html
 
     <div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; height: auto;"
     >
-        <iframe src="http://www.youtube.com/watch?feature=player_embedded&v=no3REyoxE38" frameborder="0" allowfullscreen
-                alt="Watch the video: http://www.youtube.com/watch?v=v=no3REyoxE3"
+        <iframe src="https://www.youtube.com/embed/no3REyoxE38" frameborder="0" allowfullscreen
+                alt="Watch the Application video: http://www.youtube.com/watch?v=v=no3REyoxE3"
                 style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;">
+
         </iframe>
+        <div>
+            <a href="https://www.youtube.com/watch?v=no3REyoxE38">
+                <img src="https://img.youtube.com/vi/no3REyoxE38/mqdefault.jpg"
+                     alt="Watch the Application video: http://www.youtube.com/watch?v=v=no3REyoxE3"
+                />
+            </a>
+        </div>
     </div>
     <br>
 
-.. raw:: html
 
+.. ..
     <div>
         <a href="https://www.youtube.com/watch?v=no3REyoxE38">
-            <img src="https://img.youtube.com/vi/no3REyoxE38/mqdefault.jpg" alt="Application Video" />
+            <img src="https://img.youtube.com/vi/no3REyoxE38/mqdefault.jpg"
+                 alt="Watch the Application video: http://www.youtube.com/watch?v=v=no3REyoxE3"
+            />
         </a>
     </div>
 
@@ -164,6 +175,7 @@ application stores, and shows the potential for multidisciplinary workflows in t
     <div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; height: auto;"
     >
         <iframe src="https://www.youtube.com/embed/QkdDFGEfIAY" frameborder="0" allowfullscreen
+                alt="Watch the Platform video: http://www.youtube.com/watch?v=v=QkdDFGEfIAY"
                 style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;">
         </iframe>
     </div>
@@ -174,7 +186,9 @@ application stores, and shows the potential for multidisciplinary workflows in t
 
     <div>
         <a href="https://www.youtube.com/watch?v=QkdDFGEfIAY">
-            <img src="https://img.youtube.com/vi/QkdDFGEfIAY/mqdefault.jpg" alt="Platform Video" />
+            <img src="https://img.youtube.com/vi/QkdDFGEfIAY/mqdefault.jpg"
+                 alt="Watch the Platform video: http://www.youtube.com/watch?v=v=QkdDFGEfIAY"
+            />
         </a>
     </div>
 

--- a/README.rst
+++ b/README.rst
@@ -138,11 +138,20 @@ Observation data processing can evolve, and illustrates the advantages with appl
 
     <div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; height: auto;"
     >
-        <iframe src="https://www.youtube.com/embed/no3REyoxE38" frameborder="0" allowfullscreen
+        <iframe src="http://www.youtube.com/watch?feature=player_embedded&v=no3REyoxE38" frameborder="0" allowfullscreen
+                alt="Watch the video: http://www.youtube.com/watch?v=v=no3REyoxE3"
                 style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;">
         </iframe>
     </div>
     <br>
+
+.. raw:: html
+
+    <div>
+        <a href="https://www.youtube.com/watch?v=no3REyoxE38">
+            <img src="https://img.youtube.com/vi/no3REyoxE38/mqdefault.jpg" alt="Application Video" />
+        </a>
+    </div>
 
 Platform
 ~~~~~~~~~~~~~~~~
@@ -159,6 +168,15 @@ application stores, and shows the potential for multidisciplinary workflows in t
         </iframe>
     </div>
     <br>
+
+
+.. raw:: html
+
+    <div>
+        <a href="https://www.youtube.com/watch?v=QkdDFGEfIAY">
+            <img src="https://img.youtube.com/vi/QkdDFGEfIAY/mqdefault.jpg" alt="Platform Video" />
+        </a>
+    </div>
 
 ----------------
 Links

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -t SPHINX_BUILD
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = build

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    = -t SPHINX_BUILD
+SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = build


### PR DESCRIPTION
Provide similar (external) representation of youtube videos with link in readme displayed on Github since embedded iframe doesn't work in repo (still works in ReadTheDocs).


## Preview on GitHub side

(pseudo image/link video)

![image](https://user-images.githubusercontent.com/19194484/150212840-7f2dc4b7-c722-4024-a888-ed2b540ba616.png)


## Preview on ReadTheDocs/Sphinx side

(real embedded video)

![image](https://user-images.githubusercontent.com/19194484/150213004-4d0af248-ecad-4409-8c32-3a5abb7a28f9.png)




