### PR TITLE
support different accept header / format query for job logs listing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,7 +12,8 @@ Changes
 
 Changes:
 --------
-- No change.
+- Add support of ``Accept`` header, ``f`` and ``format`` request queries for ``GET /jobs/{jobID}/logs`` retrieval
+  using ``text``, ``json``, ``yaml`` and ``xml`` (and their corresponding Media-Type definitions) to list `Job` logs.
 
 Fixes:
 ------

--- a/docs/source/processes.rst
+++ b/docs/source/processes.rst
@@ -514,7 +514,8 @@ filtering is not implemented as it offers no additional advantage for files acce
 This could be added later if ``Multipart`` raw data representation is required.
 Please |submit-issue|_ to request this feature if it is relevant for your use-cases.
 
-.. fixme::
+.. fixme:
+.. todo::
     Filtering of ``outputs`` not implemented (everything always available).
     https://github.com/crim-ca/weaver/issues/380
 
@@ -1465,4 +1466,3 @@ Workflow (Chaining Step Processes)
     - :ref:`CWL Workflow`
     - :ref:`proc_workflow_ops`
     - :ref:`Workflow` process type
-

--- a/tests/wps_restapi/test_jobs.py
+++ b/tests/wps_restapi/test_jobs.py
@@ -1,7 +1,7 @@
 import contextlib
 import datetime
-import logging
 import json
+import logging
 import os
 import shutil
 import tempfile

--- a/tests/wps_restapi/test_jobs.py
+++ b/tests/wps_restapi/test_jobs.py
@@ -1501,7 +1501,7 @@ class WpsRestApiJobsTest(unittest.TestCase):
         assert isinstance(resp.text, str)
         assert not resp.text.startswith("[\"[")  # JSON list '[' followed by each string item with [<datetime>]
         with pytest.raises(AttributeError):
-            resp.json  # noqa
+            resp.json  # noqa  # pylint: disable=pointless-statement
         lines = resp.text.split("\n")
         assert len(lines) == 3
         assert "Start" in lines[0]
@@ -1514,7 +1514,7 @@ class WpsRestApiJobsTest(unittest.TestCase):
         assert isinstance(resp.text, str)
         assert not resp.text.startswith("[\"[")  # JSON list '[' followed by each string item with [<datetime>]
         with pytest.raises(AttributeError):
-            resp.json  # noqa
+            resp.json  # noqa  # pylint: disable=pointless-statement
         lines = resp.text.split("\n")
         assert len(lines) == 3
         assert "Start" in lines[0]
@@ -1528,7 +1528,7 @@ class WpsRestApiJobsTest(unittest.TestCase):
         assert resp.text.startswith("<?xml")
         assert "<logs>" in resp.text
         with pytest.raises(AttributeError):
-            resp.json  # noqa
+            resp.json  # noqa  # pylint: disable=pointless-statement
         lines = resp.text.split("<logs>")[-1].split("</logs>")[0].split("<item")[1:]
         assert len(lines) == 3
         assert "Start" in lines[0]
@@ -1540,7 +1540,7 @@ class WpsRestApiJobsTest(unittest.TestCase):
         assert ContentType.APP_YAML in resp.content_type
         assert isinstance(resp.text, str)
         with pytest.raises(AttributeError):
-            resp.json  # noqa
+            resp.json  # noqa  # pylint: disable=pointless-statement
         lines = resp.text.split("\n")
         lines = [line for line in lines if line]
         assert len(lines) == 3

--- a/weaver/datatype.py
+++ b/weaver/datatype.py
@@ -64,6 +64,7 @@ if TYPE_CHECKING:
     from weaver.quotation.status import AnyQuoteStatus
     from weaver.status import AnyStatusType, StatusType
     from weaver.typedefs import (
+        AnyLogLevel,
         AnyProcess,
         AnySettingsContainer,
         AnyUUID,
@@ -590,7 +591,7 @@ class Job(Base):
                  errors=None,       # type: Optional[Union[str, Exception, WPSException, List[WPSException]]]
                  logger=None,       # type: Optional[Logger]
                  message=None,      # type: Optional[str]
-                 level=INFO,        # type: int
+                 level=INFO,        # type: AnyLogLevel
                  status=None,       # type: Optional[AnyStatusType]
                  progress=None,     # type: Optional[Number]
                  ):                 # type: (...) -> None

--- a/weaver/formats.py
+++ b/weaver/formats.py
@@ -591,10 +591,22 @@ def clean_mime_type_format(mime_type, suffix_subtype=False, strip_parameters=Fal
 def guess_target_format(request, default=ContentType.APP_JSON):
     # type: (AnyRequestType, str) -> str
     """
-    Guess the best applicable response ``Content-Type`` header according to request ``Accept`` header and ``format``
-    query, or defaulting to :py:data:`ContentType.APP_JSON`.
+    Guess the best applicable response ``Content-Type`` header from the request.
 
-    :returns: matched MIME-type or default.
+    Considers the request ``Accept`` header, ``format`` query and alternatively ``f`` query to parse possible formats.
+    Full Media-Type are expected in the header. Query parameters can use both the full type, or only the sub-type
+    (i.e.: :term:`JSON`, :term:`XML`, etc.), with case-insensitive names.
+    Defaults to :py:data:`ContentType.APP_JSON` if none was specified.
+
+    Applies some specific logic to handle automatically added ``Accept`` headers by many browsers such that sending
+    requests to the API using them will not automatically default back to :term:`XML` or similar `HTML` representations.
+    If browsers are used to send requests, but that ``format``/``f`` queries are used directly in the URL, those will
+    be applied since this is a very intuitive (and easier) approach to request different formats when using browsers.
+
+    When user-agent clients are identified as another source, such as sending requests from a server or from code, both
+    headers and query parameters are applied directly without question.
+
+    :returns: Matched MIME-type or default.
     """
     from weaver.utils import get_header
 

--- a/weaver/typedefs.py
+++ b/weaver/typedefs.py
@@ -74,6 +74,12 @@ if TYPE_CHECKING:
         "type": str,  # FIXME: relevant?
     }, total=False)
 
+    LogLevelStr = Literal[
+        "CRITICAL", "FATAL", "ERROR", "WARN", "WARNING", "INFO", "DEBUG",
+        "critical", "fatal", "error", "warn", "warning", "info", "debug"
+    ]
+    AnyLogLevel = Union[LogLevelStr, int]
+
     # CWL definition
     GlobType = TypedDict("GlobType", {"glob": Union[str, List[str]]}, total=False)
     CWL_IO_FileValue = TypedDict("CWL_IO_FileValue", {"class": str, "path": str, "format": Optional[str]}, total=True)

--- a/weaver/utils.py
+++ b/weaver/utils.py
@@ -230,28 +230,43 @@ def get_settings(container=None):
     raise TypeError(f"Could not retrieve settings from container object of type [{fully_qualified_name(container)}]")
 
 
-def get_header(header_name, header_container, pop=False):
-    # type: (str, AnyHeadersContainer, bool) -> Union[str, None]
+def get_header(header_name,         # type: str
+               header_container,    # type: AnyHeadersContainer
+               default=None,        # type: Optional[str], Optional[Union[str, List[str]]], bool
+               pop=False,           # type: bool
+               ):                   # type: (...) -> Optional[Union[str, List[str]]]
     """
-    Searches for the specified header by case/dash/underscore-insensitive ``header_name`` inside ``header_container``.
+    Find the specified header within a header container.
+
+    Retrieves :paramref:`header_name` by fuzzy match (independently of upper/lower-case and underscore/dash) from
+    various framework implementations of *Headers*.
+
+    :param header_name: header to find.
+    :param header_container: where to look for :paramref:`header_name`.
+    :param default: returned value if :paramref:`header_container` is invalid or :paramref:`header_name` is not found.
+    :param pop: remove the matched header(s) by name from the input container.
     """
+    def fuzzy_name(_name):
+        # type: (str) -> str
+        return _name.lower().replace("-", "_")
+
     if header_container is None:
-        return None
+        return default
     headers = header_container
     if isinstance(headers, (ResponseHeaders, EnvironHeaders, CaseInsensitiveDict)):
         headers = dict(headers)
     if isinstance(headers, dict):
         headers = header_container.items()
-    header_name = header_name.lower().replace("-", "_")
+    header_name = fuzzy_name(header_name)
     for i, (h, v) in enumerate(list(headers)):
-        if h.lower().replace("-", "_") == header_name:
+        if fuzzy_name(h) == header_name:
             if pop:
                 if isinstance(header_container, dict):
                     del header_container[h]
                 else:
                     del header_container[i]
             return v
-    return None
+    return default
 
 
 def get_cookie_headers(header_container, cookie_header_name="Cookie"):


### PR DESCRIPTION
## Changes

- Add support of ``Accept`` header, ``f`` and ``format`` request queries for ``GET /jobs/{jobID}/logs`` retrieval
  using ``text``, ``json``, ``yaml`` and ``xml`` (and their corresponding Media-Type definitions) to list `Job` logs.
