### PR TITLE
support CLI inputs with extra parameters for mediaType + more CLI tests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@ Changes:
 --------
 - Add support of ``Accept`` header, ``f`` and ``format`` request queries for ``GET /jobs/{jobID}/logs`` retrieval
   using ``text``, ``json``, ``yaml`` and ``xml`` (and their corresponding Media-Type definitions) to list `Job` logs.
+- Add parsing of `CLI` inputs with ``@parameter=value`` additional properties to be passed for the `Process`
+  execution. This can be used for specifying the ``mediaType`` and ``encoding`` of a ``File`` reference input.
 
 Fixes:
 ------

--- a/tests/processes/test_convert.py
+++ b/tests/processes/test_convert.py
@@ -812,18 +812,36 @@ def test_repr2json_input_values():
         "test8:file=/tmp/other.txt",
         "test9:str=short",
         "test10:string=long",
+        # verify that '@parameters' handle some special logic to convert known format fields (not just passed directly)
+        f"test11:File=/tmp/file.json@mediaType={ContentType.APP_JSON}@schema=http://schema.org/random.json",
+        f"test12:File=/tmp/other.xml@mimeType={ContentType.TEXT_XML}@contentSchema=http://schema.org/random.xml",
+        # different representations can be used simultaneously, each parameter is attached to the specific array item
+        f"test13:File=/tmp/one.json@mimeType={ContentType.APP_JSON};/tmp/two.xml@mediaType={ContentType.TEXT_XML}",
     ]
     expect = [
         {"id": "test1", "value": "value"},
         {"id": "test2", "value": 1},
         {"id": "test3", "value": 1.23},
         {"id": "test4", "href": "/tmp/random.txt"},
-        {"id": "test5", "value": ["val1", "val2"]},
-        {"id": "test6", "value": [1, 2]},
-        {"id": "test7", "value": [1.23, 4.56]},
+        # array values are extended to OLD listing format
+        # CLI would then convert them to OGC using 'convert_input_values_schema'
+        {"id": "test5", "value": "val1"},
+        {"id": "test5", "value": "val2"},
+        {"id": "test6", "value": 1},
+        {"id": "test6", "value": 2},
+        {"id": "test7", "value": 1.23},
+        {"id": "test7", "value": 4.56},
         {"id": "test8", "href": "/tmp/other.txt"},
         {"id": "test9", "value": "short"},
-        {"id": "test10", "value": "long"}
+        {"id": "test10", "value": "long"},
+        {"id": "test11", "href": "/tmp/file.json", "format": {
+            "mediaType": ContentType.APP_JSON, "schema": "http://schema.org/random.json"
+        }},
+        {"id": "test12", "href": "/tmp/other.xml", "format": {
+            "mediaType": ContentType.TEXT_XML, "schema": "http://schema.org/random.xml"
+        }},
+        {"id": "test13", "href": "/tmp/one.json", "format": {"mediaType": ContentType.APP_JSON}},
+        {"id": "test13", "href": "/tmp/two.xml", "format": {"mediaType": ContentType.TEXT_XML}},
     ]
     result = repr2json_input_values(values)
     assert result == expect

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,11 +1,20 @@
 """
 Unit test for :mod:`weaver.cli` utilities.
 """
+import base64
 import inspect
+import json
+import tempfile
+from contextlib import ExitStack
+from urllib.parse import quote
 
+import mock
 import pytest
+import yaml
 
-from weaver.cli import OperationResult
+from tests.utils import run_command
+from weaver.cli import OperationResult, WeaverClient, main as weaver_cli
+from weaver.formats import ContentType
 
 
 @pytest.mark.cli
@@ -22,3 +31,140 @@ def test_operation_result_repr():
           ]
         }
     """)
+
+
+@pytest.mark.cli
+def test_cli_url_required_in_client_or_param():
+    with pytest.raises(ValueError):
+        WeaverClient().execute("")
+    try:
+        with mock.patch("weaver.cli.WeaverClient._parse_inputs", return_value=OperationResult()):
+            WeaverClient(url="http://fake.domain.com").execute("")
+            WeaverClient().execute("", url="http://fake.domain.com")
+    except ValueError:
+        pytest.fail()
+
+
+@pytest.mark.cli
+def test_parse_inputs_from_file():
+    inputs = []
+    mock_result = OperationResult(False, code=500)
+
+    def parsed_inputs(_inputs, *_, **__):
+        inputs.append(_inputs)
+        return mock_result
+
+    with mock.patch("weaver.cli.WeaverClient._update_files", side_effect=parsed_inputs):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json") as input_json:
+            json.dump({"inputs": {"input1": "data"}}, input_json)
+            input_json.flush()
+            input_json.seek(0)
+            result = WeaverClient().execute("fake_process", input_json.name, url="http://fake.domain.com")
+    assert result is mock_result
+    assert len(inputs) == 1
+    assert inputs[0] == {"input1": {"value": "data"}}
+
+
+@pytest.mark.cli
+def test_parse_inputs_with_media_type():
+    inputs = []
+    mock_result = OperationResult(True, code=500)
+
+    def parsed_inputs(_inputs, *_, **__):
+        inputs.append(_inputs)
+        return mock_result
+
+    # catch and ignore returned error since we generate it
+    # voluntarily with following mock to stop processing
+    def no_error_cli(*args):
+        weaver_cli(*args)
+        return 0
+
+    with mock.patch("weaver.cli.WeaverClient._update_files", side_effect=parsed_inputs):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yml") as input_yaml:
+            yaml.safe_dump({"info": {"data": "yaml"}}, input_yaml)
+            input_yaml.flush()
+            input_yaml.seek(0)
+
+            run_command([
+                # weaver
+                "execute",
+                # different media-type than YAML on purpose to ensure parsing uses provided value, and not extension
+                "-I", f"input:File={input_yaml.name}@mediaType={ContentType.APP_CWL}",
+                "-p", "fake_process",
+                "-u", "http://fake.domain.com",
+                "-q",  # since CLI fails purposely, avoid logging errors which would be confusing if debugging logs
+            ], entrypoint=no_error_cli)
+
+    assert len(inputs) == 1
+    assert inputs[0] == {
+        "input": {
+            "href": input_yaml.name,  # normally, local file would be uploaded to vault, but we skipped it with mock
+            "format": {"mediaType": ContentType.APP_CWL}
+        }
+    }
+
+    inputs.clear()
+    schema_json = "http://schema.org/random.json"
+    schema_xml = "http://schema.org/other.xml"
+    with mock.patch("weaver.cli.WeaverClient._update_files", side_effect=parsed_inputs):
+        with ExitStack() as stack:
+            input_yaml = stack.enter_context(tempfile.NamedTemporaryFile(mode="w", suffix=".yml"))
+            yaml.safe_dump({"info": {"data": "yaml"}}, input_yaml)
+            input_yaml.flush()
+            input_yaml.seek(0)
+            input_json = stack.enter_context(tempfile.NamedTemporaryFile(mode="w", suffix=".json"))
+            json.dump({"info": {"data": "json"}}, input_json)
+            input_json.flush()
+            input_json.seek(0)
+            input_xml = stack.enter_context(tempfile.NamedTemporaryFile(mode="w", suffix=".xml"))
+            input_xml.write("<xml>data</xml>")
+            input_xml.flush()
+            input_xml.seek(0)
+            input_tif = stack.enter_context(tempfile.NamedTemporaryFile(mode="wb", suffix=".tif"))
+            input_tif.write(base64.b64encode("012345".encode("utf-8")))
+            input_tif.flush()
+            input_tif.seek(0)
+            ctype_tif = ContentType.IMAGE_GEOTIFF  # must be URL-encoded to avoid parsing issue with separators
+            assert " " in ctype_tif and ";" in ctype_tif  # just safeguard in case it is changed at some point
+            ctype_tif_escaped = quote(ctype_tif)
+            assert " " not in ctype_tif_escaped and ";" not in ctype_tif_escaped
+
+            run_command([
+                # weaver
+                "execute",
+                "-I", f"other:File={input_xml.name}@mediaType={ContentType.TEXT_XML}@schema={schema_xml}",
+                "-I", f"input:File={input_yaml.name}@mediaType={ContentType.APP_YAML}@schema={schema_json}",
+                "-I", f"input:File={input_json.name}@type={ContentType.APP_JSON}@rel=schema",
+                "-I", f"other:File={input_tif.name}@mediaType={ctype_tif_escaped}@encoding=base64@rel=image",
+                "-p", "fake_process",
+                "-u", "http://fake.domain.com",
+                "-q",  # since CLI fails purposely, avoid logging errors which would be confusing if debugging logs
+            ], entrypoint=no_error_cli)
+
+    assert len(inputs) == 1
+    assert inputs[0] == {
+        "input": [
+            {
+                "href": input_yaml.name,
+                "format": {"mediaType": ContentType.APP_YAML, "schema": schema_json}
+            },
+            {
+                "href": input_json.name,
+                "type": ContentType.APP_JSON,  # valid alternate OGC representation of format/mediaType object
+                "rel": "schema"  # known field in this case, ensure schema value is not confused with parameter keys
+            }
+        ],
+        "other": [
+            {
+                "href": input_xml.name,
+                "format": {"mediaType": ContentType.TEXT_XML, "schema": schema_xml}
+            },
+            {
+                "href": input_tif.name,
+                "format": {"mediaType": ContentType.IMAGE_GEOTIFF,  # must be unescaped
+                           "encoding": "base64"},
+                "rel": "image",  # irrelevant for real input in this case, but validate parameters are all propagated
+            }
+        ]
+    }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -62,7 +62,7 @@ def test_parse_inputs_from_file():
             result = WeaverClient().execute("fake_process", input_json.name, url="http://fake.domain.com")
     assert result is mock_result
     assert len(inputs) == 1
-    assert inputs[0] == {"input1": {"value": "data"}}
+    assert inputs[0] == {"input1": "data"}
 
 
 @pytest.mark.cli

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -70,6 +70,8 @@ if TYPE_CHECKING:
     MockConfigWPS1 = Sequence[str, str, Optional[Sequence[str]], Optional[Sequence[str]]]
     MockReturnType = TypeVar("MockReturnType")
 
+    CommandType = Callable[[Union[str, Tuple[str]]], int]
+
 MOCK_AWS_REGION = "us-central-1"
 MOCK_HTTP_REF = "http://localhost.mock"
 
@@ -320,7 +322,7 @@ def get_links(resp_links):
 
 
 def run_command(command, trim=True, expect_error=False, entrypoint=None):
-    # type: (Union[str, Iterable[str]], bool, bool, Optional[Callable[[Tuple[Any]], int]]) -> List[str]
+    # type: (Union[str, Iterable[str]], bool, bool, Optional[CommandType]) -> List[str]
     """
     Run a CLI operation and retrieve the produced output.
 

--- a/weaver/cli.py
+++ b/weaver/cli.py
@@ -508,7 +508,7 @@ class WeaverClient(object):
             # - if value of 'inputs' is an object, it can collide with 'OGC' schema,
             #   unless 'value/href' are present or their sub-dict don't have CWL 'class'
             # - if value of 'inputs' is an array, it can collide with 'OLD' schema,
-            #   unless 'value/href' (and 'id' technically) are present
+            #   unless 'value/href' (and also 'id' technically) are present
             values = inputs.get("inputs", null)
             if (
                 values is null or
@@ -526,7 +526,7 @@ class WeaverClient(object):
         return values
 
     def _update_files(self, inputs, url=None):
-        # type: (ExecutionInputsMap, Optional[str]) -> Tuple[ExecutionInputsMap, HeadersType]
+        # type: (ExecutionInputsMap, Optional[str]) -> Union[Tuple[ExecutionInputsMap, HeadersType], OperationResult]
         """
         Replaces local file paths by references uploaded to the :term:`Vault`.
 
@@ -540,7 +540,7 @@ class WeaverClient(object):
               in :ref:`file_vault_token` and :ref:`vault` chapters.
 
         :param inputs: Input values for submission of :term:`Process` execution.
-        :return: Updated inputs.
+        :return: Updated inputs or the result of a failing intermediate request.
         """
         auth_tokens = {}  # type: Dict[str, str]
         update_inputs = dict(inputs)
@@ -641,12 +641,12 @@ class WeaverClient(object):
             returned as direct values (literal or href) within the response content body.
         :returns: Results of the operation.
         """
+        base = self._get_url(url)  # raise before inputs parsing if not available
         if isinstance(inputs, list) and all(isinstance(item, list) for item in inputs):
             inputs = [items for sub in inputs for items in sub]  # flatten 2D->1D list
         values = self._parse_inputs(inputs)
         if isinstance(values, OperationResult):
             return values
-        base = self._get_url(url)
         result = self._update_files(values, url=base)
         if isinstance(result, OperationResult):
             return result
@@ -1299,24 +1299,33 @@ def make_parser():
             for selected format. Both mapping and listing formats are supported.
 
             To execute a process without any inputs (e.g.: using its defaults),
-            supply an explicit empty input (i.e.: ``-I ""`` or loaded from file as ``{}``).
+            supply an explicit empty input (i.e.: ``-I ""`` or loaded from JSON/YAML file as ``{}``).
 
             To provide inputs using literal command-line definitions, inputs should be specified using ``<id>=<value>``
             convention, with distinct ``-I`` options for each applicable input value.
 
-            Values that require other type than string to be converted for job submission can include the type
+            Values that require other type than string to be converted for job submission can include the data type
             following the ID using a colon separator (i.e.: ``<id>:<type>=<value>``). For example, an integer could be
             specified as follows: ``number:int=1`` while a floating point number would be: ``number:float=1.23``.
 
             File references (``href``) should be specified using ``File`` as the type (i.e.: ``input:File=http://...``).
             Note that ``File`` in this case is expected to be an URL location where the file can be download from.
             When a local file is supplied, Weaver will automatically convert it to a remote Vault File in order to
-            upload it and make it available for the remote process.
+            upload it at the specified URL location and make it available for the remote process.
 
-            Array input (``maxOccurs > 1``) should be specified using semicolon (;) separated values.
-            The type of an item of this array can also be provided (i.e.: ``array:int=1;2;3``).
+            Array input (``maxOccurs > 1``) can be specified using semicolon (;) separated values after the input ID.
+            The type of an element-wise item of this array can also be provided (i.e.: ``arrayInput:int=1;2;3``).
+            Alternatively, the same input ID can be repeated over many ``-I`` options each providing an element of the
+            multi-value array to be formed.
 
-            Example: ``-I message='Hello Weaver' -I value:int=1234``
+            Additional parameters can be specified following any ``<value>`` using any amount of ``@<param>=<info>``
+            specifiers. Those will be added to the inputs body submitted for execution. This can be used, amongst other
+            things, to provide a file's ``mediaType`` or ``encoding`` details. When using array values, each value in
+            the array can take ``@`` parameters independently.
+
+            Any value that contains a special separator character (:;@) must URL-encoded (%XX) to avoid invalid parsing.
+
+            Example: ``-I message='Hello Weaver' -I value:int=1234 -I file:File=data.xml@mediaType=text/xml``
         """)
     )
     # FIXME: allow filtering 'outputs' (https://github.com/crim-ca/weaver/issues/380)

--- a/weaver/cli.py
+++ b/weaver/cli.py
@@ -1323,7 +1323,7 @@ def make_parser():
             things, to provide a file's ``mediaType`` or ``encoding`` details. When using array values, each value in
             the array can take ``@`` parameters independently.
 
-            Any value that contains a special separator character (:;@) must URL-encoded (%XX) to avoid invalid parsing.
+            Any value that contains special separator characters (:;@) must URL-encoded (%%XX) to avoid invalid parsing.
 
             Example: ``-I message='Hello Weaver' -I value:int=1234 -I file:File=data.xml@mediaType=text/xml``
         """)

--- a/weaver/processes/convert.py
+++ b/weaver/processes/convert.py
@@ -8,7 +8,7 @@ from collections.abc import Hashable
 from copy import deepcopy
 from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING
-from urllib.parse import urlparse
+from urllib.parse import urlparse, unquote
 
 from owslib.wps import ComplexData, Metadata as OWS_Metadata, is_reference
 from pywps import Process as ProcessWPS
@@ -57,7 +57,7 @@ from weaver.utils import (
 from weaver.wps.utils import get_wps_client
 
 if TYPE_CHECKING:
-    from typing import Any, Dict, List, Optional, Tuple, Type, Union
+    from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
     from urllib.parse import ParseResult
 
     from pywps.app import WPSRequest
@@ -85,7 +85,8 @@ if TYPE_CHECKING:
         ExecutionInputsList,
         ExecutionOutputs,
         JobValueFile,
-        JSON
+        JSON,
+        TypedDict
     )
     from weaver.wps_restapi.constants import JobInputsOutputsSchemaType
 
@@ -104,6 +105,10 @@ if TYPE_CHECKING:
     ANY_IO_Type = Union[CWL_IO_Type, JSON_IO_Type, WPS_IO_Type, OWS_IO_Type]
     ANY_Format_Type = Union[Dict[str, Optional[str]], Format]
     ANY_Metadata_Type = Union[OWS_Metadata, WPS_Metadata, Dict[str, str]]
+    DataInputType = TypedDict("DataInputType", {
+        "data": Union[float, int, bool, str],
+        # ** any other params
+    }, total=False)
 
 
 # WPS object attribute -> all possible *other* naming variations (no need to repeat key name)
@@ -134,7 +139,8 @@ WPS_FIELD_MAPPING = {
     "range_maximum": ["maxval", "maximum", "maximumValue"],
     "range_spacing": ["spacing"],
     "range_closure": ["closure", "rangeClosure"],
-    "encoding": ["Encoding"],
+    "encoding": ["Encoding", "content_encoding", "contentEncoding"],
+    "schema": ["Schema", "contentSchema"],
     "href": ["url", "link", "reference"],
 }
 # WPS fields that contain a structure corresponding to `Format` object
@@ -157,13 +163,13 @@ setattr(DEFAULT_FORMAT, DEFAULT_FORMAT_MISSING, True)
 INPUT_VALUE_TYPE_MAPPING = {
     "bool": bool,
     "boolean": bool,
-    "file": str,
-    "File": str,
+    "file": unquote,
+    "File": unquote,
     "float": float,
     "int": int,
     "integer": int,
-    "str": str,
-    "string": str,
+    "str": unquote,
+    "string": unquote,
 }
 
 LOGGER = logging.getLogger(__name__)
@@ -1123,16 +1129,43 @@ def convert_output_params_schema(outputs, schema):
     raise NotImplementedError(f"Unknown conversion format of outputs definitions for schema: [{schema}]")
 
 
+def repr2json_input_params(value, converter=None):
+    # type: (str, Optional[Callable[[str], Any]]) -> DataInputType
+    """
+    Extracts and converts the value and its associated parameters from a :term:`KVP` string representation.
+
+    This function only interprets a pre-extracted single-value definition (i.e.: without the input ID) from a parent
+    :term:`KVP` string.
+
+    .. seealso::
+        Use :func:`repr2json_input_values` For parsing multi-value arrays and the full :term:`KVP` including the ID.
+
+    :param value: String representation of the value to be interpreted.
+    :param converter: Conversion function of the value after parsing.
+    :return: Converted value and additional parameters if applicable.
+    """
+    params = value.split("@")
+    value = params[0]
+    if converter is not None:
+        value = converter(value)
+    params = params[1:]
+    parameters = {}
+    for param in params:
+        param_key, param_val = param.split("=", 1)
+        parameters[param_key] = unquote(param_val)
+    return {"data": value, **parameters}
+
+
 def repr2json_input_values(inputs):
     # type: (List[str]) -> ExecutionInputsList
     """
     Converts inputs in string :term:`KVP` representation to corresponding :term:`JSON` values.
 
-    Expected format is as follows:
+    Expected format of the input is as follows:
 
     .. code-block:: text
 
-        input_id[:input_type]=input_value[;input_array]
+        input_id[:input_type]=input_value[@input_parameter][;input_array[@input_parameter]][;...]
 
     Where:
         - ``input_id`` represents the target identifier of the input
@@ -1140,13 +1173,31 @@ def repr2json_input_values(inputs):
           (includes ``File`` for ``href`` instead of ``value`` key in resulting object)
         - ``input_value`` represents the desired value subject to conversion by ``input_type``
         - ``input_array`` represents any additional values for array-like inputs (``maxOccurs > 1``)
+        - ``input_parameter`` represents additional :term:`KVP` details associated to each
+          ``input_value``/``input_array`` part (i.e.: per array element if applicable)
+
+    The separator character for representing array-like values is ``;`` because the full :term:`KVP`
+    (already split into a list as argument to this function), could be formed of multiple comma (``,``) or
+    ampersand (``&``) separated input definitions, depending on where the definition came from (e.g.: URI).
+
+    The ``input_parameter`` portion can combine multiple parameters each separated by ``@`` and themselves formed with
+    :term:`KVP` representation of the corresponding parameter names and values. Parameter names do not need to be
+    consistent between distinct array elements. For example, a multi-parameters input could be formatted as follows:
+
+    .. code-block:: text
+
+        input_id=item_value1@param1=value1@param2=value2;item_value2@other1=value1
+
+    .. note::
+        - Any character that matches one of the separators that should be interpreted literally should be URL-encoded.
+        - Single (``'``) and double (``"``) quotes are removed if they delimit a ``File`` reference.
 
     :param inputs: list of string inputs to parse.
     :return: parsed inputs if successful.
     """
     values = []
     for str_input in inputs:
-        str_id, str_val = str_input.split("=")
+        str_id, str_val = str_input.split("=", 1)
         str_id_typ = str_id.split(":")
         if len(str_id_typ) == 2:
             str_id, str_typ = str_id_typ
@@ -1157,19 +1208,27 @@ def repr2json_input_values(inputs):
         val_typ = any2cwl_literal_datatype(str_typ)
         if not str_id or (val_typ is null and str_typ not in INPUT_VALUE_TYPE_MAPPING):
             raise ValueError(f"Invalid input value ID representation. "
-                             f"Missing or unknown 'ID[:type]' parts after resolution as '{str_id!s}:{str_typ!s}'.")
+                             f"Missing or unknown 'ID[:TYPE]' parts after resolution as '{str_id!s}:{str_typ!s}'.")
         map_typ = val_typ if val_typ is not null else str_typ
         arr_val = str_val.split(";")
-        arr_typ = INPUT_VALUE_TYPE_MAPPING[map_typ]
-        arr_val = [arr_typ(val) for val in arr_val]
+        convert = INPUT_VALUE_TYPE_MAPPING[map_typ]
+        arr_val = [repr2json_input_params(val, convert) for val in arr_val]
         if map_typ.capitalize() == "File":
             val_key = "href"
-            for i, val in enumerate(list(arr_val)):
-                if (val.startswith("'") and val.endswith("'")) or (val.startswith("\"") and val.endswith("\"")):
-                    arr_val[i] = val[1:-1]
+            for val in arr_val:
+                ref = val["data"]
+                if (ref.startswith("'") and ref.endswith("'")) or (ref.startswith("\"") and ref.endswith("\"")):
+                    val["data"] = ref[1:-1]
+                fmt = {}  # transfer parameters matching format fields that must be nested in value definition
+                for field, target in [("mime_type", "mediaType"), ("encoding", "encoding"), ("schema", "schema")]:
+                    val_field = get_field(val, field, search_variations=True, pop_found=True)
+                    if val_field is not null:
+                        fmt[target] = val_field
+                if fmt:
+                    val["format"] = fmt
         else:
             val_key = "value"
-        values.append({"id": str_id, val_key: arr_val if ";" in str_val else arr_val[0]})
+        values.extend([{"id": str_id, val_key: val.pop("data"), **val} for val in arr_val])
     return values
 
 

--- a/weaver/processes/convert.py
+++ b/weaver/processes/convert.py
@@ -8,7 +8,7 @@ from collections.abc import Hashable
 from copy import deepcopy
 from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING
-from urllib.parse import urlparse, unquote
+from urllib.parse import unquote, urlparse
 
 from owslib.wps import ComplexData, Metadata as OWS_Metadata, is_reference
 from pywps import Process as ProcessWPS

--- a/weaver/wps_restapi/swagger_definitions.py
+++ b/weaver/wps_restapi/swagger_definitions.py
@@ -3007,10 +3007,10 @@ class ExecuteInputData(OneOfKeywordSchema):
 #   inputs:
 #     additionalProperties:           # this is the below 'variable=<input-id>'
 #       oneOf:
-# 	    - $ref: "inlineOrRefData.yaml"
-# 	    - type: array
-# 	      items:
-# 	        $ref: "inlineOrRefData.yaml"
+#       - $ref: "inlineOrRefData.yaml"
+#       - type: array
+#         items:
+#           $ref: "inlineOrRefData.yaml"
 #
 class ExecuteInputMapAdditionalProperties(ExtendedMappingSchema):
     schema_ref = f"{OGC_API_SCHEMA_URL}/{OGC_API_SCHEMA_VERSION}/core/openapi/schemas/execute.yaml"


### PR DESCRIPTION
In was impossible up until now to specify which *supported format* to employ when providing a file reference to a process that allows many. This PR fixes this problem with more parsing. The selected `@` is inspired of what is used by WPS for KVP specification of the same definitions. 