### PR TITLE
better support 'type' field for file 'href' input & link/metadata

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,10 +17,11 @@ Changes:
   of ``format.mimeType``, ``format.mediaType`` and/or directly ``type`` field to provide the Content-Type of an
   output with ``href`` file.
   By default, both the ``format`` (i.e.: ``OLD`` schema) and the ``type`` (i.e.: ``OGC`` schema) are simultaneously
-  reported for backward and forward compatibility, and for `OGC` compliance to return a file reference IANA Media-Type
+  reported for backward and forward compatibility, and for `OGC` compliance, to return the IANA Media-Type of the
+  associated file reference (relates to `#401 <https://github.com/crim-ca/weaver/issues/401>`_).
+- Add support of ``type`` as alias to the Media-Type under the ``format`` for file references when submitted
+  for ``Job`` execution inputs, in accordance to the reported inputs/outputs endpoints, and for `OGC` compliance
   (resolves `#401 <https://github.com/crim-ca/weaver/issues/401>`_).
-- Add support of ``type`` as alias to the Media-Type of the ``format`` of file references when submitted
-  for ``Job`` execution inputs, in accordance to the reported inputs/outputs endpoints, and for `OGC` compliance.
 - Drop ``type`` field for ``metadata`` items in process description that correspond to a ``value`` with a ``role``.
 - Enforce pattern validation of ``type`` as IANA Content-Type for ``metadata`` items in process description that
   correspond to a ``Link`` with ``href``. Invalid ``type`` are now rejected to adhere to `OGC` requirement classes.
@@ -29,8 +30,9 @@ Changes:
 
 Fixes:
 ------
-- Fix ``GET /jobs/{jobID}/inputs`` endpoint failing to return submitted ``inputs`` when they were specified using the
-  mapping representation (i.e.: ``OGC`` schema).
+- Fix ``GET /jobs/{jobID}/inputs`` endpoint failing to return submitted ``inputs`` for ``Job`` execution when they
+  were specified using the mapping representation (i.e.: ``OGC`` schema) instead of the listing representation
+  (i.e.: ``OLD`` schema).
 
 .. _changes_4.12.0:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,11 +12,25 @@ Changes
 
 Changes:
 --------
-- No change.
+- Add ``schema`` query parameter to ``GET /jobs/{jobID}/outputs`` request allowing to select between ``OGC``, ``OLD``
+  ``OGC+strict`` and ``OLD+strict`` representations (case insensitive), each with different combinations
+  of ``format.mimeType``, ``format.mediaType`` and/or directly ``type`` field to provide the Content-Type of an
+  output with ``href`` file.
+  By default, both the ``format`` (i.e.: ``OLD`` schema) and the ``type`` (i.e.: ``OGC`` schema) are simultaneously
+  reported for backward and forward compatibility, and for `OGC` compliance to return a file reference IANA Media-Type
+  (resolves `#401 <https://github.com/crim-ca/weaver/issues/401>`_).
+- Add support of ``type`` as alias to the Media-Type of the ``format`` of file references when submitted
+  for ``Job`` execution inputs, in accordance to the reported inputs/outputs endpoints, and for `OGC` compliance.
+- Drop ``type`` field for ``metadata`` items in process description that correspond to a ``value`` with a ``role``.
+- Enforce pattern validation of ``type`` as IANA Content-Type for ``metadata`` items in process description that
+  correspond to a ``Link`` with ``href``. Invalid ``type`` are now rejected to adhere to `OGC` requirement classes.
+- Clarify schema employed by `Weaver` to use naming that is as close as possible to `OGC` schemas to facilitate their
+  comprehension and external references.
 
 Fixes:
 ------
-- No change.
+- Fix ``GET /jobs/{jobID}/inputs`` endpoint failing to return submitted ``inputs`` when they were specified using the
+  mapping representation (i.e.: ``OGC`` schema).
 
 .. _changes_4.12.0:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,9 @@ Fixes:
 - Fix ``GET /jobs/{jobID}/inputs`` endpoint failing to return submitted ``inputs`` for ``Job`` execution when they
   were specified using the mapping representation (i.e.: ``OGC`` schema) instead of the listing representation
   (i.e.: ``OLD`` schema).
+- Fix Media-Type provided as ``Job`` file reference input not forwarded to underlying WPS execution for validation
+  against supported formats for corresponding inputs. Specified format handles both the ``OLD`` definition with
+  ``format`` field (and nested ``mimeType`` or ``mediaType``), and the more recent ``OGC`` format with ``type`` field.
 
 .. _changes_4.12.0:
 

--- a/docs/source/references.rst
+++ b/docs/source/references.rst
@@ -18,7 +18,7 @@
 .. |cwl-home| replace:: CWL Homepage
 .. _cwl-home: https://www.commonwl.org/
 .. |cwl-spec| replace:: CWL Specification
-.. _cwl-spec: https://www.commonwl.org/#Specification
+.. _cwl-spec: https://www.commonwl.org/specification/
 .. |cwl-guide| replace:: CWL User Guide
 .. _cwl-guide: http://www.commonwl.org/user_guide/
 .. |cwl-cmdtool| replace:: CWL CommandLineTool

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from tests.functional.utils import WpsConfigBase, ResourcesUtil
+from tests.functional.utils import ResourcesUtil, WpsConfigBase
 from tests.utils import (
     get_weaver_url,
     mocked_dismiss_process,

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -13,10 +13,8 @@ import uuid
 from typing import TYPE_CHECKING
 
 import pytest
-import yaml
 
-from tests.functional import APP_PKG_ROOT
-from tests.functional.utils import WpsConfigBase
+from tests.functional.utils import WpsConfigBase, ResourcesUtil
 from tests.utils import (
     get_weaver_url,
     mocked_dismiss_process,
@@ -36,7 +34,7 @@ if TYPE_CHECKING:
 
 @pytest.mark.cli
 @pytest.mark.functional
-class TestWeaverClientBase(WpsConfigBase):
+class TestWeaverClientBase(WpsConfigBase, ResourcesUtil):
     def __init__(self, *args, **kwargs):
         # won't run this as a test suite, only its derived classes
         setattr(self, "__test__", self is TestWeaverClientBase)
@@ -68,7 +66,7 @@ class TestWeaverClientBase(WpsConfigBase):
         self.test_payload = {}
         for process in ["Echo", "CatFile"]:
             self.test_process[process] = f"{self.test_process_prefix}-{process}"
-            self.test_payload[process] = self.load_resource_file(f"DeployProcess_{process}.yml", process)
+            self.test_payload[process] = self.retrieve_payload(process, "deploy", local=True)
             self.deploy_process(self.test_payload[process], process_id=self.test_process[process])
 
     @classmethod
@@ -78,17 +76,6 @@ class TestWeaverClientBase(WpsConfigBase):
             tmp_wps_out = cls.settings.get(tmp_dir_cfg, "")
             if os.path.isdir(tmp_wps_out):
                 shutil.rmtree(tmp_wps_out, ignore_errors=True)
-
-    @staticmethod
-    def get_resource_file(name, process="Echo"):
-        if os.path.isfile(name):
-            return os.path.abspath(name)
-        return os.path.join(APP_PKG_ROOT, process, name)
-
-    @classmethod
-    def load_resource_file(cls, name, process="Echo"):
-        with open(TestWeaverClientBase.get_resource_file(name, process)) as res_file:
-            return yaml.safe_load(res_file)
 
 
 class TestWeaverClient(TestWeaverClientBase):
@@ -139,8 +126,8 @@ class TestWeaverClient(TestWeaverClientBase):
 
     def test_deploy_payload_body_cwl_embedded(self):
         test_id = f"{self.test_process_prefix}-deploy-body-no-cwl"
-        payload = self.load_resource_file("DeployProcess_Echo.yml")
-        package = self.load_resource_file("echo.cwl")
+        payload = self.retrieve_payload("Echo", "deploy", local=True)
+        package = self.retrieve_payload("Echo", "package", local=True)
         payload["executionUnit"][0] = {"unit": package}
 
         result = mocked_sub_requests(self.app, self.client.deploy, test_id, payload)
@@ -153,8 +140,8 @@ class TestWeaverClient(TestWeaverClientBase):
 
     def test_deploy_payload_file_cwl_embedded(self):
         test_id = f"{self.test_process_prefix}-deploy-file-no-cwl"
-        payload = self.load_resource_file("DeployProcess_Echo.yml")
-        package = self.get_resource_file("echo.cwl")
+        payload = self.retrieve_payload("Echo", "deploy", local=True)
+        package = self.retrieve_payload("Echo", "package", local=True, ref_found=True)
         payload["executionUnit"][0] = {"href": package}
 
         with tempfile.NamedTemporaryFile(mode="w", suffix=".cwl") as body_file:
@@ -171,8 +158,8 @@ class TestWeaverClient(TestWeaverClientBase):
 
     def test_deploy_payload_inject_cwl_body(self):
         test_id = f"{self.test_process_prefix}-deploy-body-with-cwl-body"
-        payload = self.load_resource_file("DeployProcess_Echo.yml")
-        package = self.load_resource_file("echo.cwl")
+        payload = self.retrieve_payload("Echo", "deploy", local=True)
+        package = self.retrieve_payload("Echo", "package", local=True)
         payload.pop("executionUnit", None)
 
         result = mocked_sub_requests(self.app, self.client.deploy, test_id, payload, package)
@@ -185,8 +172,8 @@ class TestWeaverClient(TestWeaverClientBase):
 
     def test_deploy_payload_inject_cwl_file(self):
         test_id = f"{self.test_process_prefix}-deploy-body-with-cwl-file"
-        payload = self.load_resource_file("DeployProcess_Echo.yml")
-        package = self.get_resource_file("echo.cwl")
+        payload = self.retrieve_payload("Echo", "deploy", local=True)
+        package = self.retrieve_payload("Echo", "package", local=True, ref_found=True)
         payload.pop("executionUnit", None)
 
         result = mocked_sub_requests(self.app, self.client.deploy, test_id, payload, package)
@@ -242,12 +229,13 @@ class TestWeaverClient(TestWeaverClientBase):
         assert "description" not in result.body, "CLI should not have overridden the process description field."
 
     def run_execute_inputs_schema_variant(self, inputs_param, process="Echo",
-                                          preload=False, expect_success=True, mock_exec=True):
+                                          preload=False, location=False, expect_success=True, mock_exec=True):
         if isinstance(inputs_param, str):
+            ref = {"location": inputs_param} if location else {"ref_name": inputs_param}
             if preload:
-                inputs_param = self.load_resource_file(inputs_param, process=process)
+                inputs_param = self.retrieve_payload(process=process, local=True, **ref)
             else:
-                inputs_param = self.get_resource_file(inputs_param, process=process)
+                inputs_param = self.retrieve_payload(process=process, local=True, **ref)
         with contextlib.ExitStack() as stack_exec:
             # use pass-through function because don't care about execution result here, only the parsing of I/O
             if mock_exec:
@@ -258,7 +246,7 @@ class TestWeaverClient(TestWeaverClientBase):
                 stack_exec.enter_context(mock_exec_proc)
             result = mocked_sub_requests(self.app, self.client.execute, self.test_process[process], inputs=inputs_param)
         if expect_success:
-            assert result.success, result.message + " " + result.text
+            assert result.success, result.message + (result.text if result.text else "")
             assert "jobID" in result.body
             assert "processID" in result.body
             assert "status" in result.body
@@ -393,10 +381,10 @@ class TestWeaverClient(TestWeaverClientBase):
             if embed:
                 test_file = [test_input_file.format(test_file=tmp_file.name)]
             else:
-                exec_file = self.get_resource_file(test_input_file, process=process)
+                exec_file = self.retrieve_payload(process=process, ref_name=test_input_file, local=True, ref_found=True)
                 test_file = self.setup_test_file(exec_file, {"<TEST_FILE>": tmp_file.name})
             result = self.run_execute_inputs_schema_variant(test_file, process=process,
-                                                            preload=preload, mock_exec=False)
+                                                            preload=preload, location=True, mock_exec=False)
         job_id = result.body["jobID"]
         result = mocked_sub_requests(self.app, self.client.results, job_id)
         assert result.success, result.message
@@ -498,8 +486,8 @@ class TestWeaverCLI(TestWeaverClientBase):
             assert any(f"\"id\": \"{proc}\"" in line for line in lines)
 
     def test_deploy_no_process_id_option(self):
-        payload = self.get_resource_file("DeployProcess_Echo.yml")
-        package = self.get_resource_file("echo.cwl")
+        payload = self.retrieve_payload("Echo", "deploy", local=True, ref_found=True)
+        package = self.retrieve_payload("Echo", "package", local=True, ref_found=True)
         lines = mocked_sub_requests(
             self.app, run_command,
             [
@@ -518,8 +506,8 @@ class TestWeaverCLI(TestWeaverClientBase):
 
     def test_deploy_payload_body_cwl_embedded(self):
         test_id = f"{self.test_process_prefix}-deploy-body-no-cwl"
-        payload = self.load_resource_file("DeployProcess_Echo.yml")
-        package = self.load_resource_file("echo.cwl")
+        payload = self.retrieve_payload("Echo", "deploy", local=True)
+        package = self.retrieve_payload("Echo", "package", local=True)
         payload["executionUnit"][0] = {"unit": package}
 
         lines = mocked_sub_requests(
@@ -540,8 +528,8 @@ class TestWeaverCLI(TestWeaverClientBase):
 
     def test_deploy_payload_file_cwl_embedded(self):
         test_id = f"{self.test_process_prefix}-deploy-file-no-cwl"
-        payload = self.load_resource_file("DeployProcess_Echo.yml")
-        package = self.get_resource_file("echo.cwl")
+        payload = self.retrieve_payload("Echo", "deploy", local=True)
+        package = self.retrieve_payload("Echo", "package", local=True, ref_found=True)
         payload["executionUnit"][0] = {"href": package}
 
         with tempfile.NamedTemporaryFile(mode="w", suffix=".cwl") as body_file:
@@ -567,8 +555,8 @@ class TestWeaverCLI(TestWeaverClientBase):
 
     def test_deploy_payload_inject_cwl_body(self):
         test_id = f"{self.test_process_prefix}-deploy-body-with-cwl-body"
-        payload = self.load_resource_file("DeployProcess_Echo.yml")
-        package = self.load_resource_file("echo.cwl")
+        payload = self.retrieve_payload("Echo", "deploy", local=True)
+        package = self.retrieve_payload("Echo", "package", local=True)
         payload.pop("executionUnit", None)
 
         lines = mocked_sub_requests(
@@ -590,8 +578,8 @@ class TestWeaverCLI(TestWeaverClientBase):
 
     def test_deploy_payload_inject_cwl_file(self):
         test_id = f"{self.test_process_prefix}-deploy-body-with-cwl-file"
-        payload = self.load_resource_file("DeployProcess_Echo.yml")
-        package = self.get_resource_file("echo.cwl")
+        payload = self.retrieve_payload("Echo", "deploy", local=True)
+        package = self.retrieve_payload("Echo", "package", local=True, ref_found=True)
         payload.pop("executionUnit", None)
 
         lines = mocked_sub_requests(

--- a/tests/functional/test_workflow.py
+++ b/tests/functional/test_workflow.py
@@ -554,8 +554,14 @@ class WorkflowTestRunnerBase(ResourcesUtil, TestCase):
         return not cls.is_local() and not cls.is_remote()
 
     @classmethod
-    def request(cls, method, url, ignore_errors=False, force_requests=False, log_enabled=True, **kw):
-        # type: (str, str, bool, bool, bool, Optional[Any]) -> AnyResponseType
+    def request(cls,                    # pylint: disable=W0221
+                method,                 # type: str
+                url,                    # type: str
+                ignore_errors=False,    # type: bool
+                force_requests=False,   # type: bool
+                log_enabled=True,       # type: bool
+                **kw                    # type: Any
+                ):                      # type: (...) -> AnyResponseType
         """
         Executes the request, but following any server prior redirects as needed.
 

--- a/tests/functional/test_workflow.py
+++ b/tests/functional/test_workflow.py
@@ -21,6 +21,7 @@ from pyramid.settings import asbool
 # use 'Web' prefix to avoid pytest to pick up these classes and throw warnings
 from webtest import TestApp as WebTestApp
 
+from tests.functional.utils import ResourcesUtil
 from tests.utils import (
     get_settings_from_config_ini,
     get_settings_from_testapp,
@@ -31,7 +32,6 @@ from tests.utils import (
     mocked_wps_output,
     setup_config_with_mongodb
 )
-from tests.functional.utils import ResourcesUtil
 from weaver import WEAVER_ROOT_DIR
 from weaver.config import WeaverConfiguration
 from weaver.formats import ContentType

--- a/tests/functional/test_workflow.py
+++ b/tests/functional/test_workflow.py
@@ -15,7 +15,6 @@ from urllib.parse import urlparse
 
 import mock
 import pytest
-import yaml
 from pyramid import testing
 from pyramid.httpexceptions import HTTPConflict, HTTPCreated, HTTPNotFound, HTTPOk
 from pyramid.settings import asbool
@@ -32,6 +31,7 @@ from tests.utils import (
     mocked_wps_output,
     setup_config_with_mongodb
 )
+from tests.functional.utils import ResourcesUtil
 from weaver import WEAVER_ROOT_DIR
 from weaver.config import WeaverConfiguration
 from weaver.formats import ContentType
@@ -103,7 +103,7 @@ class ProcessInfo(object):
 
 @pytest.mark.functional
 @pytest.mark.workflow
-class WorkflowTestRunnerBase(TestCase):
+class WorkflowTestRunnerBase(ResourcesUtil, TestCase):
     """
     Runs an end-2-end test procedure on weaver configured as EMS located on specified `WEAVER_TEST_SERVER_HOSTNAME`.
     """
@@ -495,75 +495,6 @@ class WorkflowTestRunnerBase(TestCase):
                     i["data"] = swap[1]
 
         return ProcessInfo(process_id, test_process_id, deploy_payload, execute_payload)
-
-    @classmethod
-    def retrieve_payload(cls, process, ref_type=None, location=None):
-        # type: (str, Optional[str], Optional[str]) -> Dict[str, JSON]
-        """
-        Retrieve content using known structures and locations.
-
-        .. seealso::
-            :meth:`retrieve_process_info`
-
-        :param process: process identifier
-        :param ref_type: content reference type to retrieve {deploy, execute, package}.
-        :param location: override location (unique location with exact lookup instead of variations).
-        :return: first matched contents.
-        """
-        if location:
-            locations = [location]
-        else:
-            var_locations = list(dict.fromkeys([  # don't use set to preserve this prioritized order
-                os.path.join(os.path.dirname(__file__), "application-packages"),
-                os.getenv("TEST_GITHUB_SOURCE_URL"),
-                "https://raw.githubusercontent.com/crim-ca/testbed14/master/application-packages",
-                "https://raw.githubusercontent.com/crim-ca/application-packages/master/OGC/TB16/application-packages",
-            ]))
-            var_locations = [url for url in var_locations if url]
-
-            if ref_type == "deploy":
-                flat_ref = f"DeployProcess_{process}.json"
-                pdir_ref = f"{process}/deploy.json"
-                both_ref = f"{process}/DeployProcess_{process}.json"
-            elif ref_type == "execute":
-                flat_ref = f"Execute_{process}.json"
-                pdir_ref = f"{process}/execute.json"
-                both_ref = f"{process}/Execute_{process}.json"
-            elif ref_type == "package":
-                flat_ref = f"{process}.cwl"
-                pdir_ref = f"{process}/package.cwl"
-                both_ref = f"{process}/{process}.cwl"
-            else:
-                raise ValueError(f"unknown reference type: {ref_type}")
-
-            locations = []
-            for var_loc in var_locations:
-                for var_ref in [flat_ref, pdir_ref, both_ref]:
-                    locations.append(f"{var_loc}/{var_ref}")
-
-        tested_ref = []
-        try:
-            for path in locations:
-                extension = os.path.splitext(path)[-1]
-                retry_extensions = [".json", ".yaml", ".yml"]
-                if extension not in retry_extensions:
-                    retry_extensions = [extension]
-                # Try to find it locally, then fallback to remote
-                for ext in retry_extensions:
-                    path_ext = os.path.splitext(path)[0] + ext
-                    if os.path.isfile(path_ext):
-                        with open(path_ext, "r", encoding="utf-8") as f:
-                            json_payload = yaml.safe_load(f)  # both JSON/YAML
-                            return json_payload
-                    if urlparse(path_ext).scheme != "":
-                        resp = cls.request("GET", path, force_requests=True, ignore_errors=True)
-                        if resp.status_code == HTTPOk.code:
-                            return yaml.safe_load(resp.text)  # both JSON/YAML
-                    tested_ref.append(path)
-        except (IOError, ValueError):
-            pass
-        cls.log("{}Cannot find payload from any of the following references:\n- {}"
-                .format(cls.logger_separator_calls, "\n- ".join(tested_ref)), exception=True)
 
     @classmethod
     def assert_response(cls, response, status=None, message=""):

--- a/tests/functional/test_wps_package.py
+++ b/tests/functional/test_wps_package.py
@@ -1599,7 +1599,8 @@ class WpsPackageAppTest(WpsConfigBase, ResourcesUtil):
         tmp_file = "{}/{}".format(self.settings["weaver.wps_output_dir"], job_output_path)
 
         try:
-            processed_values = json.load(open(tmp_file, "r"))
+            with open(tmp_file, "r") as out_file:
+                processed_values = json.load(out_file)
         except FileNotFoundError:
             self.fail("Output file [{}] was not found where it was expected to resume test".format(tmp_file))
         except Exception as exception:
@@ -1791,7 +1792,7 @@ class WpsPackageAppTest(WpsConfigBase, ResourcesUtil):
                 results = self.monitor_job(status_url, timeout=5)
                 wps_dir = self.settings["weaver.wps_output_dir"]
                 ctx_dir = (wps_dir + "/" + ctx) if ctx else wps_dir
-                out_url = "https://localhost" + self.settings["weaver.wps_output_path"]
+                out_url = self.settings["weaver.wps_output_url"]
                 ctx_url = (out_url + "/" + ctx) if ctx else out_url
                 res_url = ctx_url + "/" + job_id + "/stdout.log"
                 res_path = os.path.join(ctx_dir, job_id, "stdout.log")

--- a/tests/functional/utils.py
+++ b/tests/functional/utils.py
@@ -11,6 +11,7 @@ import pytest
 import yaml
 from pyramid.httpexceptions import HTTPOk
 
+from tests.functional import APP_PKG_ROOT
 from tests.utils import (
     get_test_weaver_app,
     get_test_weaver_config,
@@ -19,9 +20,8 @@ from tests.utils import (
     setup_config_with_mongodb,
     setup_config_with_pywps,
     setup_mongodb_jobstore,
-    setup_mongodb_processstore,
+    setup_mongodb_processstore
 )
-from tests.functional import APP_PKG_ROOT
 from weaver import WEAVER_ROOT_DIR
 from weaver.database import get_db
 from weaver.formats import ContentType

--- a/tests/functional/utils.py
+++ b/tests/functional/utils.py
@@ -31,8 +31,8 @@ from weaver.utils import fully_qualified_name, load_file
 from weaver.visibility import Visibility
 
 if TYPE_CHECKING:
-    from typing import Any, Dict, Literal, Optional, Union
-    from weaver.typedefs import AnyResponseType, JSON, SettingsType
+    from typing import Any, Dict, Optional, Union
+    from weaver.typedefs import AnyResponseType, JSON, Literal, SettingsType
 
     ReferenceType = Literal["deploy", "execute", "package"]
 

--- a/tests/wps_restapi/test_processes.py
+++ b/tests/wps_restapi/test_processes.py
@@ -1185,8 +1185,8 @@ class WpsRestApiProcessesTest(unittest.TestCase):
         process = {
             "id": self._testMethodName,
             "metadata": [
-                {"type": "value-typed", "value": "some-value", "lang": "en-US"},
-                {"type": "link-typed", "href": "https://example.com", "hreflang": "en-US", "rel": "example"}
+                {"role": "http://example.com/value-typed", "value": "some-value", "lang": "en-US"},
+                {"type": ContentType.TEXT_PLAIN, "href": "https://example.com", "hreflang": "en-US", "rel": "example"}
             ],
             "inputs": [],
             "outputs": [],

--- a/weaver/processes/execution.py
+++ b/weaver/processes/execution.py
@@ -303,10 +303,10 @@ def parse_wps_inputs(wps_process, job):
             # in case of array inputs, must repeat (id,value)
             if isinstance(input_val, list):
                 input_values = input_val
-                input_details = job_input
+                input_details = input_val  # each value has its own metadata
             else:
                 input_values = [input_val]
-                input_details = [job_input]
+                input_details = [job_input]  # metadata directly in definition, not nested per array value
 
             # we need to support file:// scheme but PyWPS doesn't like them so remove the scheme file://
             input_values = [

--- a/weaver/processes/wps_package.py
+++ b/weaver/processes/wps_package.py
@@ -6,7 +6,7 @@ defined as :term:`CWL` `CommandLineTool`/`Workflow` and :term:`WPS` `ProcessDesc
 generate :term:`ADES`/:term:`EMS` deployable :term:`Application Package`.
 
 .. seealso::
-    - `CWL specification <https://www.commonwl.org/#Specification>`_
+    - `CWL specification <https://www.commonwl.org/specification/>`_
     - `WPS-1/2 schemas <http://schemas.opengis.net/wps/>`_
     - `WPS-REST schemas <https://github.com/opengeospatial/wps-rest-binding>`_
     - :mod:`weaver.wps_restapi.api` conformance details

--- a/weaver/wps_restapi/colander_extras.py
+++ b/weaver/wps_restapi/colander_extras.py
@@ -112,6 +112,16 @@ class OneOfCaseInsensitive(colander.OneOf):
     """
     Validator that ensures the given value matches one of the available choices, but allowing case insensitive values.
     """
+    def __init__(self, choices, *args, **kwargs):
+        insensitive_choices = dict()  # set with kept order
+        for choice in choices:
+            insensitive_choices.setdefault(choice, None)
+            if isinstance(choice, str):
+                # add common combinations (not technically all possible ones)
+                insensitive_choices.setdefault(choice.lower(), None)
+                insensitive_choices.setdefault(choice.upper(), None)
+        insensitive_choices = list(insensitive_choices)
+        super(OneOfCaseInsensitive, self).__init__(insensitive_choices, *args, **kwargs)
 
     def __call__(self, node, value):
         if str(value).lower() not in (choice.lower() for choice in self.choices):

--- a/weaver/wps_restapi/constants.py
+++ b/weaver/wps_restapi/constants.py
@@ -1,0 +1,24 @@
+from typing import TYPE_CHECKING
+
+from weaver.base import Constants
+
+
+class JobOutputsSchema(Constants):
+    """
+    Schema selector to represent a :term:`Job` output results.
+    """
+    OGC_STRICT = "ogc+strict"
+    OLD_STRICT = "old+strict"
+    OGC = "ogc"
+    OLD = "old"
+
+
+if TYPE_CHECKING:
+    from weaver.typedefs import Literal
+
+    JobOutputsSchemaType = Literal[
+        JobOutputsSchema.OGC_STRICT,
+        JobOutputsSchema.OLD_STRICT,
+        JobOutputsSchema.OGC,
+        JobOutputsSchema.OLD
+    ]

--- a/weaver/wps_restapi/swagger_definitions.py
+++ b/weaver/wps_restapi/swagger_definitions.py
@@ -2856,15 +2856,16 @@ class ExecuteInputListValues(ExtendedSequenceSchema):
 # Defined as:
 #   https://github.com/opengeospatial/ogcapi-processes/blob/master/core/openapi/schemas/link.yaml
 # But explicitly in the context of an execution input, rather than any other link (eg: metadata)
-class ExecuteInputLink(Link):  # for other metadata (title, hreflang, etc.)
+class ExecuteInputFileLink(Link):  # for other metadata (title, hreflang, etc.)
     schema_ref = f"{OGC_API_SCHEMA_URL}/{OGC_API_SCHEMA_VERSION}/core/openapi/schemas/link.yaml"
     href = ReferenceURL(  # no just a plain 'URL' like 'Link' has (extended with s3, vault, etc.)
         description="Location of the file reference."
     )
     type = MediaType(
-        default=ContentType.TEXT_PLAIN,  # as per OGC, not required
+        default=ContentType.TEXT_PLAIN,  # as per OGC, not mandatory (ie: 'default' supported format)
         description="IANA identifier of content-type located at the link."
     )
+    rel = LinkRelationshipType(missing=drop)  # optional opposite to normal 'Link'
 
 
 # same as 'ExecuteInputLink', but using 'OLD' schema with 'format' field
@@ -2874,8 +2875,8 @@ class ExecuteInputReference(Reference):
 
 class ExecuteInputFile(AnyOfKeywordSchema):
     _any_of = [
-        ExecuteInputLink(),
-        ExecuteInputReference(),
+        ExecuteInputFileLink(),   # 'OGC' schema with 'type: <MediaType>'
+        ExecuteInputReference(),  # 'OLD' schema with 'format: {mimeType|mediaType: <MediaType>}'
     ]
 
 
@@ -2893,10 +2894,10 @@ class ExecuteInputFile(AnyOfKeywordSchema):
 class ExecuteInputInlineValue(OneOfKeywordSchema):
     description = "Execute input value provided inline."
     _one_of = [
-        ExtendedSchemaNode(Float()),
-        ExtendedSchemaNode(Integer()),
-        ExtendedSchemaNode(Boolean()),
-        ExtendedSchemaNode(String()),
+        ExtendedSchemaNode(Float(), title="ExecuteInputValueFloat"),
+        ExtendedSchemaNode(Integer(), title="ExecuteInputValueInteger"),
+        ExtendedSchemaNode(Boolean(), title="ExecuteInputValueBoolean"),
+        ExtendedSchemaNode(String(), title="ExecuteInputValueString"),
     ]
 
 


### PR DESCRIPTION
## Overview

Better support 'type' field for file 'href' input & other link/metadata references.

## Changes

- Add ``schema`` query parameter to ``GET /jobs/{jobID}/outputs`` request allowing to select between ``OGC``, ``OLD``
  ``OGC+strict`` and ``OLD+strict`` representations (case insensitive), each with different combinations
  of ``format.mimeType``, ``format.mediaType`` and/or directly ``type`` field to provide the Content-Type of an
  output with ``href`` file.
  By default, both the ``format`` (i.e.: ``OLD`` schema) and the ``type`` (i.e.: ``OGC`` schema) are simultaneously
  reported for backward and forward compatibility, and for `OGC` compliance to return a file reference IANA Media-Type
  (resolves `#401 <https://github.com/crim-ca/weaver/issues/401>`_).
- Add support of ``type`` as alias to the Media-Type of the ``format`` of file references when submitted
  for ``Job`` execution inputs, in accordance to the reported inputs/outputs endpoints, and for `OGC` compliance.
- Drop ``type`` field for ``metadata`` items in process description that correspond to a ``value`` with a ``role``.
- Enforce pattern validation of ``type`` as IANA Content-Type for ``metadata`` items in process description that
  correspond to a ``Link`` with ``href``. Invalid ``type`` are now rejected to adhere to `OGC` requirement classes.
- Clarify schema employed by `Weaver` to use naming that is as close as possible to `OGC` schemas to facilitate their
  comprehension and external references.

## Fixes
- Fix ``GET /jobs/{jobID}/inputs`` endpoint failing to return submitted ``inputs`` for ``Job`` execution when they
  were specified using the mapping representation (i.e.: ``OGC`` schema) instead of the listing representation
  (i.e.: ``OLD`` schema).

## References

- fixes #401