### PR TITLE
allow process deployment using OGC schema (without nested 'process' f…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,7 +23,9 @@ Changes:
 
 Fixes:
 ------
-- No change.
+- Fix resolution of the ``default`` field specifier under a list of supported ``formats`` during deployment.
+  For various combinations such as when ``default: True`` format is omitted, or when the default is not ordered first,
+  resolved ``default`` specifically for ``outputs`` definitions would be incorrect.
 
 .. _changes_4.10.0:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,7 +12,14 @@ Changes
 
 Changes:
 --------
-- No change.
+- Support `Process` deployment using `OGC` schema (i.e.: `Process` metadata can be provided directly under
+  ``processDescription`` instead of being nested under ``processDescription.process``).
+  This aligns the deployment schema with reference `OGC API - Processes: Deploy, Replace, Undeploy` extension
+  (see |ogc-app-pkg|_ schema).
+  The previous schema for deployment with nested ``process`` field remains supported for backward compatibility.
+
+.. |ogc-app-pkg| replace:: OGC Application Package
+.. _ogc-app-pkg: https://github.com/opengeospatial/ogcapi-processes/blob/master/extensions/deploy_replace_undeploy/standard/openapi/schemas/ogcapppkg.yaml
 
 Fixes:
 ------

--- a/tests/functional/test_wps_package.py
+++ b/tests/functional/test_wps_package.py
@@ -140,6 +140,71 @@ class WpsPackageAppTest(WpsConfigBase):
         assert proc["inputs"][0]["id"] == "url"
         assert proc["outputs"][0]["id"] == "values"
 
+    def test_deploy_process_io_no_format_default(self):
+        """
+        Validate resolution of ``default`` format field during deployment.
+
+        Omitted ``default`` field in formats during deployment must only add them later on during process description.
+
+        .. versionchanged:: 4.11.0
+            Previously, ``default: False`` would be added automatically *during deployment parsing*
+            (from :mod:`colander` deserialization) when omitted in the submitted payload.
+            This caused comparison between submitted ``inputs`` and ``outputs`` against their parsed counterparts
+            to differ, failing deployment. Newer versions do not add the missing ``default`` during deployment, but
+            adds them as needed for following *process description parsing*, as they are then required in the schema.
+
+        .. seealso::
+            :func:`tests.test_schemas.test_format_variations`
+        """
+        cwl = {
+            "cwlVersion": "v1.0",
+            "class": "CommandLineTool",
+            "inputs": {"file": {"type": "File"}},
+            "outputs": {"file": {"type": "File"}}
+        }
+        body = {
+            "processDescription": {
+                "id": self._testMethodName,
+                "inputs": {
+                    "file": {
+                        "formats": [
+                            # no explicit defaults for any entry
+                            {"mediaType": ContentType.APP_JSON},  # first should resolve as default
+                            {"mediaType": ContentType.TEXT_PLAIN}
+                        ]
+                    }
+                },
+                "outputs": {
+                    "file": {
+                        "formats": [
+                            # explicit defaults are respected
+                            {"mediaType": ContentType.IMAGE_PNG, "default": False},
+                            {"mediaType": ContentType.IMAGE_JPEG, "default": True},  # must respect even if not first
+                            # and can be mixed with omitted that must resolve as non default
+                            {"mediaType": ContentType.IMAGE_GEOTIFF},
+                        ]
+                    }
+                }
+            },
+            "deploymentProfileName": "http://www.opengis.net/profiles/eoc/dockerizedApplication",
+            "executionUnit": [{"unit": cwl}],
+        }
+        desc, _ = self.deploy_process(body, describe_schema=ProcessSchema.OGC)
+
+        # add fields that are generated inline by the process description
+        expect_inputs = body["processDescription"]["inputs"]  # type: JSON
+        expect_outputs = body["processDescription"]["outputs"]  # type: JSON
+        expect_inputs["file"].update({"title": "file", "minOccurs": 1, "maxOccurs": 1})
+        expect_inputs["file"]["formats"][0]["default"] = True
+        expect_inputs["file"]["formats"][1]["default"] = False
+        expect_outputs["file"].update({"title": "file"})  # no min/max occurs for outputs
+        expect_outputs["file"]["formats"][0]["default"] = False
+        expect_outputs["file"]["formats"][1]["default"] = True
+        expect_outputs["file"]["formats"][2]["default"] = False
+
+        assert desc["inputs"] == expect_inputs
+        assert desc["outputs"] == expect_outputs
+
     def test_deploy_merge_literal_io_from_package(self):
         """
         Test validates that literal I/O definitions *only* defined in the `CWL` package as `JSON` within the deployment

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -88,21 +88,32 @@ def test_url_schemes():
 
 
 def test_format_variations():
+    """
+    Test format parsing for deployment payload.
+
+    .. versionchanged:: 4.11.0
+        Omitted field ``default: False`` not added automatically *during deployment* anymore.
+        It remains there if provided though, and will be added once again during process description parsing.
+
+    .. seealso::
+        Validation of above mentioned behavior is accomplished with
+        :func:`tests.functional.test_wps_package.WpsPackageAppTest.test_deploy_process_io_no_format_default`.
+    """
     format_schema = sd.DeploymentFormat()
     schema = "https://www.iana.org/assignments/media-types/{}".format(ContentType.APP_JSON)
     test_valid_fmt_deploy = [
         (
             {"mimeType": ContentType.APP_JSON},
-            {"mimeType": ContentType.APP_JSON, "default": False}),
+            {"mimeType": ContentType.APP_JSON}),
         (
             {"mediaType": ContentType.APP_JSON},
-            {"mediaType": ContentType.APP_JSON, "default": False}),
+            {"mediaType": ContentType.APP_JSON}),
         (
             {"mediaType": ContentType.APP_JSON, "maximumMegabytes": 200},
-            {"mediaType": ContentType.APP_JSON, "maximumMegabytes": 200, "default": False}),
+            {"mediaType": ContentType.APP_JSON, "maximumMegabytes": 200}),
         (
             {"mediaType": ContentType.APP_JSON, "maximumMegabytes": None},
-            {"mediaType": ContentType.APP_JSON, "default": False}),
+            {"mediaType": ContentType.APP_JSON}),
         (
             {"mediaType": ContentType.APP_JSON, "default": False},
             {"mediaType": ContentType.APP_JSON, "default": False}),
@@ -111,10 +122,10 @@ def test_format_variations():
             {"mediaType": ContentType.APP_JSON, "default": True}),
         (
             {"mediaType": ContentType.APP_JSON, "schema": None},
-            {"mediaType": ContentType.APP_JSON, "default": False}),
+            {"mediaType": ContentType.APP_JSON}),
         (
             {"mediaType": ContentType.APP_JSON, "schema": schema},
-            {"mediaType": ContentType.APP_JSON, "schema": schema, "default": False}),
+            {"mediaType": ContentType.APP_JSON, "schema": schema}),
     ]
     for fmt, res in test_valid_fmt_deploy:
         try:

--- a/tests/wps_restapi/test_processes.py
+++ b/tests/wps_restapi/test_processes.py
@@ -45,6 +45,7 @@ from weaver.wps_restapi import swagger_definitions as sd
 if TYPE_CHECKING:
     from typing import Optional
 
+    from weaver.processes.constants import ProcessSchemaType
     from weaver.typedefs import CWL, JSON
 
 
@@ -87,8 +88,8 @@ class WpsRestApiProcessesTest(unittest.TestCase):
         self.process_store.set_visibility(self.process_public.identifier, Visibility.PUBLIC)
         self.process_store.set_visibility(self.process_private.identifier, Visibility.PRIVATE)
 
-    def get_process_deploy_template(self, process_id=None, cwl=None):
-        # type: (Optional[str], Optional[CWL]) -> JSON
+    def get_process_deploy_template(self, process_id=None, cwl=None, schema=ProcessSchema.OLD):
+        # type: (Optional[str], Optional[CWL], ProcessSchemaType) -> JSON
         """
         Provides deploy process bare minimum template with undefined execution unit.
 
@@ -98,15 +99,18 @@ class WpsRestApiProcessesTest(unittest.TestCase):
         if not process_id:
             process_id = self.fully_qualified_test_process_name()
         body = {
-            "processDescription": {
-                "process": {
-                    "id": process_id,
-                    "title": "Test process '{}'.".format(process_id),
-                }
-            },
+            "processDescription": {},
             "deploymentProfileName": "http://www.opengis.net/profiles/eoc/dockerizedApplication",
             "executionUnit": []
         }
+        meta = {
+            "id": process_id,
+            "title": "Test process '{}'.".format(process_id),
+        }
+        if schema == ProcessSchema.OLD:
+            body["processDescription"]["process"] = meta
+        else:
+            body["processDescription"].update(meta)
         if cwl:
             body["executionUnit"].append({"unit": cwl})
         else:
@@ -422,6 +426,21 @@ class WpsRestApiProcessesTest(unittest.TestCase):
     def test_deploy_process_success(self):
         process_name = self.fully_qualified_test_process_name()
         process_data = self.get_process_deploy_template(process_name)
+        package_mock = mocked_process_package()
+
+        with contextlib.ExitStack() as stack:
+            for pkg in package_mock:
+                stack.enter_context(pkg)
+            path = "/processes"
+            resp = self.app.post_json(path, params=process_data, headers=self.json_headers, expect_errors=True)
+            assert resp.status_code == 201
+            assert resp.content_type == ContentType.APP_JSON
+            assert resp.json["processSummary"]["id"] == process_name
+            assert isinstance(resp.json["deploymentDone"], bool) and resp.json["deploymentDone"]
+
+    def test_deploy_process_ogc_scheme(self):
+        process_name = self.fully_qualified_test_process_name()
+        process_data = self.get_process_deploy_template(process_name, schema=ProcessSchema.OGC)
         package_mock = mocked_process_package()
 
         with contextlib.ExitStack() as stack:

--- a/tests/wps_restapi/test_processes.py
+++ b/tests/wps_restapi/test_processes.py
@@ -438,16 +438,20 @@ class WpsRestApiProcessesTest(unittest.TestCase):
             assert resp.json["processSummary"]["id"] == process_name
             assert isinstance(resp.json["deploymentDone"], bool) and resp.json["deploymentDone"]
 
-    def test_deploy_process_ogc_scheme(self):
+    def test_deploy_process_ogc_schema(self):
         process_name = self.fully_qualified_test_process_name()
         process_data = self.get_process_deploy_template(process_name, schema=ProcessSchema.OGC)
+        process_desc = process_data["processDescription"]
         package_mock = mocked_process_package()
 
         with contextlib.ExitStack() as stack:
             for pkg in package_mock:
                 stack.enter_context(pkg)
+            assert "process" not in process_desc
+            assert "id" in process_desc
+            process_desc["visibility"] = Visibility.PUBLIC  # save ourself an update request
             path = "/processes"
-            resp = self.app.post_json(path, params=process_data, headers=self.json_headers, expect_errors=True)
+            resp = self.app.post_json(path, params=process_data, headers=self.json_headers)
             assert resp.status_code == 201
             assert resp.content_type == ContentType.APP_JSON
             assert resp.json["processSummary"]["id"] == process_name

--- a/weaver/processes/utils.py
+++ b/weaver/processes/utils.py
@@ -136,8 +136,14 @@ def _check_deploy(payload):
         # Because many fields are optional during deployment to allow flexibility between compatible WPS/CWL
         # definitions, any invalid field at lower-level could make a full higher-level definition to be dropped.
         # Verify the result to ensure this was not the case for known cases to attempt early detection.
-        p_inputs = payload.get("processDescription", {}).get("process", {}).get("inputs")
-        r_inputs = results.get("processDescription", {}).get("process", {}).get("inputs")
+        p_process = payload.get("processDescription", {})
+        r_process = results.get("processDescription", {})
+        if "process" in p_process:
+            # if process is nested, both provided/result description must align
+            p_process = p_process.get("process", {})
+            r_process = r_process.get("process", {})
+        p_inputs = p_process.get("inputs")
+        r_inputs = r_process.get("inputs")
         if p_inputs and p_inputs != r_inputs:
             message = "Process deployment inputs definition is invalid."
             # try raising sub-schema to have specific reason

--- a/weaver/processes/utils.py
+++ b/weaver/processes/utils.py
@@ -248,7 +248,7 @@ def deploy_process_from_payload(payload, container, overwrite=False):
 
     # validate identifier naming for unsupported characters
     process_description = payload.get("processDescription")
-    process_info = process_description.get("process", {})
+    process_info = process_description.get("process", process_description)
     process_href = process_description.pop("href", None)
 
     # retrieve CWL package definition, either via "href" (WPS-1/2), "owsContext" or "executionUnit" (package/reference)

--- a/weaver/wps_restapi/swagger_definitions.py
+++ b/weaver/wps_restapi/swagger_definitions.py
@@ -107,6 +107,7 @@ IO_INFO_IDS = (
 
 OGC_API_REPO_URL = "https://github.com/opengeospatial/ogcapi-processes"
 OGC_API_SCHEMA_URL = "https://raw.githubusercontent.com/opengeospatial/ogcapi-processes"
+OGC_API_SCHEMA_VERSION = "master"
 
 DATETIME_INTERVAL_CLOSED_SYMBOL = "/"
 DATETIME_INTERVAL_OPEN_START_SYMBOL = "../"
@@ -655,11 +656,11 @@ class FormatMimeType(ExtendedMappingSchema):
     schema = FormatSchema(missing=drop)
 
 
-# https://github.com/opengeospatial/ogcapi-processes/blob/master/core/openapi/schemas/format.yaml
 class Format(ExtendedMappingSchema):
     """
     Used to respect ``mediaType`` field as suggested per `OGC-API`.
     """
+    schema_ref = f"{OGC_API_SCHEMA_URL}/{OGC_API_SCHEMA_VERSION}/core/openapi/schemas/format.yaml"
     mediaType = MediaType(default=ContentType.TEXT_PLAIN, example=ContentType.APP_JSON)
     encoding = ExtendedSchemaNode(String(), missing=drop)
     schema = FormatSchema(missing=drop)
@@ -741,7 +742,7 @@ class ResultFormat(FormatDescription):
     """
     Format employed for reference results respecting 'OGC API - Processes' schemas.
     """
-    schema_ref = "{}/master/core/openapi/schemas/formatDescription.yaml".format(OGC_API_SCHEMA_URL)
+    schema_ref = f"{OGC_API_SCHEMA_URL}/{OGC_API_SCHEMA_VERSION}/core/openapi/schemas/formatDescription.yaml"
     mediaType = MediaType(String())
     encoding = ExtendedSchemaNode(String(), missing=drop)
     schema = FormatSchema(missing=drop)
@@ -1016,7 +1017,7 @@ class LiteralReference(ExtendedMappingSchema):
 
 # https://github.com/opengeospatial/ogcapi-processes/blob/e6893b/extensions/workflows/openapi/workflows.yaml#L1707-L1716
 class NameReferenceType(ExtendedMappingSchema):
-    schema_ref = "{}/master/core/openapi/schemas/nameReferenceType.yaml".format(OGC_API_SCHEMA_URL)
+    schema_ref = f"{OGC_API_SCHEMA_URL}/{OGC_API_SCHEMA_VERSION}/core/openapi/schemas/nameReferenceType.yaml"
     name = ExtendedSchemaNode(String())
     reference = ReferenceURL(missing=drop, description="Reference URL to schema definition of the named entity.")
 
@@ -1364,10 +1365,10 @@ class DeployOutputTypeAny(OneOfKeywordSchema):
 
 
 class JobExecuteModeEnum(ExtendedSchemaNode):
+    schema_ref = f"{OGC_API_SCHEMA_URL}/{OGC_API_SCHEMA_VERSION}/core/openapi/schemas/execute.yaml"
     schema_type = String
     title = "JobExecuteMode"
     # no default to enforce required input as per OGC-API schemas
-    # https://github.com/opengeospatial/ogcapi-processes/blob/master/core/openapi/schemas/execute.yaml
     # default = EXECUTE_MODE_AUTO
     example = ExecuteMode.ASYNC
     validator = OneOf(ExecuteMode.values())
@@ -1382,10 +1383,10 @@ class JobControlOptionsEnum(ExtendedSchemaNode):
 
 
 class JobResponseOptionsEnum(ExtendedSchemaNode):
+    schema_ref = f"{OGC_API_SCHEMA_URL}/{OGC_API_SCHEMA_VERSION}/core/openapi/schemas/execute.yaml"
     schema_type = String
     title = "JobResponseOptions"
     # no default to enforce required input as per OGC-API schemas
-    # https://github.com/opengeospatial/ogcapi-processes/blob/master/core/openapi/schemas/execute.yaml
     # default = ExecuteResponse.DOCUMENT
     example = ExecuteResponse.DOCUMENT
     validator = OneOf(ExecuteResponse.values())
@@ -2831,8 +2832,8 @@ class ExecuteInputInlineValue(OneOfKeywordSchema):
 #   oneOf:
 #     - $ref: "inputValueNoObject.yaml"
 #     - type: object
-#
 class ExecuteInputObjectData(OneOfKeywordSchema):
+    schema_ref = f"{OGC_API_SCHEMA_URL}/{OGC_API_SCHEMA_VERSION}/core/openapi/schemas/inputValue.yaml"
     description = "Data value of any schema "
     _one_of = [
         ExecuteInputInlineValue,
@@ -2842,6 +2843,7 @@ class ExecuteInputObjectData(OneOfKeywordSchema):
 
 # https://github.com/opengeospatial/ogcapi-processes/blob/master/core/openapi/schemas/qualifiedInputValue.yaml
 class ExecuteInputObject(Format):
+    schema_ref = f"{OGC_API_SCHEMA_URL}/{OGC_API_SCHEMA_VERSION}/core/openapi/schemas/qualifiedInputValue.yaml"
     value = ExecuteInputObjectData()    # can be anything, including literal value, array of them, nested object
 
 
@@ -2865,6 +2867,7 @@ class ExecuteInputInline(OneOfKeywordSchema):
 #     - $ref: "link.yaml"
 #
 class ExecuteInputAny(OneOfKeywordSchema):
+    schema_ref = f"{OGC_API_SCHEMA_URL}/{OGC_API_SCHEMA_VERSION}/core/openapi/schemas/inlineOrRefData.yaml"
     description = "Execute data definition of the input."
     _one_of = [
         ExecuteInputInline(summary="Execute input value(s) provided inline."),          # 'inputValueNoObject' + 'link'
@@ -2883,6 +2886,7 @@ class ExecuteInputAny(OneOfKeywordSchema):
 # 	        $ref: "inlineOrRefData.yaml"
 #
 class ExecuteInputMapValues(ExtendedMappingSchema):
+    schema_ref = f"{OGC_API_SCHEMA_URL}/{OGC_API_SCHEMA_VERSION}/core/openapi/schemas/execute.yaml"
     input_id = ExecuteInputAny(variable="{input-id}", title="ExecuteInputValue",
                                description="Received mapping input value definition during job submission.")
 
@@ -3486,7 +3490,7 @@ class ResultReferenceList(ExtendedSequenceSchema):
 
 
 class ResultData(OneOfKeywordSchema):
-    schema_ref = "{}/master/core/openapi/schemas/result.yaml".format(OGC_API_SCHEMA_URL)
+    schema_ref = f"{OGC_API_SCHEMA_URL}/{OGC_API_SCHEMA_VERSION}/core/openapi/schemas/result.yaml"
     _one_of = [
         # must place formatted value first since both value/format fields are simultaneously required
         # other classes require only one of the two, and therefore are more permissive during schema validation
@@ -3503,7 +3507,7 @@ class Result(ExtendedMappingSchema):
     """
     Result outputs obtained from a successful process job execution.
     """
-    example_ref = "{}/master/core/examples/json/Result.json".format(OGC_API_SCHEMA_URL)
+    example_ref = f"{OGC_API_SCHEMA_URL}/{OGC_API_SCHEMA_VERSION}/core/examples/json/Result.json"
     output_id = ResultData(
         variable="{output-id}", title="Output Identifier",
         description=(
@@ -3610,17 +3614,21 @@ class ExecutionUnitList(ExtendedSequenceSchema):
     )
 
 
-class ProcessDeploymentOffering(ExtendedMappingSchema):
-    process = ProcessDeployment()
+class DeployProcessOffering(ProcessControl):
+    process = ProcessDeployment(description="Process definition nested under process field for backward compatibility.")
     processVersion = Version(title="processVersion", missing=drop)
-    jobControlOptions = JobControlOptionsList(missing=drop)
-    outputTransmission = TransmissionModeList(missing=drop)
+
+
+class DeployProcessDescription(ProcessDeployment, ProcessControl):
+    schema_ref = f"{OGC_API_SCHEMA_URL}/{OGC_API_SCHEMA_VERSION}/core/openapi/schemas/process.yaml"
+    description = "Process description fields directly provided."
 
 
 class ProcessDescriptionChoiceType(OneOfKeywordSchema):
     _one_of = [
         Reference(),
-        ProcessDeploymentOffering()
+        DeployProcessOffering(),
+        DeployProcessDescription()
     ]
 
 

--- a/weaver/wps_restapi/swagger_definitions.py
+++ b/weaver/wps_restapi/swagger_definitions.py
@@ -717,7 +717,10 @@ class FormatDescription(ExtendedMappingSchema):
 # from 'ResultFormat' employed for result reporting, which shouldn't have a default (applied vs supported format)
 class FormatDefault(ExtendedMappingSchema):
     default = ExtendedSchemaNode(
-        Boolean(), missing=drop, default=False,
+        Boolean(), missing=drop,
+        # don't insert "default" field if omitted in deploy body to avoid causing differing "inputs"/"outputs"
+        # definitions between the submitted payload and the validated one (in 'weaver.processes.utils._check_deploy')
+        # default=False,
         description=(
             "Indicates if this format should be considered as the default one in case none of the other "
             "allowed or supported formats was matched nor provided as input during job submission."


### PR DESCRIPTION
## Changes

- Support `Process` deployment using `OGC` schema (i.e.: `Process` metadata can be provided directly under
  ``processDescription`` instead of being nested under ``processDescription.process``).
  This aligns the deployment schema with reference `OGC API - Processes: Deploy, Replace, Undeploy` extension
  (see https://github.com/opengeospatial/ogcapi-processes/blob/master/extensions/deploy_replace_undeploy/standard/openapi/schemas/ogcapppkg.yaml schema).
  The previous schema for deployment with nested ``process`` field remains supported for backward compatibility.
- Fix resolution of the ``default`` field specifier under a list of supported ``formats`` during deployment.
  For various combinations such as when ``default: True`` format is omitted, or when the default is not ordered first,
  resolved ``default`` specifically for ``outputs`` definitions would be incorrect.