### PR TITLE
Add new CLI options

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@ Changes:
 --------
 - Add `CLI` option ``-L/--no-links`` that drops the ``links`` section of any response to make the printed result more
   concise and specific to relevant details of the called operation.
+- Add `CLI` option ``-F/--format`` that allows output of contents in an alternative format.
+  Available formatters include JSON, YAML and XML representations, with either pretty indentation and newlines or not.
 
 Fixes:
 ------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,10 @@ Changes:
   concise and specific to relevant details of the called operation.
 - Add `CLI` option ``-F/--format`` that allows output of contents in an alternative format.
   Available formatters include JSON, YAML and XML representations, with either pretty indentation and newlines or not.
+- Add `CLI` option ``-H/--headers`` that allows output of response headers as well as the response contents.
+  This can be useful for endpoints that can return critical information, such as ``Location`` header for the `Job`
+  status endpoint of an `OGC` compliant service, or the ``Preference-Applied`` header for services that support multiple
+  execution modes (i.e.: ``wait`` for ``sync-execute`` or ``respond-async`` for ``async-execute`` control options).
 
 Fixes:
 ------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,9 @@ Changes:
   concise and specific to relevant details of the called operation.
 - Add `CLI` option ``-F/--format`` that allows output of contents in an alternative format.
   Available formatters include JSON, YAML and XML representations, with either pretty indentation and newlines or not.
+  This allows `CLI` calls that can return contents in the preferred format of a such that might need to parse the
+  relevant details. Alternative until the API itself can return similar formatted responses
+  (relates to `#125 <https://github.com/crim-ca/weaver/issues/125>`_).
 - Add `CLI` option ``-H/--headers`` that allows output of response headers as well as the response contents.
   This can be useful for endpoints that can return critical information, such as ``Location`` header for the `Job`
   status endpoint of an `OGC` compliant service, or the ``Preference-Applied`` header for services that support multiple

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,7 +12,8 @@ Changes
 
 Changes:
 --------
-- No change.
+- Add `CLI` option ``-L/--no-links`` that drops the ``links`` section of any response to make the printed result more
+  concise and specific to relevant details of the called operation.
 
 Fixes:
 ------

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,6 +36,7 @@ git+https://github.com/ESGF/esgf-compute-api.git@v2.3.7#egg=esgf-compute-api
 # it is also only available for Python >=3.5
 # use pserve to continue supporting config.ini with paste settings
 gunicorn>=20.0.4
+json2xml
 jsonschema>=3.0.1
 lxml
 mako

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -631,6 +631,28 @@ class TestWeaverCLI(TestWeaverClientBase):
         assert any("\"inputs\": {" in line for line in lines)
         assert any("\"outputs\": {" in line for line in lines)
 
+    def test_describe_no_links(self):
+        # prints formatted JSON ProcessDescription over many lines
+        proc = self.test_process["Echo"]
+        lines = mocked_sub_requests(
+            self.app, run_command,
+            [
+                # "weaver",
+                "describe",
+                "-u", self.url,
+                "-p", proc,
+                "-L",
+            ],
+            trim=False,
+            entrypoint=weaver_cli,
+            only_local=True,
+        )
+        # ignore indents of fields from formatted JSON content
+        assert any(f"\"id\": \"{proc}\"" in line for line in lines)
+        assert any("\"inputs\": {" in line for line in lines)
+        assert any("\"outputs\": {" in line for line in lines)
+        assert all("\"links\":" not in line for line in lines)
+
     def test_execute_inputs_capture(self):
         """
         Verify that specified inputs are captured for a limited number of 1 item per ``-I`` option.

--- a/weaver/datatype.py
+++ b/weaver/datatype.py
@@ -31,7 +31,7 @@ from pywps import Process as ProcessWPS
 from weaver import xml_util
 from weaver.exceptions import ProcessInstanceError, ServiceParsingError
 from weaver.execute import ExecuteControlOption, ExecuteMode, ExecuteTransmissionMode
-from weaver.formats import AcceptLanguage, ContentType
+from weaver.formats import AcceptLanguage, ContentType, repr_json
 from weaver.processes.constants import ProcessSchema
 from weaver.processes.convert import get_field, null, ows2json, wps2json_io
 from weaver.processes.types import ProcessType
@@ -45,7 +45,6 @@ from weaver.utils import (
     get_log_fmt,
     get_settings,
     now,
-    repr_json,
     request_extra
 )
 from weaver.visibility import Visibility

--- a/weaver/processes/wps3_process.py
+++ b/weaver/processes/wps3_process.py
@@ -8,7 +8,7 @@ from pyramid.settings import asbool
 
 from weaver.exceptions import PackageExecutionError
 from weaver.execute import ExecuteMode, ExecuteResponse, ExecuteTransmissionMode
-from weaver.formats import ContentType
+from weaver.formats import ContentType, repr_json
 from weaver.processes import opensearch
 from weaver.processes.sources import get_data_source_from_url, retrieve_data_source_url
 from weaver.processes.utils import map_progress
@@ -21,7 +21,6 @@ from weaver.utils import (
     get_job_log_msg,
     get_log_monitor_msg,
     pass_http_error,
-    repr_json,
     request_extra
 )
 from weaver.visibility import Visibility

--- a/weaver/processes/wps_package.py
+++ b/weaver/processes/wps_package.py
@@ -48,7 +48,7 @@ from weaver.exceptions import (
     PackageTypeError,
     PayloadNotFound
 )
-from weaver.formats import ContentType, get_cwl_file_format
+from weaver.formats import ContentType, get_cwl_file_format, repr_json
 from weaver.processes import opensearch
 from weaver.processes.constants import (
     CWL_REQUIREMENT_APP_BUILTIN,
@@ -89,7 +89,6 @@ from weaver.utils import (
     get_settings,
     is_remote_file,
     load_file,
-    repr_json,
     request_extra,
     setup_loggers
 )

--- a/weaver/store/mongodb.py
+++ b/weaver/store/mongodb.py
@@ -38,11 +38,12 @@ from weaver.exceptions import (
     VaultFileRegistrationError
 )
 from weaver.execute import ExecuteMode
+from weaver.formats import repr_json
 from weaver.processes.types import ProcessType
 from weaver.sort import Sort, SortMethods
 from weaver.status import JOB_STATUS_CATEGORIES, Status, map_status
 from weaver.store.base import StoreBills, StoreJobs, StoreProcesses, StoreQuotes, StoreServices, StoreVault
-from weaver.utils import get_base_url, get_sane_name, get_weaver_url, islambda, now, repr_json
+from weaver.utils import get_base_url, get_sane_name, get_weaver_url, islambda, now
 from weaver.visibility import Visibility
 from weaver.wps.utils import get_wps_url
 

--- a/weaver/utils.py
+++ b/weaver/utils.py
@@ -563,22 +563,6 @@ def now(tz_name=None):
     return localize_datetime(datetime.now().astimezone(), tz_name=tz_name)
 
 
-def repr_json(data, force_string=True, **kwargs):
-    # type: (Any, bool, Any) -> Union[JSON, str, None]
-    """
-    Ensure that the input data can be serialized as JSON to return it formatted representation as such.
-
-    If formatting as JSON fails, returns the data as string representation or ``None`` accordingly.
-    """
-    if data is None:
-        return None
-    try:
-        data_str = json.dumps(data, **kwargs)
-        return data_str if force_string else data
-    except Exception:  # noqa: W0703 # nosec: B110
-        return str(data)
-
-
 def wait_secs(run_step=-1):
     # type: (int) -> int
     """

--- a/weaver/vault/utils.py
+++ b/weaver/vault/utils.py
@@ -11,8 +11,9 @@ from pyramid.httpexceptions import HTTPBadRequest, HTTPForbidden, HTTPGone
 
 from weaver.database import get_db
 from weaver.datatype import VaultFile
+from weaver.formats import repr_json
 from weaver.store.base import StoreVault
-from weaver.utils import get_header, get_settings, get_weaver_url, is_uuid, repr_json
+from weaver.utils import get_header, get_settings, get_weaver_url, is_uuid
 from weaver.wps_restapi import swagger_definitions as sd
 
 if TYPE_CHECKING:

--- a/weaver/wps_restapi/jobs/jobs.py
+++ b/weaver/wps_restapi/jobs/jobs.py
@@ -31,12 +31,12 @@ from weaver.exceptions import (
     ServiceNotFound,
     log_unhandled_exceptions
 )
-from weaver.formats import ContentType, OutputFormat, get_format
+from weaver.formats import ContentType, OutputFormat, get_format, repr_json
 from weaver.owsexceptions import OWSNotFound
 from weaver.processes.convert import any2wps_literal_datatype
 from weaver.status import JOB_STATUS_CATEGORIES, Status, StatusCategory, map_status
 from weaver.store.base import StoreJobs, StoreProcesses, StoreServices
-from weaver.utils import get_any_id, get_any_value, get_path_kvp, get_settings, get_weaver_url, is_uuid, repr_json
+from weaver.utils import get_any_id, get_any_value, get_path_kvp, get_settings, get_weaver_url, is_uuid
 from weaver.visibility import Visibility
 from weaver.wps.utils import get_wps_output_dir, get_wps_output_url
 from weaver.wps_restapi import swagger_definitions as sd

--- a/weaver/wps_restapi/processes/processes.py
+++ b/weaver/wps_restapi/processes/processes.py
@@ -15,13 +15,13 @@ from pyramid.settings import asbool
 
 from weaver.database import get_db
 from weaver.exceptions import ProcessNotFound, ServiceException, log_unhandled_exceptions
-from weaver.formats import OutputFormat
+from weaver.formats import OutputFormat, repr_json
 from weaver.processes import opensearch
 from weaver.processes.execution import submit_job
 from weaver.processes.types import ProcessType
 from weaver.processes.utils import deploy_process_from_payload, get_job_submission_response, get_process
 from weaver.store.base import StoreProcesses
-from weaver.utils import fully_qualified_name, get_any_id, repr_json
+from weaver.utils import fully_qualified_name, get_any_id
 from weaver.visibility import Visibility
 from weaver.wps_restapi import swagger_definitions as sd
 from weaver.wps_restapi.processes.utils import get_process_list_links, get_processes_filtered_by_valid_schemas


### PR DESCRIPTION
## Changes
- Add `CLI` option ``-L/--no-links`` that drops the ``links`` section of any response to make the printed result more
  concise and specific to relevant details of the called operation.
- Add `CLI` option ``-F/--format`` that allows output of contents in an alternative format.
  Available formatters include JSON, YAML and XML representations, with either pretty indentation and newlines or not.
- Add `CLI` option ``-H/--headers`` that allows output of response headers as well as the response contents.
  This can be useful for endpoints that can return critical information, such as ``Location`` header for the `Job`
  status endpoint of an `OGC` compliant service, or the ``Preference-Applied`` header for services that support multiple
  execution modes (i.e.: ``wait`` for ``sync-execute`` or ``respond-async`` for ``async-execute`` control options).