### PR TITLE
deploymentProfileName optional + profile deploymentProfile in process description

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,10 @@ Changes:
 --------
 - Add support of ``Accept`` header, ``f`` and ``format`` request queries for ``GET /jobs/{jobID}/logs`` retrieval
   using ``text``, ``json``, ``yaml`` and ``xml`` (and their corresponding Media-Type definitions) to list `Job` logs.
+- Remove ``deploymentProfileName`` requirement during `Process` deployment. The corresponding ``deploymentProfile``
+  property is instead automatically generated from resolved `CWL` package/reference or remote `WPS` reference. This
+  further simplifies deployment using the `CLI` to its bare minimum components as only the `CWL` or `WPS` reference
+  needs to be provided along the desired `Process` ID without any further details.
 
 Fixes:
 ------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,7 +17,8 @@ Changes:
 
 Fixes:
 ------
-- No change.
+- Fix missing ``deploymentProfile`` property in `Process` description
+  (resolves `#319 <https://github.com/crim-ca/weaver/issues/319>`_).
 
 .. _changes_4.15.0:
 

--- a/tests/wps_restapi/test_processes.py
+++ b/tests/wps_restapi/test_processes.py
@@ -495,7 +495,7 @@ class WpsRestApiProcessesTest(unittest.TestCase):
         process_data_tests[2]["processDescription"]["process"].pop("id")  # noqa
         process_data_tests[3]["processDescription"]["jobControlOptions"] = ExecuteControlOption.ASYNC
         process_data_tests[4]["processDescription"]["jobControlOptions"] = [ExecuteMode.ASYNC]  # noqa
-        process_data_tests[5].pop("deploymentProfileName")
+        process_data_tests[5]["deploymentProfileName"] = "random"  # can be omitted, but if provided, must be valid
         process_data_tests[6].pop("executionUnit")
         process_data_tests[7]["executionUnit"] = {}
         process_data_tests[8]["executionUnit"] = []

--- a/weaver/cli.py
+++ b/weaver/cli.py
@@ -390,6 +390,7 @@ class WeaverClient(object):
             if result.code not in [200, 404]:
                 return OperationResult(False, "Failed requested undeployment prior deployment.",
                                        body=result.body, text=result.text, code=result.code, headers=result.headers)
+        LOGGER.debug("Deployment Body:\n%s", OutputFormat.convert(data, OutputFormat.JSON_STR))
         path = f"{base}/processes"
         resp = request_extra("POST", path, json=data, headers=req_headers, settings=self._settings)
         return self._parse_result(resp, show_links=show_links, show_headers=show_headers, output_format=output_format)

--- a/weaver/datatype.py
+++ b/weaver/datatype.py
@@ -1929,6 +1929,19 @@ class Process(Base):
         return self.type != ProcessType.BUILTIN
 
     @property
+    def deployment_profile(self):
+        # type: () -> str
+        base = "http://www.opengis.net/profiles/eoc/"
+        _typ = self.type
+        if _typ == ProcessType.APPLICATION:
+            profile = base + "dockerizedApplication"
+        elif "wps" in _typ:
+            profile = base + "wpsApplication"
+        else:
+            profile = base + _typ
+        return profile
+
+    @property
     def package(self):
         # type: () -> Optional[CWL]
         """
@@ -2163,7 +2176,10 @@ class Process(Base):
         """
         process = self.dict()
         links = self.links()
-        process.update({"links": links})
+        process.update({
+            "deploymentProfile": self.deployment_profile,
+            "links": links
+        })
         # force selection of schema to avoid ambiguity
         if str(schema or ProcessSchema.OGC).upper() == ProcessSchema.OLD:
             # nested process fields + I/O as lists

--- a/weaver/processes/utils.py
+++ b/weaver/processes/utils.py
@@ -263,7 +263,7 @@ def deploy_process_from_payload(payload, container, overwrite=False):
     found = False
     if process_href:
         reference = process_href  # reference type handled downstream
-        found = isinstance(reference, str) and "://" in reference
+        found = isinstance(reference, str)
     elif isinstance(ows_context, dict):
         offering = ows_context.get("offering")
         if not isinstance(offering, dict):
@@ -273,7 +273,7 @@ def deploy_process_from_payload(payload, container, overwrite=False):
             raise HTTPUnprocessableEntity("Invalid parameter 'processDescription.process.owsContext.offering.content'.")
         package = None
         reference = content.get("href")
-        found = isinstance(reference, str) and "://" in reference
+        found = isinstance(reference, str)
     else:
         if deployment_profile_name:  # optional hint
             allowed_profile_suffix = [ProcessType.APPLICATION, ProcessType.WORKFLOW]
@@ -291,7 +291,7 @@ def deploy_process_from_payload(payload, container, overwrite=False):
             if package:
                 found = isinstance(package, dict) and package
             elif reference:
-                found = isinstance(reference, str) and "://" in reference
+                found = isinstance(reference, str)
             if found:
                 break
     if not found:

--- a/weaver/processes/utils.py
+++ b/weaver/processes/utils.py
@@ -256,12 +256,14 @@ def deploy_process_from_payload(payload, container, overwrite=False):
     process_href = process_description.pop("href", None)
 
     # retrieve CWL package definition, either via "href" (WPS-1/2), "owsContext" or "executionUnit" (package/reference)
-    deployment_profile_name = payload.get("deploymentProfileName", "").lower()
+    deployment_profile_name = payload.get("deploymentProfileName", "")
     ows_context = process_info.pop("owsContext", None)
     reference = None
     package = None
+    found = False
     if process_href:
         reference = process_href  # reference type handled downstream
+        found = isinstance(reference, str) and "://" in reference
     elif isinstance(ows_context, dict):
         offering = ows_context.get("offering")
         if not isinstance(offering, dict):
@@ -271,9 +273,12 @@ def deploy_process_from_payload(payload, container, overwrite=False):
             raise HTTPUnprocessableEntity("Invalid parameter 'processDescription.process.owsContext.offering.content'.")
         package = None
         reference = content.get("href")
-    elif deployment_profile_name:
-        if not any(deployment_profile_name.endswith(typ) for typ in [ProcessType.APPLICATION, ProcessType.WORKFLOW]):
-            raise HTTPBadRequest("Invalid value for parameter 'deploymentProfileName'.")
+        found = isinstance(reference, str) and "://" in reference
+    else:
+        if deployment_profile_name:  # optional hint
+            allowed_profile_suffix = [ProcessType.APPLICATION, ProcessType.WORKFLOW]
+            if not any(deployment_profile_name.lower().endswith(typ) for typ in allowed_profile_suffix):
+                raise HTTPBadRequest("Invalid value for parameter 'deploymentProfileName'.")
         execution_units = payload.get("executionUnit")
         if not isinstance(execution_units, list):
             raise HTTPUnprocessableEntity("Invalid parameter 'executionUnit'.")
@@ -283,10 +288,21 @@ def deploy_process_from_payload(payload, container, overwrite=False):
             package = execution_unit.get("unit")
             reference = execution_unit.get("href")
             # stop on first package/reference found, simultaneous usage will raise during package retrieval
-            if package or reference:
+            if package:
+                found = isinstance(package, dict) and package
+            elif reference:
+                found = isinstance(reference, str) and "://" in reference
+            if found:
                 break
-    else:
-        raise HTTPBadRequest("Missing one of required parameters [href, owsContext, deploymentProfileName].")
+    if not found:
+        params = [
+            "ProcessDescription.href",
+            "ProcessDescription.owsContext.content.href",
+            "executionUnit[*].(unit|href)",
+        ]
+        raise HTTPBadRequest(
+            f"Missing one of required parameters {params} to obtain package/process definition or reference."
+        )
 
     if process_info.get("type", "") == ProcessType.BUILTIN:
         raise HTTPBadRequest(
@@ -333,11 +349,14 @@ def deploy_process_from_payload(payload, container, overwrite=False):
         # raised on invalid process name
         raise HTTPBadRequest(detail=str(ex))
 
-    return HTTPCreated(json={
+    data = {
         "description": sd.OkPostProcessesResponse.description,
         "processSummary": process_summary,
         "deploymentDone": True
-    })
+    }
+    if deployment_profile_name:
+        data["deploymentProfileName"] = deployment_profile_name
+    return HTTPCreated(json=data)
 
 
 def parse_wps_process_config(config_entry):

--- a/weaver/wps_restapi/api.py
+++ b/weaver/wps_restapi/api.py
@@ -305,9 +305,7 @@ def get_conformance(category):
         ogcapi_proc_part2 + "/req/ogcapppkg",
         ogcapi_proc_part2 + "/req/ogcapppkg/execution-unit-docker",
         ogcapi_proc_part2 + "/req/ogcapppkg/process-description",
-        # FIXME: 'deploymentProfile = http://www.opengis.net/profiles/eoc/dockerizedApplication'
-        #   https://github.com/crim-ca/weaver/issues/319
-        # ogcapi_proc_part2 + "/req/ogcapppkg/profile-docker",
+        ogcapi_proc_part2 + "/req/ogcapppkg/profile-docker",
         ogcapi_proc_part2 + "/req/ogcapppkg/schema",
         ogcapi_proc_part2 + "/req/deploy-replace-undeploy",
         ogcapi_proc_part2 + "/req/deploy-replace-undeploy/deploy/body",

--- a/weaver/wps_restapi/swagger_definitions.py
+++ b/weaver/wps_restapi/swagger_definitions.py
@@ -133,6 +133,7 @@ PROCESS_DESCRIPTION_FIELD_AFTER = [
     "processDescriptionURL",
     "processEndpointWPS1",
     "executeEndpoint",
+    "deploymentProfile",
     "links"
 ]
 # fields ordering for nested process definition of OLD schema format of ProcessDescription
@@ -2617,6 +2618,10 @@ class ProcessVisibility(ExtendedMappingSchema):
     visibility = VisibilityValue(missing=drop)
 
 
+class ProcessDeploymentProfile(ExtendedMappingSchema):
+    deploymentProfile = URL(missing=drop)
+
+
 class Process(
     # following are like 'ProcessSummary',
     # except without 'ProcessControl' and 'DescriptionLinks' that are outside of nested 'process'
@@ -2635,7 +2640,7 @@ class Process(
     _sort_after = PROCESS_DESCRIPTION_FIELD_AFTER
 
 
-class ProcessDescriptionOLD(ProcessControl, DescriptionLinks):
+class ProcessDescriptionOLD(ProcessControl, ProcessDeploymentProfile, DescriptionLinks):
     """
     Old schema for process description.
     """
@@ -2646,7 +2651,14 @@ class ProcessDescriptionOLD(ProcessControl, DescriptionLinks):
     _sort_after = PROCESS_DESCRIPTION_FIELD_AFTER_OLD_SCHEMA
 
 
-class ProcessDescriptionOGC(ProcessSummary, ProcessContext, ProcessVisibility, ProcessLocations, DescriptionLinks):
+class ProcessDescriptionOGC(
+    ProcessSummary,
+    ProcessContext,
+    ProcessVisibility,
+    ProcessLocations,
+    ProcessDeploymentProfile,
+    DescriptionLinks
+):
     """
     OGC-API schema for process description.
     """


### PR DESCRIPTION
## Changes

- Add `deploymentProfile` (see requirement https://github.com/opengeospatial/ogcapi-processes/blob/master/extensions/deploy_replace_undeploy/standard/requirements/ogcapppkg/REQ_profile-docker.adoc) using available `type` parameter that provided similar information.
- Remove ``deploymentProfileName`` requirement during `Process` deployment. The corresponding ``deploymentProfile``
  property is instead automatically generated from resolved `CWL` package/reference or remote `WPS` reference. This
  further simplifies deployment using the `CLI` to its bare minimum components as only the `CWL` or `WPS` reference
  needs to be provided along the desired `Process` ID without any further details.

## References

- fixes #319