### PR TITLE
WeaverClient/CLI with auth handler and other CLI adjustments

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,7 +16,7 @@ Changes:
   ``WeaverClient`` methods that allows inline request authentication and authorization resolution to access a
   protected service. Any *Authentication Handler* implementation can be used to fulfill required server functionalities.
 - Replaced `CLI` option ``-t`` by ``-T`` (`Docker` token) during ``deploy`` operation to match naming convention of
-  other options.
+  other options (resolves `#400 <https://github.com/crim-ca/weaver/issues/400>`_).
 - Replaced `CLI` option ``-H`` by ``nH`` (``--no-headers``) and ``wH`` (``--with-headers``) to respectively
   enable or (explicitly) disable return of headers from response of the executed operation.
 - Replaced `CLI` option ``-L`` by ``nL`` (``--no-links``) and ``wL`` (``--with-links``) to respectively

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,7 +16,7 @@ Changes:
 
 Fixes:
 ------
-- No change.
+- Fix `CLI` operations assuming valid JSON response to instead return error response content and status code.
 
 .. _changes_4.17.0:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,7 @@ Changes:
 - Replaced previously defined ``-H`` option by new ``-H/--header`` argument allowing insertion of explicitly provided
   request headers for relevant requests called by the executed operation.
 - Add case insensitive support of values for common `API`, `CLI`, and ``WeaverClient`` parameter choices.
+- Add all missing `CLI` and ``WeaverClient`` examples in the documentation.
 
 Fixes:
 ------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,11 +12,22 @@ Changes
 
 Changes:
 --------
-- No change.
+- Add `CLI` *Authentication Handler* parameters and corresponding ``auth`` argument of instantiated classes for
+  ``WeaverClient`` methods that allows inline request authentication and authorization resolution to access a
+  protected service. Any *Authentication Handler* implementation can be used to fulfill required server functionalities.
+- Replaced `CLI` option ``-t`` by ``-T`` (`Docker` token) during ``deploy`` operation to match naming convention of
+  other options.
+- Replaced `CLI` option ``-H`` by ``nH`` (``--no-headers``) and ``wH`` (``--with-headers``) to respectively
+  enable or (explicitly) disable return of headers from response of the executed operation.
+- Replaced `CLI` option ``-L`` by ``nL`` (``--no-links``) and ``wL`` (``--with-links``) to respectively
+  enable (explicitly) or disable return of links from response of the executed operation.
+- Replaced previously defined ``-H`` option by new ``-H/--header`` argument allowing insertion of explicitly provided
+  request headers for relevant requests called by the executed operation.
 
 Fixes:
 ------
 - Fix `CLI` operations assuming valid JSON response to instead return error response content and status code.
+- Fix `CLI` rendering of various optional arguments and groups when displaying help messages.
 
 .. _changes_4.17.0:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ Changes:
 - Add `CLI` *Authentication Handler* parameters and corresponding ``auth`` argument of instantiated classes for
   ``WeaverClient`` methods that allows inline request authentication and authorization resolution to access a
   protected service. Any *Authentication Handler* implementation can be used to fulfill required server functionalities.
+- Add `CLI` handling of uncaught exceptions to gracefully report message and error instead of exception traceback.
 - Replaced `CLI` option ``-t`` by ``-T`` (`Docker` token) during ``deploy`` operation to match naming convention of
   other options (resolves `#400 <https://github.com/crim-ca/weaver/issues/400>`_).
 - Replaced `CLI` option ``-H`` by ``nH`` (``--no-headers``) and ``wH`` (``--with-headers``) to respectively
@@ -23,11 +24,15 @@ Changes:
   enable (explicitly) or disable return of links from response of the executed operation.
 - Replaced previously defined ``-H`` option by new ``-H/--header`` argument allowing insertion of explicitly provided
   request headers for relevant requests called by the executed operation.
+- Add case insensitive support of values for common `API`, `CLI`, and ``WeaverClient`` parameter choices.
 
 Fixes:
 ------
 - Fix `CLI` operations assuming valid JSON response to instead return error response content and status code.
 - Fix `CLI` rendering of various optional arguments and groups when displaying help messages.
+- Fix invalid handling of ``Constants`` definitions mixed with ``classproperty`` such as in ``OutputFormat`` causing
+  returned value to be the ``classproperty`` itself instead of the retrieved value from its getter definition.
+- Fix minor typing definitions that were incorrect.
 
 .. _changes_4.17.0:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -62,8 +62,9 @@ Fixes:
 
 Changes:
 --------
-- Add `OpenGIS <http://www.opengis.net/def/glossary>`_ as a potential namespace resolver for common geospatial
-  Media-Types such as ``image/tiff; subtype=geotiff`` that must be distinguished from generic IANA formats.
+- Add `OpenGIS <https://defs.opengis.net/vocprez/object?uri=http://www.opengis.net/def/glossary>`_ as a potential
+  namespace resolver for common geospatial Media-Types such as ``image/tiff; subtype=geotiff`` that must be
+  distinguished from generic IANA formats.
 
 Fixes:
 ------

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,8 @@ Weaver (the nest-builder)
 
 `Weaver` is an OGC-API flavored |ems| that allows the execution of workflows chaining various
 applications and |wps| inputs and outputs. Remote execution is deferred by the `EMS` to one or many
-|ades| or remote service providers, and employs |cwl| configurations to define an |ogc-apppkg|_ deployed for each process.
+|ades| or remote service providers, and employs |cwl| configurations to define an |ogc-apppkg|_ deployed
+for each process.
 
 
 .. start-badges
@@ -104,8 +105,8 @@ ensuring the transfer of files accordingly between instances when located across
 
 `Weaver` can also accomplish the `ADES` role in order to perform application deployment at the data source using
 the application definition provided by |cwl| configuration. It can then directly execute
-a registered process |ogc-apppkg|_ with received inputs from a WPS request to expose output results for a following `ADES`
-in a `EMS` workflow execution chain.
+a registered process |ogc-apppkg|_ with received inputs from a WPS request to expose output results for a
+following `ADES` in a `EMS` workflow execution chain.
 
 `Weaver` **extends** |ogc-proc-api|_ by providing additional functionalities such as more detailed job logs
 endpoints, adding more process management and search request options than required by the standard, and supporting

--- a/README.rst
+++ b/README.rst
@@ -262,8 +262,8 @@ Videos and more functionalities were introduced in `Weaver` following |ogc-eo-ap
 Corresponding developments are reported in the |ogc-eo-apps-pilot-er|_.
 
 `Weaver` has been used to participate in interoperability testing effort that lead to |ogc-best-practices-eo-apppkg|_
-technical report. This resulted, along with previous efforts, in the definition of |ogc-api-proc-ext-part2| backed by 
-validated test cases using |cwl| as the represention method for the deployment and execution of |ogc-apppkg|_ close 
+technical report. This resulted, along with previous efforts, in the definition of |ogc-api-proc-part2-ext| backed by
+validated test cases using |cwl| as the representation method for the deployment and execution of |ogc-apppkg|_ close
 to the data.
 
 The project is furthermore developed through the *Data Analytics for Canadian Climate Services* (`DACCS`_) initiative.

--- a/docs/source/appendix.rst
+++ b/docs/source/appendix.rst
@@ -169,7 +169,7 @@ Glossary
         later retrieval using an access token.
 
         .. seealso::
-            :ref:`vault`
+            :ref:`vault_upload`
 
     WKT
         Well-Known Text geometry representation.

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -80,6 +80,7 @@ Operations are equivalent between the :term:`CLI` and Python client.
 For each of the following examples, the client is created as follows:
 
 .. code-block:: python
+    :caption: Python
 
     client = WeaverClient(url="{WEAVER_URL}")
 
@@ -124,6 +125,7 @@ handler implementation.
 Below are examples of possible commands:
 
 .. code-block:: shell
+    :caption: Command Line
 
     weaver capabilities -u {WEAVER_URL} -aH requests_magpie.MagpieAuth -aU ${MAGPIE_URL} -aI <username> -aP <password>
 
@@ -168,12 +170,14 @@ desired :ref:`application-package`.
 The contents of below URL definition is also available in :ref:`example_app_pkg_script`.
 
 .. code-block:: shell
+    :caption: Command Line
 
     weaver deploy -u {WEAVER_URL} \
         -p docker-python-script-report \
         --cwl https://raw.githubusercontent.com/crim-ca/weaver/master/docs/examples/docker-python-script-report.cwl
 
 .. code-block:: python
+    :caption: Python
 
     client.deploy(
         process_id="docker-python-script-report",
@@ -196,10 +200,12 @@ Accomplishes the *Undeployment* request to remove a previously :ref:`Deployed <p
 from the service. Requires a `Weaver` or |ogc-api-proc-part2|_ compliant instance.
 
 .. code-block:: shell
+    :caption: Command Line
 
     weaver undeploy -u {WEAVER_URL} -p docker-python-script-report
 
 .. code-block:: python
+    :caption: Python
 
     client.undeploy("docker-python-script-report")
 
@@ -217,10 +223,12 @@ GetCapabilities Example
 Accomplishes the :ref:`GetCapabilities <proc_op_getcap>` request to obtain a list of available :term:`Process`.
 
 .. code-block:: shell
+    :caption: Command Line
 
     weaver capabilities -u {WEAVER_URL}
 
 .. code-block:: python
+    :caption: Python
 
     client.capabilities()
 
@@ -239,10 +247,12 @@ DescribeProcess Example
 Accomplishes the :ref:`DescribeProcess <proc_op_describe>` request to obtain the :term:`Process` definition.
 
 .. code-block:: shell
+    :caption: Command Line
 
     weaver describe -u {WEAVER_URL} -p jsonarray2netcdf
 
 .. code-block:: python
+    :caption: Python
 
     client.describe("jsonarray2netcdf")
 
@@ -285,6 +295,7 @@ Arguments can be provided using literal string entries by repeating ``-I`` optio
 to be submitted to the :term:`Process`. Please refer to :term:`CLI` :ref:`execute` help message for more explanations.
 
 .. code-block:: shell
+    :caption: Command Line
 
     weaver execute -u {WEAVER_URL} -p Echo \
         -I "message='Hello World!'" \
@@ -302,6 +313,7 @@ When using the :ref:`Python Interface <client_commands>`, the inputs can be prov
 above :term:`CLI` variations, but it is usually more intuitive to use a Python :class:`dict` directly.
 
 .. code-block:: python
+    :caption: Python
 
     client.execute("Echo", {
         "message": "Hello World!",
@@ -333,10 +345,12 @@ Accomplishes the :term:`Job` dismiss request to either cancel an accepted or run
 any stored results from a successful execution.
 
 .. code-block:: shell
+    :caption: Command Line
 
     weaver dismiss -u {WEAVER_URL} -j "29af3a33-0a3e-477d-863e-efccc97e0b02"
 
 .. code-block:: python
+    :caption: Python
 
     client.dismiss("29af3a33-0a3e-477d-863e-efccc97e0b02")
 
@@ -354,10 +368,12 @@ GetStatus Example
 Accomplishes the :ref:`GetStatus <proc_op_status>` operation to request the current status of a :term:`Job`.
 
 .. code-block:: shell
+    :caption: Command Line
 
     weaver status -u {WEAVER_URL} -j "797c0c5e-9bc2-4bf3-ab73-5f3df32044a8"
 
 .. code-block:: python
+    :caption: Python
 
     client.status("797c0c5e-9bc2-4bf3-ab73-5f3df32044a8")
 
@@ -376,10 +392,12 @@ Jobs Example
 Accomplishes the :term:`Job` listing request to obtain known :term:`Job` definitions using filter search queries.
 
 .. code-block:: shell
+    :caption: Command Line
 
     weaver jobs -u {WEAVER_URL} -nL
 
 .. code-block:: python
+    :caption: Python
 
     client.jobs(with_links=False)
 
@@ -407,11 +425,13 @@ a pending or running :term:`Job`.
 
 
 .. code-block:: shell
+    :caption: Command Line
 
     # assuming job is 'running'
     weaver monitor -u {WEAVER_URL} -j "14c68477-c3ed-4784-9c0f-a4c9e1344db5"
 
 .. code-block:: python
+    :caption: Python
 
     client.results("14c68477-c3ed-4784-9c0f-a4c9e1344db5")
 
@@ -432,10 +452,12 @@ Retrieves the :ref:`Job Results <proc_op_result>` from a successful :term:`Job` 
     in the specified local output directory.
 
 .. code-block:: shell
+    :caption: Command Line
 
     weaver results -u {WEAVER_URL} -j "14c68477-c3ed-4784-9c0f-a4c9e1344db5"
 
 .. code-block:: python
+    :caption: Python
 
     client.results("14c68477-c3ed-4784-9c0f-a4c9e1344db5")
 
@@ -461,10 +483,12 @@ This operation allows manual upload of a local file to the :term:`Vault`.
     :ref:`file_vault_inputs` and :ref:`vault_upload` provide more details about this feature.
 
 .. code-block:: shell
+    :caption: Command Line
 
     weaver upload -u {WEAVER_URL} -f /path/to/file.txt
 
 .. code-block:: python
+    :caption: Python
 
     client.upload("/path/to/file.txt")
 

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -13,6 +13,11 @@ This offers to the user methods to use file references (e.g.: local :term:`CWL` 
 to rapidly operate with functionalities such as :ref:`Deploy <proc_op_deploy>`, :ref:`Describe <proc_op_describe>`,
 :ref:`Execute <proc_op_execute>` and any other operation described in :ref:`proc_operations` section.
 
+.. note::
+    Technically, any :term:`OGC API - Processes` implementation could be supported using the provided :term:`CLI`
+    and :py:class:`weaver.cli.WeaverClient`. There are however some operations such as :ref:`vault_upload` feature
+    (and any utility that makes use of it) that are applicable only for `Weaver` instances.
+
 Please refer to following sections for more details.
 
 .. contents::
@@ -90,11 +95,11 @@ it is possible to either provide the ``auth`` parameter during initialization of
 itself (the specific :py:class:`weaver.cli.AuthHandler` is reused for **all** operations), or as argument to individual
 methods when calling the respective operation (handler only used for that step).
 
-When using the :ref:`Python Interface <client_commands>`, any class implementation that derives from
-:py:class:`weaver.cli.AuthHandler` or :py:class:`requests.auth.AuthBase` can be used for the ``auth`` argument. This
-class must implement a ``__call__`` method taking and returning a ``request`` instance, and must apply any relevant
-modifications to grant the necessary authentication/authorization details. This ``__call__`` will be performed inline
-prior to sending the actual request toward the service.
+Any class implementation that derives from :py:class:`weaver.cli.AuthHandler` or :py:class:`requests.auth.AuthBase` can
+be used for the ``auth`` argument. This class must implement the ``__call__`` method taking a single ``request``argument
+and returning the adjusted ``request`` instance. The call should apply any relevant modifications to grant the necessary
+authentication/authorization details. This ``__call__`` will be performed inline prior to sending the actual request
+toward the service.
 
 .. note::
     There are multiple predefined handlers available for use:
@@ -110,15 +115,19 @@ prior to sending the actual request toward the service.
 .. |requests-magpie-auth| replace:: ``requests_magpie.MagpieAuth``
 .. _requests-magpie-auth: https://github.com/Ouranosinc/requests-magpie/blob/master/requests_magpie.py
 
-When using the :ref:`CLI <cli_commands>`, the specific :py:class:`weaver.cli.AuthHandler` implementation to employ
+When using the :ref:`cli_commands`, the specific :py:class:`weaver.cli.AuthHandler` implementation to employ
 must be provided using the ``--auth-handler`` (``-aH``) argument. This can be an importable (installed) class module
-path or a plain Python script path separated with a ``:`` character followed by the class definition.
+reference or a plain Python script path separated with a ``:`` character followed by the class name definition.
+Other ``--auth`` prefixed arguments can also be supplied, but their actual use depend on the targeted authentication
+handler implementation.
 
 Below are examples of possible commands:
 
 .. code-block:: shell
 
     weaver capabilities -u {WEAVER_URL} -aH requests_magpie.MagpieAuth -aU ${MAGPIE_URL} -aI <username> -aP <password>
+
+When using the :ref:`Python Interface <client_commands>`, the desired implementation can be specified directly.
 
 .. code-block:: python
 
@@ -131,7 +140,51 @@ Below are examples of possible commands:
 Deploy Example
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. todo:: example
+Accomplishes the :ref:`Deployment <proc_op_deploy>` request in order to subscribe a new :term:`Process` in the service.
+Requires a `Weaver` or |ogc-api-proc-part2|_ compliant instance.
+
+The :term:`Process` can correspond to an :ref:`application-package` using :term:`CWL` (i.e.: a script, a :term:`Docker`
+application, etc.) or a :ref:`proc_remote_provider` using an external :term:`WPS` (:term:`XML`, :term:`JSON`) or another
+:term:`OGC API - Processes` instance.
+A :term:`Workflow` of multiple :term:`Process` references (possibly of distinct nature) can also be deployed.
+
+.. seealso::
+    Chapter :ref:`proc_types` covers supported definitions and further explain each type.
+
+.. note::
+    If the :ref:`application-package` being deployed employs a protected :term:`Docker` repository reference, access
+    can be provided using the corresponding parameters. Those will be required for later execution of the application
+    in order to retrieve the referenced :term:`Docker` image.
+
+.. note::
+    Content definitions for :term:`CWL` :ref:`application-package` and/or the literal :term:`Process` body
+    can be submitted using either a local file reference, an URL, or a literal string formatted as :term:`JSON`
+    or :temr:`YAML`. With the :ref:`Python Interface <client_commands>`, the definition can also be provided
+    with a :class:`dict` directly.
+
+Below is a sample :term:`Process` deployment using a basic Python script wrapped in a :term:`Docker` image to ensure
+all requirements are met. The :term:`CWL` definition provides all necessary inputs and outputs definition to run the
+desired :ref:`application-package`.
+The contents of below URL definition is also available in :ref:`example_app_pkg_script`.
+
+.. code-block:: shell
+
+    weaver deploy -u {WEAVER_URL} \
+        -p docker-python-script-report \
+        --cwl https://raw.githubusercontent.com/crim-ca/weaver/master/docs/examples/docker-python-script-report.cwl
+
+.. code-block:: python
+
+    client.deploy(
+        process_id="docker-python-script-report",
+        cwl="https://raw.githubusercontent.com/crim-ca/weaver/master/docs/examples/docker-python-script-report.cwl",
+    )
+
+Sample Output:
+
+.. literalinclude:: ../../weaver/wps_restapi/examples/local_process_deploy_success.json
+    :language: json
+
 
 .. _cli_undeploy:
 
@@ -139,8 +192,21 @@ Deploy Example
 Undeploy Example
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. todo:: example
+Accomplishes the *Undeployment* request to remove a previously :ref:`Deployed <proc_op_deploy>` :term:`Process`
+from the service. Requires a `Weaver` or |ogc-api-proc-part2|_ compliant instance.
 
+.. code-block:: shell
+
+    weaver undeploy -u {WEAVER_URL} -p docker-python-script-report
+
+.. code-block:: python
+
+    client.undeploy("docker-python-script-report")
+
+Sample Output:
+
+.. literalinclude:: ../../weaver/wps_restapi/examples/local_process_undeploy_success.json
+    :language: json
 
 .. _cli_example_getcap:
 
@@ -191,10 +257,71 @@ Sample Output:
 Execute Example
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Accomplishes the :ref:`Execute <proc_op_execute>` request to obtain launch a :term:`Job`
-with the specified :term:`Process` and provided inputs.
+Accomplishes the :ref:`Execute <proc_op_execute>` request to launch a :term:`Job` execution with the
+specified :term:`Process` and provided inputs. Execution can also take multiple execution control parameters
+such as requesting outputs by reference, selecting the (a)synchronous mode to be employed and much more.
 
-.. todo:: example
+.. seealso::
+    Please refer to :meth:`weaver.cli.WeaverClient.execute` arguments, :term:`CLI` :ref:`execute` operation and chapter
+    :ref:`Execute <proc_op_execute>` documentation for more details regarding all implications of :term:`Job` execution.
+    File reference types, request contents, execution modes and other advanced use cases are covered in greater extent.
+
+.. note::
+    Parameters available for :ref:`Status Monitoring <cli_example_monitor>` can also be provided directly during this
+    operation. This has the effect of executing the :term:`Job` and immediately monitor the obtained status until the
+    completed status is obtained, or timeout is reached, whichever occurs first.
+
+.. note::
+    Any valid *local* file path given as input for the :term:`Job` execution will be automatically uploaded toward
+    the service (`Weaver` required) in order to make it available for the underlying application defined by
+    the :term:`Process`.
+    The same procedure as the :ref:`Manual Upload <cli_example_upload>` operation is employed to temporarily place the
+    file(s) in the :term:`Vault` and make it accessible only for the submitted :term:`Job`. The file(s) submitted this
+    way will be deleted once retrieved by the :term:`Process` for execution.
+
+In order to use the :ref:`cli_commands`, the :term:`Job` inputs definition has been made extremely versatile.
+Arguments can be provided using literal string entries by repeating ``-I`` options followed by their desired
+:term:`KVP` definitions. Additional properties can also be supplied in order to specify precisely what needs
+to be submitted to the :term:`Process`. Please refer to :term:`CLI` :ref:`execute` help message for more explanations.
+
+.. code-block:: shell
+
+    weaver execute -u {WEAVER_URL} -p Echo \
+        -I "message='Hello World!'" \
+        -I value:int=123456 \
+        -I array:float=1.23,4.56 \
+        -I multi:File=http://example.com/data.json;=http://other.com/catalog.json \
+        -I multi:File=http://another.com/data.json \
+        -I single:File=/workspace/data.xml@mediaType=text/xml
+
+Inputs can also be provided using a :term:`JSON` or :term:`YAML` :term:`Job` document (as when running :term:`CWL`)
+or using a :term:`JSON` document matching the schema normally submitted by HTTP request for :term:`OGC APi - Processes`
+execution.
+
+When using the :ref:`Python Interface <client_commands>`, the inputs can be provided in the same manner as for the
+above :term:`CLI` variations, but it is usually more intuitive to use a Python :class:`dict` directly.
+
+.. code-block:: python
+
+    client.execute("Echo", {
+        "message": "Hello World!",
+        "value": 123456,
+        "array": [1.23, 4.56],
+        "multi": [
+            {"href": "http://example.com/data.json"},
+            {"href": "http://other.com/catalog.json"},
+            {"href": "http://another.com/data.json"},
+        ],
+        "single": {
+            "href": "/workspace/data.xml@mediaType",  # note: uploaded to vault automatically before execution
+            "type": "text/xml",
+        }
+    })
+
+Sample Output:
+
+.. literalinclude:: ../../weaver/wps_restapi/examples/job_status_accepted.json
+    :language: json
 
 .. _cli_example_dismiss:
 
@@ -228,11 +355,11 @@ Accomplishes the :ref:`GetStatus <proc_op_status>` operation to request the curr
 
 .. code-block:: shell
 
-    weaver status -u {WEAVER_URL} -j "14c68477-c3ed-4784-9c0f-a4c9e1344db5"
+    weaver status -u {WEAVER_URL} -j "797c0c5e-9bc2-4bf3-ab73-5f3df32044a8"
 
 .. code-block:: python
 
-    client.status("14c68477-c3ed-4784-9c0f-a4c9e1344db5")
+    client.status("797c0c5e-9bc2-4bf3-ab73-5f3df32044a8")
 
 
 Sample Output:
@@ -278,8 +405,18 @@ a pending or running :term:`Job`.
     It is possible to directly perform monitoring when calling the :ref:`Job Execution <cli_example_execute>` operation.
     Simply provide the relevant arguments and options applicable to the monitoring step during the ``execute`` call.
 
-.. todo:: example
 
+.. code-block:: shell
+
+    # assuming job is 'running'
+    weaver monitor -u {WEAVER_URL} -j "14c68477-c3ed-4784-9c0f-a4c9e1344db5"
+
+.. code-block:: python
+
+    client.results("14c68477-c3ed-4784-9c0f-a4c9e1344db5")
+
+
+Monitor output should be in as similar format as :ref:`cli_example_status` with the latest :term:`Job` status retrieved.
 
 .. _cli_example_results:
 
@@ -290,8 +427,8 @@ Results Example
 Retrieves the :ref:`Job Results <proc_op_result>` from a successful :term:`Job` execution.
 
 .. note::
-    It is possible to employ the ``download`` argument to retrieve `File` outputs from a :term:`Job`. If this is
-    enabled, files will be downloaded using the URL references specified in the :term:`Job` result and store them
+    It is possible to employ the ``download`` argument to retrieve ``File`` outputs from a :term:`Job`. If this is
+    enabled, files will be downloaded using the URL references specified in the :term:`Job` results and store them
     in the specified local output directory.
 
 .. code-block:: shell
@@ -321,7 +458,7 @@ This operation allows manual upload of a local file to the :term:`Vault`.
     as :term:`Vault` file in order to make it available for the remote `Weaver` server for :term:`Process` execution.
 
 .. seealso::
-    :ref:`file_vault_inputs` and :ref:`vault` provide more details about this feature.
+    :ref:`file_vault_inputs` and :ref:`vault_upload` provide more details about this feature.
 
 .. code-block:: shell
 

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -117,10 +117,10 @@ toward the service.
 .. _requests-magpie-auth: https://github.com/Ouranosinc/requests-magpie/blob/master/requests_magpie.py
 
 When using the :ref:`cli_commands`, the specific :py:class:`weaver.cli.AuthHandler` implementation to employ
-must be provided using the ``--auth-handler`` (``-aH``) argument. This can be an importable (installed) class module
-reference or a plain Python script path separated with a ``:`` character followed by the class name definition.
-Other ``--auth`` prefixed arguments can also be supplied, but their actual use depend on the targeted authentication
-handler implementation.
+must be provided using the ``--auth-handler``/``--auth-class`` (``-aC``) argument. This can be an importable (installed)
+class module reference or a plain Python script path separated with a ``:`` character followed by the class name
+definition. Other ``--auth`` prefixed arguments can also be supplied, but their actual use depend on the targeted
+authentication handler implementation.
 
 Below are examples of possible commands:
 

--- a/docs/source/package.rst
+++ b/docs/source/package.rst
@@ -87,11 +87,10 @@ Because a Python runner is required, the |cwl-docker-req|_ specification defines
 meets our needs. Note that in this case, special interpretation of ``$(...)`` entries within the definition can be
 provided to tell :term:`CWL` how to map :term:`Job` input values to the dynamically created script.
 
-.. _example_app_pkg_script:
-
 .. literalinclude:: ../examples/docker-python-script-report.cwl
     :language: yaml
     :caption: Sample CWL definition of a Python script
+    :name: example_app_pkg_script
 
 .. _app_pkg_docker:
 
@@ -130,10 +129,12 @@ For the moment, only ``Basic`` (:rfc:`7617`) authentication is supported.
 To generate the base64 token, following methods can be used:
 
 .. code-block:: shell
+    :caption: Command Line
 
     echo -n "<username>:<password>" | base64
 
 .. code-block:: python
+    :caption: Python
 
     import base64
     base64.b64encode(b"<username>:<password>")

--- a/docs/source/package.rst
+++ b/docs/source/package.rst
@@ -87,6 +87,8 @@ Because a Python runner is required, the |cwl-docker-req|_ specification defines
 meets our needs. Note that in this case, special interpretation of ``$(...)`` entries within the definition can be
 provided to tell :term:`CWL` how to map :term:`Job` input values to the dynamically created script.
 
+.. _example_app_pkg_script:
+
 .. literalinclude:: ../examples/docker-python-script-report.cwl
     :language: yaml
     :caption: Sample CWL definition of a Python script

--- a/docs/source/processes.rst
+++ b/docs/source/processes.rst
@@ -871,13 +871,13 @@ combinations.
 .. [#vault2file]
     When a |vault_ref| file is specified, the local :ref:`WPS-REST` process can make use of it directly. The file is
     therefore retrieved from the :term:`Vault` using the provided UUID and access token to be passed to the application.
-    See :ref:`file_vault_inputs` and :ref:`vault` for more details.
+    See :ref:`file_vault_inputs` and :ref:`vault_upload` for more details.
 
 .. [#vault2http]
     When a |vault_ref| file is specified, the remote process needs to access it using the hosted :term:`Vault` endpoint.
     Therefore, `Weaver` converts any vault reference to the corresponding location and inserts the access token in the
-    requests headers to authorize download from the remote server. See :ref:`file_vault_inputs` and :ref:`vault` for
-    more details.
+    requests headers to authorize download from the remote server. See :ref:`file_vault_inputs` and :ref:`vault_upload`
+    for more details.
 
 .. [#wf]
     Workflows are only available on :term:`EMS` and :term:`HYBRID` instances. Since they chain processes,
@@ -920,7 +920,7 @@ When using |vault_ref| references, the resulting file name will be obtained from
 the ``Content-Disposition`` within the uploaded content of the ``multipart/form-data`` request.
 
 .. seealso::
-    - :ref:`vault`
+    - :ref:`vault_upload`
 
 .. _file_vault_token:
 .. _file_vault_inputs:
@@ -929,7 +929,7 @@ File Vault Inputs
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. seealso::
-    Refer to :ref:`vault` section for general details about the :term:`Vault` feature.
+    Refer to :ref:`vault_upload` section for general details about the :term:`Vault` feature.
 
 Stored files in the :term:`Vault` can be employed as input for :ref:`proc_op_execute` operation using the
 provided |vault_ref| reference from the response following upload. The :ref:`Execute <proc_op_execute>`
@@ -1320,7 +1320,7 @@ Note again that the more the :term:`Process` is verbose, the more tracking will 
     A *local* :term:`Process` would have its :term:`Job` references as ``/processes/{processId}/jobs/{jobID}/...``
     while a :ref:`proc_remote_provider` will use ``/provider/{providerName}/processes/{processId}/jobs/{jobID}/...``.
 
-.. _vault:
+.. _vault_upload:
 
 Uploading File to the Vault
 -----------------------------

--- a/docs/source/references.rst
+++ b/docs/source/references.rst
@@ -60,6 +60,8 @@
 .. _ogc-exec-sync-responses: https://docs.ogc.org/is/18-062r2/18-062r2.html#sc_execute_response
 .. |ogc-exec-async-responses| replace:: OGC API - Processes, Responses (async)
 .. _ogc-exec-async-responses: https://docs.ogc.org/is/18-062r2/18-062r2.html#_response_7
+.. |ogc-api-proc-part2| replace:: OGC API - Processes - Part 2: Deploy, Replace, Undeploy
+.. _ogc-api-proc-part2: https://github.com/opengeospatial/ogcapi-processes/tree/master/extensions/deploy_replace_undeploy
 .. |pywps| replace:: PyWPS
 .. _pywps: https://github.com/geopython/pywps/
 .. |pywps-status| replace:: Progress and Status Report

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,7 +16,8 @@ mock<4
 # AWS mock tests (against boto3)
 moto>3
 pluggy>=0.7
-pytest
+# FIXME: bad interpolation of 'setup.cfg' for pytest 'log_format' (https://github.com/pytest-dev/pytest/issues/10019)
+pytest<7
 pydocstyle
 # FIXME: bad docstring asterisks args handling (https://github.com/PyCQA/pylint/issues/5406)
 pylint>=2.11,<2.12

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,8 +54,8 @@ addopts =
 capture = tee-sys
 log_cli = false
 log_level = DEBUG
-log_format = [%(asctime)s] %(levelname)-8.8s [%(threadName)s][%(name)s] %(message)s
-log_date_format = %Y-%m-%d %H:%M:%S
+log_format = [%%(asctime)s] %%(levelname)-8.8s [%%(threadName)s][%%(name)s] %%(message)s
+log_date_format = %%Y-%%m-%%d %%H:%%M:%%S
 python_files = test_*.py
 markers =
 	cli: mark test as related to CLI operations

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,6 +54,7 @@ addopts =
 capture = tee-sys
 log_cli = false
 log_level = DEBUG
+# FIXME: pytest<7 required to parse below configs (https://github.com/pytest-dev/pytest/issues/10019)
 log_format = [%%(asctime)s] %%(levelname)-8.8s [%%(threadName)s][%%(name)s] %%(message)s
 log_date_format = %%Y-%%m-%%d %%H:%%M:%%S
 python_files = test_*.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,23 +5,23 @@ tag = True
 tag_name = {new_version}
 
 [bumpversion:file:CHANGES.rst]
-search = 
+search =
 	`Unreleased <https://github.com/crim-ca/weaver/tree/master>`_ (latest)
 	========================================================================
-replace = 
+replace =
 	`Unreleased <https://github.com/crim-ca/weaver/tree/master>`_ (latest)
 	========================================================================
-	
+
 	Changes:
 	--------
 	- No change.
-	
+
 	Fixes:
 	------
 	- No change.
-	
+
 	.. _changes_{new_version}:
-	
+
 	`{new_version} <https://github.com/crim-ca/weaver/tree/{new_version}>`_ ({now:%%Y-%%m-%%d})
 	========================================================================
 
@@ -42,12 +42,22 @@ search = LABEL version="{current_version}"
 replace = LABEL version="{new_version}"
 
 [tool:pytest]
-addopts = 
+addopts =
 	--strict-markers
 	--tb=native
 	weaver/
+# enabling 'log_cli' will capture any logging call
+# since our CLI tests depend on capturing stdout/stderr,
+# this would make them fail because outputs will be redirected to pytest live logging
+# instead, use a logger that is nested under the package (i.e.: __package__ + "." + __meta__)
+# captured outputs will be reported since the package loggers are enabled based on INI config
+capture = tee-sys
+log_cli = false
+log_level = DEBUG
+log_format = [%(asctime)s] %(levelname)-8.8s [%(threadName)s][%(name)s] %(message)s
+log_date_format = %Y-%m-%d %H:%M:%S
 python_files = test_*.py
-markers = 
+markers =
 	cli: mark test as related to CLI operations
 	testbed14: mark test as 'testbed14' validation
 	functional: mark test as functionality validation
@@ -78,7 +88,7 @@ targets = .
 [flake8]
 ignore = E126,E226,E402,F401,W503,W504
 max-line-length = 120
-exclude = 
+exclude =
 	src,
 	.git,
 	__pycache__,
@@ -103,14 +113,14 @@ add_select = D201,D213
 branch = true
 source = ./
 include = weaver/*
-omit = 
+omit =
 	setup.py
 	docs/*
 	tests/*
 	*_mako
 
 [coverage:report]
-exclude_lines = 
+exclude_lines =
 	pragma: no cover
 	raise AssertionError
 	raise NotImplementedError

--- a/setup.cfg
+++ b/setup.cfg
@@ -134,3 +134,4 @@ exclude_lines =
 	LOGGER.exception
 	LOGGER.log
 	@overload
+	if not result.success:

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -134,7 +134,9 @@ class TestWeaverClient(TestWeaverClientBase):
 
     def test_custom_auth_handler(self):
         """
-        Validate use of custom authentication handler works. Called operation does not matter.
+        Validate use of custom authentication handler works.
+
+        Called operation does not matter.
         """
         token = str(uuid.uuid4())
 

--- a/tests/functional/test_ems_end2end.py
+++ b/tests/functional/test_ems_end2end.py
@@ -28,11 +28,6 @@ if TYPE_CHECKING:
 @pytest.mark.skipif(condition=not len(str(os.getenv("WEAVER_TEST_SERVER_HOSTNAME", ""))),
                     reason="Test server not defined!")
 class WorkflowTestRunnerRemoteWithAuth(WorkflowTestRunnerBase):
-    def __init__(self, *args, **kwargs):
-        # won't run this as a test suite, only its derived classes
-        setattr(self, "__test__", self is WorkflowTestRunnerBase)
-        super(WorkflowTestRunnerRemoteWithAuth, self).__init__(*args, **kwargs)
-
     @classmethod
     def setup_test_processes_before(cls):
         # security configs if enabled

--- a/tests/functional/test_workflow.py
+++ b/tests/functional/test_workflow.py
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
 
     from responses import RequestsMock
 
-    from weaver.typedefs import AnyResponseType, CookiesType, HeadersType, JSON, SettingsType
+    from weaver.typedefs import AnyRequestMethod, AnyResponseType, CookiesType, HeadersType, JSON, SettingsType
 
 
 class WorkflowProcesses(enum.Enum):
@@ -140,14 +140,14 @@ class WorkflowTestRunnerBase(ResourcesUtil, TestCase):
 
     def __init__(self, *args, **kwargs):
         # won't run this as a test suite, only its derived classes
-        setattr(self, "__test__", self is WorkflowTestRunnerBase)
+        setattr(self, "__test__", self is not WorkflowTestRunnerBase)
         super(WorkflowTestRunnerBase, self).__init__(*args, **kwargs)
 
     @classmethod
     def setUpClass(cls):
         # disable SSL warnings from logs
         try:
-            import urllib3  # noqa
+            import urllib3.exceptions  # noqa
             urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
         except ImportError:
             pass
@@ -558,7 +558,7 @@ class WorkflowTestRunnerBase(ResourcesUtil, TestCase):
 
     @classmethod
     def request(cls,                    # pylint: disable=W0221
-                method,                 # type: str
+                method,                 # type: AnyRequestMethod
                 url,                    # type: str
                 ignore_errors=False,    # type: bool
                 force_requests=False,   # type: bool

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,0 +1,92 @@
+import pytest
+
+from weaver.base import Constants, ExtendedEnum
+
+
+class DummyConstant(Constants):
+    # pylint: disable=C0103,invalid-name  # on purpose for test
+    T1 = "t1"
+    T2 = "T2"
+    t3 = "t3"
+    t4 = "T4"
+    T5 = "random5"  # ensure name is case-insensitive (not matched via the lowercase value)
+    t6 = "RANDOM6"  # ensure name is case-insensitive (not matched via the uppercase value)
+
+
+def test_constants_get_by_name_or_value_case_insensitive():
+    assert DummyConstant.get("t1") == DummyConstant.T1
+    assert DummyConstant.get("T1") == DummyConstant.T1
+    assert DummyConstant.get("t2") == DummyConstant.T2
+    assert DummyConstant.get("T2") == DummyConstant.T2
+    assert DummyConstant.get("t3") == DummyConstant.t3
+    assert DummyConstant.get("T3") == DummyConstant.t3
+    assert DummyConstant.get("t4") == DummyConstant.t4
+    assert DummyConstant.get("T4") == DummyConstant.t4
+    assert DummyConstant.get("t5") == DummyConstant.T5
+    assert DummyConstant.get("T5") == DummyConstant.T5
+    assert DummyConstant.get("t6") == DummyConstant.t6
+    assert DummyConstant.get("T6") == DummyConstant.t6
+    assert DummyConstant.get("random5") == DummyConstant.T5
+    assert DummyConstant.get("RANDOM5") == DummyConstant.T5
+    assert DummyConstant.get("random6") == DummyConstant.t6
+    assert DummyConstant.get("RANDOM6") == DummyConstant.t6
+
+
+def test_constants_in_by_name_or_value():
+    assert "t1" in DummyConstant
+    assert "T1" in DummyConstant
+    assert "t2" in DummyConstant
+    assert "T2" in DummyConstant
+    assert "t3" in DummyConstant
+    assert "T3" in DummyConstant
+    assert "t4" in DummyConstant
+    assert "T4" in DummyConstant
+
+
+def test_constants_immutable():
+    with pytest.raises(TypeError):
+        DummyConstant.T1 = "x"
+    with pytest.raises(TypeError):
+        setattr(DummyConstant, "T1", "x")
+    with pytest.raises(TypeError):
+        setattr(DummyConstant, "random", "x")
+
+
+class DummyEnum(ExtendedEnum):
+    # pylint: disable=C0103,invalid-name  # on purpose for test
+    long = "LONG"
+    SHORT = "short"
+
+
+def test_enum_in_case_insensitive():
+    assert "long" in DummyEnum
+    assert "LONG" in DummyEnum
+    assert DummyEnum.long in DummyEnum
+    assert "short" in DummyEnum
+    assert "SHORT" in DummyEnum
+    assert DummyEnum.SHORT in DummyEnum
+
+
+def test_enum_names():
+    assert DummyEnum.names() == ["long", "SHORT"]
+
+
+def test_enum_values():
+    assert DummyEnum.values() == ["LONG", "short"]
+
+
+def test_enum_titles():
+    assert DummyEnum.titles() == ["Long", "Short"]
+
+
+def test_enum_get_by_name_or_value():
+    assert DummyEnum.get("LONG") == DummyEnum.long
+    assert DummyEnum.get("long") == DummyEnum.long
+    assert DummyEnum.get(DummyEnum.long) == DummyEnum.long
+    assert DummyEnum.get("Long") is None
+    assert DummyEnum.get("SHORT") == DummyEnum.SHORT
+    assert DummyEnum.get("short") == DummyEnum.SHORT
+    assert DummyEnum.get(DummyEnum.SHORT) == DummyEnum.SHORT
+    assert DummyEnum.get("Short") is None
+    assert DummyEnum.get("random") is None
+    assert DummyEnum.get("random", default="other") == "other"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,7 +20,8 @@ from weaver.cli import (
     BearerAuthHandler,
     CookieAuthHandler,
     OperationResult,
-    WeaverClient, main as weaver_cli
+    WeaverClient,
+    main as weaver_cli
 )
 from weaver.formats import ContentType
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -372,6 +372,14 @@ def run_command(command, trim=True, expect_error=False, entrypoint=None):
     return out_lines
 
 
+class MockedResponse(TestResponse):
+    """
+    Replaces the ``json`` property by the expected callable from all real response implementations.
+    """
+    def json(self):  # pylint: disable=W0236,invalid-overridden-method
+        return self.json_body or json.loads(self.body.decode("UTF-8"))
+
+
 def mocked_file_response(path, url):
     # type: (str, str) -> Union[Response, HTTPException]
     """
@@ -398,7 +406,7 @@ def mocked_file_response(path, url):
     class StreamReader(object):
         _data = [None, content]  # should technically be split up more to respect chuck size...
 
-        def read(self, chuck_size=None):  # noqa: E811
+        def read(self, chuck_size=None):  # noqa  # E811, parameter not used, but must be present as passed by kwargs
             return self._data.pop(-1)
 
     # add extra methods that 'real' response would have and that are employed by underlying code

--- a/weaver/base.py
+++ b/weaver/base.py
@@ -19,7 +19,7 @@ class _Const(type):
         raise TypeError(f"Constant [{cls.__name__}.{key}] is not modifiable!")
 
     def __setitem__(cls, key, value):
-        _Const.__setattr__(cls, key, value)
+        _Const.__setattr__(cls, key, value)  # pragma: no cover  # hard to test, but no constants works without it
 
     def __contains__(cls, item):
         return cls.get(item) is not None

--- a/weaver/base.py
+++ b/weaver/base.py
@@ -7,7 +7,7 @@ import inspect
 from typing import TYPE_CHECKING, NewType
 
 if TYPE_CHECKING:
-    from typing import Any, Dict, List, Optional, Union
+    from typing import Any, Callable, Dict, List, Optional, Union
 
     from weaver.typedefs import AnyKey
 
@@ -91,7 +91,12 @@ class classproperty(property):  # pylint: disable=C0103,invalid-name
         https://stackoverflow.com/a/5191224
     """
 
-    def __init__(self, fget=None, fset=None, fdel=None, doc=None):
+    def __init__(self,
+                 fget=None,     # type: Optional[Callable[[object], Any]]
+                 fset=None,     # type: Optional[Callable[[object, Any], None]]
+                 fdel=None,     # type: Optional[Callable[[object], None]]
+                 doc="",        # type: str
+                 ):             # type: (...) -> None
         super(classproperty, self).__init__(fget=fget, fset=fset, fdel=fdel, doc=doc)
         self.__doc__ = inspect.cleandoc(doc)
 

--- a/weaver/base.py
+++ b/weaver/base.py
@@ -48,12 +48,21 @@ class Constants(object, metaclass=_Const):
             lower_key = key_or_value.lower()
         else:
             upper_key = lower_key = key_or_value
-        if upper_key in cls.names():
-            return cls.__dict__.get(upper_key, default)
-        if lower_key in cls.names():
-            return cls.__dict__.get(lower_key, default)
-        if key_or_value in cls.values():
-            return key_or_value
+        names = cls.names()
+        values = cls.values()
+        found = None
+        if upper_key in names:
+            found = cls.__dict__.get(upper_key, default)
+        elif lower_key in names:
+            found = cls.__dict__.get(lower_key, default)
+        elif upper_key in values:
+            found = upper_key
+        elif lower_key in values:
+            found = lower_key
+        if found:
+            if isinstance(found, classproperty):
+                found = found.fget(cls)
+            return found
         return default
 
     @classmethod

--- a/weaver/base.py
+++ b/weaver/base.py
@@ -43,8 +43,15 @@ class Constants(object, metaclass=_Const):
     @classmethod
     def get(cls, key_or_value, default=None):
         # type: (Union[AnyKey, EnumType], Optional[Any]) -> Any
-        if key_or_value in cls.names():
-            return cls.__dict__.get(key_or_value, default)
+        if isinstance(key_or_value, str):
+            upper_key = key_or_value.upper()
+            lower_key = key_or_value.lower()
+        else:
+            upper_key = lower_key = key_or_value
+        if upper_key in cls.names():
+            return cls.__dict__.get(upper_key, default)
+        if lower_key in cls.names():
+            return cls.__dict__.get(lower_key, default)
         if key_or_value in cls.values():
             return key_or_value
         return default

--- a/weaver/cli.py
+++ b/weaver/cli.py
@@ -1489,7 +1489,7 @@ class ValidateMethodAction(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
         # type: (argparse.ArgumentParser, argparse.Namespace, Union[str, Sequence[Any], None], Optional[str]) -> None
         if values not in self.methods:
-            allow = ', '.join(self.methods)
+            allow = ", ".join(self.methods)
             error = f"Value '{values}' is not a valid HTTP method, must be one of [{allow}]."
             raise argparse.ArgumentError(self, error)
         setattr(namespace, self.dest, values)

--- a/weaver/cli.py
+++ b/weaver/cli.py
@@ -1866,18 +1866,21 @@ def make_parser():
             Note that ``File`` in this case is expected to be an URL location where the file can be download from.
             When a local file is supplied, Weaver will automatically convert it to a remote Vault File in order to
             upload it at the specified URL location and make it available for the remote process.
-
-            Array input (``maxOccurs > 1``) can be specified using semicolon (;) separated values after the input ID.
-            The type of an element-wise item of this array can also be provided (i.e.: ``arrayInput:int=1;2;3``).
+            
+            Inputs with multiplicity (``maxOccurs > 1``) can be specified using semicolon (``;``) separated values
+            after a single input ID. Note that this is not the same as an single-value array-like input, which should
+            use comma (``,``) separated values instead.
+            The type of an element-wise item of this input can also be provided (i.e.: ``multiInput:int=1;2;3``).
             Alternatively, the same input ID can be repeated over many ``-I`` options each providing an element of the
-            multi-value array to be formed.
+            multi-value input to be formed (i.e.: ``-I multiInput=1 -I multiInput=2 -I multiInput=3``).
 
             Additional parameters can be specified following any ``<value>`` using any amount of ``@<param>=<info>``
             specifiers. Those will be added to the inputs body submitted for execution. This can be used, amongst other
-            things, to provide a file's ``mediaType`` or ``encoding`` details. When using array values, each value in
-            the array can take ``@`` parameters independently.
+            things, to provide a file's ``mediaType`` or ``encoding`` details. When using multi-value inputs, each item
+            value can take ``@`` parameters independently with distinct properties.
 
-            Any value that contains special separator characters (:;@) must URL-encoded (%%XX) to avoid invalid parsing.
+            Any value that contains special separator characters (``:;@``) to be used as literal entries 
+            must be URL-encoded (``%%XX``) to avoid invalid parsing.
 
             Example: ``-I message='Hello Weaver' -I value:int=1234 -I file:File=data.xml@mediaType=text/xml``
         """)

--- a/weaver/cli.py
+++ b/weaver/cli.py
@@ -245,8 +245,12 @@ class RequestAuthHandler(AuthHandler, HTTPBasicAuth):
     def __call__(self, request):
         # type: (AnyRequestType) -> AnyRequestType
         auth_token = self.request_auth()
-        auth_header = self.auth_header(auth_token)
-        request.headers.update(auth_header)
+        if not auth_token:
+            LOGGER.warning("Expected authorization token could not be retrieved from: [%s] in [%s]",
+                           self.url, fully_qualified_name(self))
+        else:
+            auth_header = self.auth_header(auth_token)
+            request.headers.update(auth_header)
         return request
 
 

--- a/weaver/cli.py
+++ b/weaver/cli.py
@@ -1866,7 +1866,7 @@ def make_parser():
             Note that ``File`` in this case is expected to be an URL location where the file can be download from.
             When a local file is supplied, Weaver will automatically convert it to a remote Vault File in order to
             upload it at the specified URL location and make it available for the remote process.
-            
+
             Inputs with multiplicity (``maxOccurs > 1``) can be specified using semicolon (``;``) separated values
             after a single input ID. Note that this is not the same as an single-value array-like input, which should
             use comma (``,``) separated values instead.
@@ -1879,7 +1879,7 @@ def make_parser():
             things, to provide a file's ``mediaType`` or ``encoding`` details. When using multi-value inputs, each item
             value can take ``@`` parameters independently with distinct properties.
 
-            Any value that contains special separator characters (``:;@``) to be used as literal entries 
+            Any value that contains special separator characters (``:;@``) to be used as literal entries
             must be URL-encoded (``%%XX``) to avoid invalid parsing.
 
             Example: ``-I message='Hello Weaver' -I value:int=1234 -I file:File=data.xml@mediaType=text/xml``

--- a/weaver/cli.py
+++ b/weaver/cli.py
@@ -411,7 +411,7 @@ class WeaverClient(object):
                 _success = True
             msg = message or getattr(response, "message", None) or msg or "undefined"
             text = text or OutputFormat.convert(body, output_format or OutputFormat.JSON_STR, item_root="result")
-        except Exception as exc:  # noqa
+        except Exception as exc:  # noqa  # pragma: no cover  # ignore safeguard against error in implementation
             msg = "Could not parse body."
             text = body = response.text
             LOGGER.warning(msg, exc_info=exc)
@@ -452,7 +452,7 @@ class WeaverClient(object):
                 desc["id"] = process_id
             data.setdefault("processDescription", desc)  # already applied if description was found/updated at any level
             desc["visibility"] = Visibility.PUBLIC
-        except (ValueError, TypeError, ScannerError) as exc:
+        except (ValueError, TypeError, ScannerError) as exc:  # pragma: no cover
             return OperationResult(False, f"Failed resolution of body definition: [{exc!s}]", body)
         return OperationResult(True, "", data)
 
@@ -478,7 +478,7 @@ class WeaverClient(object):
                 LOGGER.debug("Override provided CWL into provided/loaded body for process: [%s]", p_id)
                 get_process_definition(info, package=cwl, headers=headers)  # validate
                 body["executionUnit"] = [{"unit": cwl}]
-        except (PackageRegistrationError, ScannerError) as exc:
+        except (PackageRegistrationError, ScannerError) as exc:  # pragma: no cover
             message = f"Failed resolution of package definition: [{exc!s}]"
             return OperationResult(False, message, cwl)
         return OperationResult(True, p_id, body)
@@ -751,7 +751,7 @@ class WeaverClient(object):
                 )
             ):
                 values = cwl2json_input_values(inputs, schema=ProcessSchema.OGC)
-            if values is null:
+            if values is null:  # pragma: no cover  # ignore safeguard against error in implementation
                 raise ValueError("Input values parsed as null. Could not properly detect employed schema.")
             values = convert_input_values_schema(values, schema=ProcessSchema.OGC)
         except Exception as exc:
@@ -1258,7 +1258,7 @@ class WeaverClient(object):
         outputs = res_out.body
         headers = res_out.headers
         out_links = res_out.links(["Link"])
-        if not res_out.success or not (isinstance(res_out.body, dict) or len(out_links)):
+        if not res_out.success or not (isinstance(res_out.body, dict) or len(out_links)):  # pragma: no cover
             return OperationResult(False, "Could not retrieve any output results from job.", outputs, headers)
         if not download:
             res_out.message = "Listing job results."

--- a/weaver/cli.py
+++ b/weaver/cli.py
@@ -1579,8 +1579,6 @@ class ValidateHeaderAction(argparse._AppendAction):  # noqa
 
 
 class ParagraphFormatter(argparse.HelpFormatter):
-    # pragma: no cover  # somehow marked not covered, but functionality covered by 'test_execute_help_details'
-
     @property
     def help_mode(self):
         parser = getattr(self, "parser", None)

--- a/weaver/formats.py
+++ b/weaver/formats.py
@@ -174,7 +174,7 @@ class OutputFormat(Constants):
                 xml = xml.strip()
             return xml
         if fmt in [OutputFormat.YML, OutputFormat.YAML]:
-            yml = yaml.safe_dump(data, indent=2, sort_keys=False, width=float("inf"))
+            yml = yaml.safe_dump(data, indent=2, sort_keys=False, width=float("inf"))  # type: ignore
             if yml.endswith("\n...\n"):  # added when data is single literal or None instead of list/object
                 yml = yml[:-4]
             return yml

--- a/weaver/formats.py
+++ b/weaver/formats.py
@@ -163,7 +163,7 @@ class OutputFormat(Constants):
             return data
         if fmt == OutputFormat.JSON_STR:
             return repr_json(data, indent=2, ensure_ascii=False)
-        if fmt == OutputFormat.JSON_RAW:
+        if fmt in [OutputFormat.JSON_RAW, OutputFormat.TEXT, OutputFormat.TXT]:
             return repr_json(data, indent=None, ensure_ascii=False)
         if fmt in [OutputFormat.XML, OutputFormat.XML_RAW, OutputFormat.XML_STR]:
             pretty = fmt == OutputFormat.XML_STR

--- a/weaver/formats.py
+++ b/weaver/formats.py
@@ -297,7 +297,7 @@ _CONTENT_TYPE_SYNONYM_MAPPING = {
 #   - IANA: https://www.iana.org/assignments/media-types/media-types.xhtml
 #   - EDAM-classes: http://bioportal.bioontology.org/ontologies/EDAM/?p=classes (section 'Format')
 #   - EDAM-browser: https://ifb-elixirfr.github.io/edam-browser/
-#   - OpenGIS vocabulary: http://www.opengis.net/def/glossary
+#   - OpenGIS vocabulary: https://defs.opengis.net/vocprez/object?uri=http://www.opengis.net/def/glossary
 IANA_NAMESPACE = "iana"
 IANA_NAMESPACE_URL = "https://www.iana.org/assignments/media-types/"
 IANA_NAMESPACE_DEFINITION = {IANA_NAMESPACE: IANA_NAMESPACE_URL}
@@ -332,6 +332,10 @@ EDAM_MAPPING = {
     ContentType.APP_YAML: "format_3750",
     ContentType.TEXT_PLAIN: "format_1964",
 }
+# Official links to be employed in definitions must be formed as:
+#   http://www.opengis.net/def/glossary/...
+# But they should be redirected to full definitions as:
+#   https://defs.opengis.net/vocprez/object?uri=http://www.opengis.net/def/glossary/...
 OPENGIS_NAMESPACE = "opengis"
 OPENGIS_NAMESPACE_URL = "http://www.opengis.net/"
 OPENGIS_NAMESPACE_DEFINITION = {OPENGIS_NAMESPACE: OPENGIS_NAMESPACE_URL}

--- a/weaver/store/base.py
+++ b/weaver/store/base.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
         SettingsType,
         TypedDict
     )
+    from weaver.visibility import AnyVisibility
 
     JobGroupCategory = TypedDict("JobGroupCategory",
                                  {"category": Dict[str, Optional[str]], "count": int, "jobs": List[Job]})
@@ -55,7 +56,7 @@ class StoreServices(StoreInterface):
 
     @abc.abstractmethod
     def fetch_by_name(self, name, visibility=None):
-        # type: (str, Optional[str]) -> Service
+        # type: (str, Optional[AnyVisibility]) -> Service
         raise NotImplementedError
 
     @abc.abstractmethod
@@ -79,12 +80,12 @@ class StoreProcesses(StoreInterface):
 
     @abc.abstractmethod
     def delete_process(self, process_id, visibility=None):
-        # type: (str, Optional[str]) -> bool
+        # type: (str, Optional[AnyVisibility]) -> bool
         raise NotImplementedError
 
     @abc.abstractmethod
     def list_processes(self,
-                       visibility=None,     # type: Optional[str]
+                       visibility=None,     # type: Optional[AnyVisibility, List[AnyVisibility]]
                        page=None,           # type: Optional[int]
                        limit=None,          # type: Optional[int]
                        sort=None,           # type: Optional[str]
@@ -94,17 +95,17 @@ class StoreProcesses(StoreInterface):
 
     @abc.abstractmethod
     def fetch_by_id(self, process_id, visibility=None):
-        # type: (str, Optional[str]) -> Process
+        # type: (str, Optional[AnyVisibility]) -> Process
         raise NotImplementedError
 
     @abc.abstractmethod
     def get_visibility(self, process_id):
-        # type: (str) -> str
+        # type: (str) -> AnyVisibility
         raise NotImplementedError
 
     @abc.abstractmethod
     def set_visibility(self, process_id, visibility):
-        # type: (str, str) -> None
+        # type: (str, AnyVisibility) -> None
         raise NotImplementedError
 
     @abc.abstractmethod
@@ -129,7 +130,7 @@ class StoreJobs(StoreInterface):
                  execute_response=None,     # type: Optional[AnyExecuteResponse]
                  custom_tags=None,          # type: Optional[List[str]]
                  user_id=None,              # type: Optional[int]
-                 access=None,               # type: Optional[str]
+                 access=None,               # type: Optional[AnyVisibility]
                  context=None,              # type: Optional[str]
                  notification_email=None,   # type: Optional[str]
                  accept_language=None,      # type: Optional[str]

--- a/weaver/store/mongodb.py
+++ b/weaver/store/mongodb.py
@@ -503,7 +503,7 @@ class MongodbProcessStore(StoreProcesses, MongodbStore, ListingMixin):
         return [Process(item) for item in found]
 
     def fetch_by_id(self, process_id, visibility=None):
-        # type: (str, Optional[Visibility]) -> Process
+        # type: (str, Optional[AnyVisibility]) -> Process
         """
         Get process for given :paramref:`process_id` from storage, optionally filtered by :paramref:`visibility`.
 
@@ -580,7 +580,7 @@ class MongodbJobStore(StoreJobs, MongodbStore, ListingMixin):
                  execute_response=None,     # type: Optional[AnyExecuteResponse]
                  custom_tags=None,          # type: Optional[List[str]]
                  user_id=None,              # type: Optional[int]
-                 access=None,               # type: Optional[str]
+                 access=None,               # type: Optional[AnyVisibility]
                  context=None,              # type: Optional[str]
                  notification_email=None,   # type: Optional[str]
                  accept_language=None,      # type: Optional[str]

--- a/weaver/typedefs.py
+++ b/weaver/typedefs.py
@@ -66,6 +66,7 @@ if TYPE_CHECKING:
     from pywps.app import WPSRequest
     from pywps.inout import BoundingBoxInput, ComplexInput, LiteralInput
     from requests import PreparedRequest, Request as RequestsRequest
+    from requests.models import Response as RequestsResponse
     from requests.structures import CaseInsensitiveDict
     from webob.headers import ResponseHeaders, EnvironHeaders
     from webob.response import Response as WebobResponse
@@ -258,8 +259,13 @@ if TYPE_CHECKING:
     HeaderCookiesTuple = Union[Tuple[None, None], Tuple[HeadersBaseType, CookiesBaseType]]
     AnyHeadersContainer = Union[HeadersBaseType, ResponseHeaders, EnvironHeaders, CaseInsensitiveDict]
     AnyCookiesContainer = Union[CookiesBaseType, WPSRequest, PyramidRequest, AnyHeadersContainer]
-    AnyResponseType = Union[PyramidResponse, WebobResponse, TestResponse]
+    AnyResponseType = Union[PyramidResponse, WebobResponse, RequestsResponse, TestResponse]
     AnyRequestType = Union[PyramidRequest, WerkzeugRequest, PreparedRequest, RequestsRequest, DummyRequest]
+    RequestMethod = Literal[
+        "HEAD", "GET", "POST", "PUT", "PATCH", "DELETE",
+        "head", "get", "post", "put", "patch", "delete",
+    ]
+    AnyRequestMethod = Union[RequestMethod, str]
     HTTPValid = Union[HTTPSuccessful, HTTPRedirection]
 
     AnyProcess = Union[Process, ProcessOWS, ProcessWPS, JSON]

--- a/weaver/utils.py
+++ b/weaver/utils.py
@@ -66,6 +66,7 @@ if TYPE_CHECKING:
         AnyHeadersContainer,
         AnySettingsContainer,
         AnyRegistryContainer,
+        AnyRequestMethod,
         AnyResponseType,
         AnyValueType,
         HeadersType,
@@ -1260,7 +1261,7 @@ def _request_cached(method, url, kwargs):
 
 
 @retry_on_cache_error
-def request_extra(method,                       # type: str
+def request_extra(method,                       # type: AnyRequestMethod
                   url,                          # type: str
                   retries=None,                 # type: Optional[int]
                   backoff=None,                 # type: Optional[Number]

--- a/weaver/utils.py
+++ b/weaver/utils.py
@@ -1228,11 +1228,11 @@ def retry_on_cache_error(func):
             if "Cache region not configured" in str(exc):
                 LOGGER.debug("Invalid cache region setup detected, retrying operation after setup...")
                 setup_cache(get_settings() or {})
-            else:
+            else:  # pragma: no cover
                 raise  # if not the expected cache exception, ignore retry attempt
         try:
             return func(*args, **kwargs)
-        except BeakerException as exc:
+        except BeakerException as exc:  # pragma: no cover
             LOGGER.error("Invalid cache region setup could not be resolved: [%s]", exc)
             raise
     return wrapped
@@ -1453,6 +1453,7 @@ def download_file_http(file_reference, file_outdir, settings=None, **request_kwa
     request_kwargs.pop("stream", None)
     resp = request_extra("get", file_reference, stream=True, retries=3, settings=settings, **request_kwargs)
     if resp.status_code >= 400:
+        # pragma: no cover
         # use method since response object does not derive from Exception, therefore cannot be raised directly
         if hasattr(resp, "raise_for_status"):
             resp.raise_for_status()
@@ -1619,7 +1620,7 @@ def load_file(file_path, text=False):
     except OSError as exc:
         LOGGER.debug("Loading error: %s", exc, exc_info=exc)
         raise
-    except ScannerError as exc:
+    except ScannerError as exc:  # pragma: no cover
         LOGGER.debug("Parsing error: %s", exc, exc_info=exc)
         raise ValueError("Failed parsing file content as JSON or YAML.")
 
@@ -1664,7 +1665,7 @@ def get_sane_name(name, min_len=3, max_len=None, assert_invalid=True, replace_ch
     :param replace_character:
         Single character to use for replacement of invalid ones if :paramref:`assert_invalid` is ``False``.
     """
-    if not isinstance(replace_character, str) or not len(replace_character) == 1:
+    if not isinstance(replace_character, str) or not len(replace_character) == 1:  # pragma: no cover
         raise ValueError(f"Single replace character is expected, got invalid [{replace_character!s}]")
     max_len = max_len or len(name)
     if assert_invalid:

--- a/weaver/wps_restapi/examples/job_dismissed_error.json
+++ b/weaver/wps_restapi/examples/job_dismissed_error.json
@@ -1,35 +1,10 @@
 {
-  "code": "JobDismissed",
-  "description": "Job was dismissed and artifacts have been removed.",
-  "value": "29af3a33-0a3e-477d-863e-efccc97e0b02",
-  "links": [
-    {
-      "href": "http://schema-example.com/processes/sleep/jobs/29af3a33-0a3e-477d-863e-efccc97e0b02",
-      "rel": "status",
-      "title": "Job status.",
-      "type": "application/json",
-      "hreflang": "en-CA"
-    },
-    {
-      "href": "http://schema-example.com/jobs/29af3a33-0a3e-477d-863e-efccc97e0b02",
-      "rel": "alternate",
-      "title": "Job status generic endpoint.",
-      "type": "application/json",
-      "hreflang": "en-CA"
-    },
-    {
-      "href": "http://schema-example.com/jobs",
-      "rel": "collection",
-      "title": "List of submitted jobs.",
-      "type": "application/json",
-      "hreflang": "en-CA"
-    },
-    {
-      "href": "http://schema-example.com/jobs",
-      "rel": "up",
-      "title": "List of submitted jobs.",
-      "type": "application/json",
-      "hreflang": "en-CA"
-    }
-  ]
+  "type": "JobDismissed",
+  "title": "JobDismissed",
+  "status": 410,
+  "detail": "Job was dismissed and artifacts have been removed.",
+  "cause": {
+    "status": "dismissed"
+  },
+  "value": "29af3a33-0a3e-477d-863e-efccc97e0b02"
 }

--- a/weaver/wps_restapi/examples/job_dismissed_success.json
+++ b/weaver/wps_restapi/examples/job_dismissed_success.json
@@ -1,0 +1,35 @@
+{
+  "code": "JobDismissed",
+  "description": "Job was dismissed and artifacts have been removed.",
+  "value": "29af3a33-0a3e-477d-863e-efccc97e0b02",
+  "links": [
+    {
+      "href": "http://schema-example.com/processes/sleep/jobs/29af3a33-0a3e-477d-863e-efccc97e0b02",
+      "rel": "status",
+      "title": "Job status.",
+      "type": "application/json",
+      "hreflang": "en-CA"
+    },
+    {
+      "href": "http://schema-example.com/jobs/29af3a33-0a3e-477d-863e-efccc97e0b02",
+      "rel": "alternate",
+      "title": "Job status generic endpoint.",
+      "type": "application/json",
+      "hreflang": "en-CA"
+    },
+    {
+      "href": "http://schema-example.com/jobs",
+      "rel": "collection",
+      "title": "List of submitted jobs.",
+      "type": "application/json",
+      "hreflang": "en-CA"
+    },
+    {
+      "href": "http://schema-example.com/jobs",
+      "rel": "up",
+      "title": "List of submitted jobs.",
+      "type": "application/json",
+      "hreflang": "en-CA"
+    }
+  ]
+}

--- a/weaver/wps_restapi/examples/job_status_accepted.json
+++ b/weaver/wps_restapi/examples/job_status_accepted.json
@@ -1,0 +1,7 @@
+{
+  "description": "Job successfully submitted to processing queue. Execution should begin when resources are available.",
+  "jobID": "797c0c5e-9bc2-4bf3-ab73-5f3df32044a8",
+  "processID": "Echo",
+  "status": "accepted",
+  "location": "http://schema-example.com/processes/Echo/jobs/797c0c5e-9bc2-4bf3-ab73-5f3df32044a8"
+}

--- a/weaver/wps_restapi/examples/job_status_success.json
+++ b/weaver/wps_restapi/examples/job_status_success.json
@@ -1,54 +1,110 @@
 {
-  "jobID": "14c68477-c3ed-4784-9c0f-a4c9e1344db5",
+  "jobID": "797c0c5e-9bc2-4bf3-ab73-5f3df32044a8",
+  "processID": "Echo",
+  "providerID": null,
+  "type": "process",
   "status": "succeeded",
   "message": "Job succeeded.",
-  "created": "2021-03-02T03:32:38.487000+00:00",
-  "started": "2021-03-02T03:32:39.134000+00:00",
-  "finished": "2021-03-02T03:32:43.775000+00:00",
-  "duration": "00:00:00",
+  "created": "2022-06-03T23:46:45.049000+00:00",
+  "started": "2022-06-03T23:46:45.077000+00:00",
+  "finished": "2022-06-03T23:46:48.134000+00:00",
+  "updated": "2022-06-03T23:46:48.135000+00:00",
+  "duration": "00:00:03",
+  "runningDuration": "PT03S",
+  "runningSeconds": 3.057,
   "percentCompleted": 100,
+  "progress": 100,
   "links": [
     {
-      "type": "application/json",
       "title": "Job status.",
-      "hreflang": "en-US",
-      "href": "http://schema-example.com/providers/hummingbird/processes/ncdump/jobs/14c68477-c3ed-4784-9c0f-a4c9e1344db5",
+      "hreflang": "en-CA",
+      "href": "http://schema-example.com/processes/Echo/jobs/797c0c5e-9bc2-4bf3-ab73-5f3df32044a8",
+      "type": "application/json",
       "rel": "status"
     },
     {
+      "title": "Job monitoring location.",
+      "hreflang": "en-CA",
+      "href": "http://schema-example.com/processes/Echo/jobs/797c0c5e-9bc2-4bf3-ab73-5f3df32044a8",
       "type": "application/json",
-      "title": "Job logs.",
-      "hreflang": "en-US",
-      "href": "http://schema-example.com/providers/hummingbird/processes/ncdump/jobs/14c68477-c3ed-4784-9c0f-a4c9e1344db5/logs",
-      "rel": "logs"
+      "rel": "monitor"
     },
     {
+      "title": "Job status generic endpoint.",
+      "hreflang": "en-CA",
+      "href": "http://schema-example.com/jobs/797c0c5e-9bc2-4bf3-ab73-5f3df32044a8",
       "type": "application/json",
-      "title": "Job inputs.",
-      "hreflang": "en-US",
-      "href": "http://schema-example.com/providers/hummingbird/processes/ncdump/jobs/14c68477-c3ed-4784-9c0f-a4c9e1344db5/inputs",
+      "rel": "alternate"
+    },
+    {
+      "title": "List of submitted jobs.",
+      "hreflang": "en-CA",
+      "href": "http://schema-example.com/jobs",
+      "type": "application/json",
+      "rel": "collection"
+    },
+    {
+      "title": "List of submitted jobs.",
+      "hreflang": "en-CA",
+      "href": "http://schema-example.com/jobs",
+      "type": "application/json",
+      "rel": "http://www.opengis.net/def/rel/ogc/1.0/job-list"
+    },
+    {
+      "title": "New job submission endpoint for the corresponding process.",
+      "hreflang": "en-CA",
+      "href": "http://schema-example.com/processes/Echo/jobs/execution",
+      "type": "application/json",
+      "rel": "http://www.opengis.net/def/rel/ogc/1.0/execute"
+    },
+    {
+      "title": "Submitted job inputs for process execution.",
+      "hreflang": "en-CA",
+      "href": "http://schema-example.com/processes/Echo/jobs/797c0c5e-9bc2-4bf3-ab73-5f3df32044a8/inputs",
+      "type": "application/json",
       "rel": "inputs"
     },
     {
+      "title": "Job outputs of successful process execution (extended outputs with metadata).",
+      "hreflang": "en-CA",
+      "href": "http://schema-example.com/processes/Echo/jobs/797c0c5e-9bc2-4bf3-ab73-5f3df32044a8/outputs",
       "type": "application/json",
-      "title": "Job outputs.",
-      "hreflang": "en-US",
-      "href": "http://schema-example.com/providers/hummingbird/processes/ncdump/jobs/14c68477-c3ed-4784-9c0f-a4c9e1344db5/outputs",
       "rel": "outputs"
     },
     {
+      "title": "Job results of successful process execution (direct output values mapping).",
+      "hreflang": "en-CA",
+      "href": "http://schema-example.com/processes/Echo/jobs/797c0c5e-9bc2-4bf3-ab73-5f3df32044a8/results",
       "type": "application/json",
-      "title": "Job results.",
-      "hreflang": "en-US",
-      "href": "http://schema-example.com/providers/hummingbird/processes/ncdump/jobs/14c68477-c3ed-4784-9c0f-a4c9e1344db5/results",
-      "rel": "results"
+      "rel": "http://www.opengis.net/def/rel/ogc/1.0/results"
     },
     {
+      "title": "Job statistics collected following process execution.",
+      "hreflang": "en-CA",
+      "href": "http://schema-example.com/processes/Echo/jobs/797c0c5e-9bc2-4bf3-ab73-5f3df32044a8/statistics",
       "type": "application/json",
+      "rel": "statistics"
+    },
+    {
+      "title": "List of collected job logs during process execution.",
+      "hreflang": "en-CA",
+      "href": "http://schema-example.com/processes/Echo/jobs/797c0c5e-9bc2-4bf3-ab73-5f3df32044a8/logs",
+      "type": "application/json",
+      "rel": "logs"
+    },
+    {
       "title": "Job status.",
-      "hreflang": "en-US",
-      "href": "http://schema-example.com/providers/hummingbird/processes/ncdump/jobs/14c68477-c3ed-4784-9c0f-a4c9e1344db5",
+      "hreflang": "en-CA",
+      "href": "http://schema-example.com/processes/Echo/jobs/797c0c5e-9bc2-4bf3-ab73-5f3df32044a8",
+      "type": "application/json",
       "rel": "self"
+    },
+    {
+      "title": "Job status details.",
+      "hreflang": "en-CA",
+      "href": "http://schema-example.com/processes/Echo/jobs/797c0c5e-9bc2-4bf3-ab73-5f3df32044a8",
+      "type": "application/json",
+      "rel": "up"
     }
   ]
 }

--- a/weaver/wps_restapi/examples/local_process_deploy_success.json
+++ b/weaver/wps_restapi/examples/local_process_deploy_success.json
@@ -1,0 +1,22 @@
+{
+  "description": "Process successfully deployed.",
+  "processSummary": {
+    "id": "docker-python-script-report",
+    "mutable": true,
+    "keywords": [
+      "application"
+    ],
+    "metadata": [],
+    "jobControlOptions": [
+      "async-execute",
+      "sync-execute"
+    ],
+    "outputTransmission": [
+      "reference",
+      "value"
+    ],
+    "processDescriptionURL": "http://schema-example.com/processes/docker-python-script-report",
+    "executeEndpoint": "http://schema-example.com/processes/docker-python-script-report/jobs"
+  },
+  "deploymentDone": true
+}

--- a/weaver/wps_restapi/examples/local_process_description.json
+++ b/weaver/wps_restapi/examples/local_process_description.json
@@ -33,6 +33,6 @@
       }
     ],
     "visibility": "public",
-    "executeEndpoint": "http://localhost:4002/processes/jsonarray2netcdf/jobs"
+    "executeEndpoint": "http://schema-example.com/processes/jsonarray2netcdf/jobs"
   }
 }

--- a/weaver/wps_restapi/examples/local_process_description_ogc_api.json
+++ b/weaver/wps_restapi/examples/local_process_description_ogc_api.json
@@ -30,43 +30,43 @@
     }
   },
   "visibility": "public",
-  "processEndpointWPS1": "http://localhost:4002/wps",
-  "processDescriptionURL": "http://localhost:4002/processes/jsonarray2netcdf/jobs",
-  "executeEndpoint": "http://localhost:4002/processes/jsonarray2netcdf/jobs",
+  "processEndpointWPS1": "http://schema-example.com/wps",
+  "processDescriptionURL": "http://schema-example.com/processes/jsonarray2netcdf/jobs",
+  "executeEndpoint": "http://schema-example.com/processes/jsonarray2netcdf/jobs",
   "links": [
     {
       "type": "application/json",
       "title": "Process description.",
       "hreflang": "en-CA",
-      "href": "http://localhost:4002/processes/jsonarray2netcdf",
+      "href": "http://schema-example.com/processes/jsonarray2netcdf",
       "rel": "self"
     },
     {
       "type": "application/json",
       "title": "Process description.",
       "hreflang": "en-CA",
-      "href": "http://localhost:4002/processes/jsonarray2netcdf",
+      "href": "http://schema-example.com/processes/jsonarray2netcdf",
       "rel": "process-desc"
     },
     {
       "type": "application/json",
       "title": "Process execution endpoint for job submission.",
       "hreflang": "en-CA",
-      "href": "http://localhost:4002/processes/jsonarray2netcdf/execution",
+      "href": "http://schema-example.com/processes/jsonarray2netcdf/execution",
       "rel": "execute"
     },
     {
       "type": "application/json",
       "title": "List of registered processes.",
       "hreflang": "en-CA",
-      "href": "http://localhost:4002/processes",
+      "href": "http://schema-example.com/processes",
       "rel": "collection"
     },
     {
       "type": "application/xml",
       "title": "Service definition.",
       "hreflang": "en-CA",
-      "href": "http://localhost:4002/ows/wps?service=WPS&request=GetCapabilities",
+      "href": "http://schema-example.com/ows/wps?service=WPS&request=GetCapabilities",
       "rel": "service-desc"
     }
   ]

--- a/weaver/wps_restapi/examples/local_process_undeploy_success.json
+++ b/weaver/wps_restapi/examples/local_process_undeploy_success.json
@@ -1,0 +1,5 @@
+{
+  "description": "Process successfully undeployed.",
+  "identifier": "docker-python-script-report",
+  "undeploymentDone": true
+}

--- a/weaver/wps_restapi/examples/provider_listing.json
+++ b/weaver/wps_restapi/examples/provider_listing.json
@@ -5,7 +5,7 @@
       "id": "finch",
       "title": "Finch",
       "description": "A Web Processing Service for Climate Indicators.",
-      "url": "http://localhost:8095/wps",
+      "url": "http://remote-provider.com/wps",
       "type": "wps-remote",
       "public": false,
       "keywords": [
@@ -45,28 +45,28 @@
           "type": "application/xml",
           "title": "Service description (GetCapabilities).",
           "hreflang": "en-US",
-          "href": "http://localhost:8095/wps?service=WPS&request=GetCapabilities",
+          "href": "http://remote-provider.com/wps?service=WPS&request=GetCapabilities",
           "rel": "service-desc"
         },
         {
           "type": "application/json",
           "title": "Service definition.",
           "hreflang": "en-US",
-          "href": "http://localhost:4002/providers/finch",
+          "href": "http://schema-example.com/providers/finch",
           "rel": "service"
         },
         {
           "type": "application/json",
           "title": "Service definition.",
           "hreflang": "en-CA",
-          "href": "http://localhost:4002/providers/finch",
+          "href": "http://schema-example.com/providers/finch",
           "rel": "self"
         },
         {
           "type": "application/json",
           "title": "Listing of processes provided by this service.",
           "hreflang": "en-CA",
-          "href": "http://localhost:4002/providers/finch/processes",
+          "href": "http://schema-example.com/providers/finch/processes",
           "rel": "processes"
         }
       ]
@@ -121,21 +121,21 @@
           "type": "application/json",
           "title": "Service definition.",
           "hreflang": "en-US",
-          "href": "http://localhost:4002/providers/hummingbird",
+          "href": "http://schema-example.com/providers/hummingbird",
           "rel": "service"
         },
         {
           "type": "application/json",
           "title": "Service definition.",
           "hreflang": "en-CA",
-          "href": "http://localhost:4002/providers/hummingbird",
+          "href": "http://schema-example.com/providers/hummingbird",
           "rel": "self"
         },
         {
           "type": "application/json",
           "title": "Listing of processes provided by this service.",
           "hreflang": "en-CA",
-          "href": "http://localhost:4002/providers/hummingbird/processes",
+          "href": "http://schema-example.com/providers/hummingbird/processes",
           "rel": "processes"
         }
       ]

--- a/weaver/wps_restapi/examples/providers_processes_details.json
+++ b/weaver/wps_restapi/examples/providers_processes_details.json
@@ -13,9 +13,9 @@
       "outputTransmission": [
         "value"
       ],
-      "processDescriptionURL": "http://localhost:4002/processes/ColibriFlyingpigeon_SubsetBbox",
-      "processEndpointWPS1": "http://localhost:4002/ows/wps",
-      "executeEndpoint": "http://localhost:4002/processes/ColibriFlyingpigeon_SubsetBbox/jobs"
+      "processDescriptionURL": "http://schema-example.com/processes/ColibriFlyingpigeon_SubsetBbox",
+      "processEndpointWPS1": "http://schema-example.com/ows/wps",
+      "executeEndpoint": "http://schema-example.com/processes/ColibriFlyingpigeon_SubsetBbox/jobs"
     },
     {
       "id": "OutardeFlyingpigeon_SubsetBbox",
@@ -30,9 +30,9 @@
       "outputTransmission": [
         "value"
       ],
-      "processDescriptionURL": "http://localhost:4002/processes/OutardeFlyingpigeon_SubsetBbox",
-      "processEndpointWPS1": "http://localhost:4002/ows/wps",
-      "executeEndpoint": "http://localhost:4002/processes/OutardeFlyingpigeon_SubsetBbox/jobs"
+      "processDescriptionURL": "http://schema-example.com/processes/OutardeFlyingpigeon_SubsetBbox",
+      "processEndpointWPS1": "http://schema-example.com/ows/wps",
+      "executeEndpoint": "http://schema-example.com/processes/OutardeFlyingpigeon_SubsetBbox/jobs"
     },
     {
       "id": "Staging_S2L1C",
@@ -49,9 +49,9 @@
       "outputTransmission": [
         "value"
       ],
-      "processDescriptionURL": "http://localhost:4002/processes/Staging_S2L1C",
-      "processEndpointWPS1": "http://localhost:4002/ows/wps",
-      "executeEndpoint": "http://localhost:4002/processes/Staging_S2L1C/jobs"
+      "processDescriptionURL": "http://schema-example.com/processes/Staging_S2L1C",
+      "processEndpointWPS1": "http://schema-example.com/ows/wps",
+      "executeEndpoint": "http://schema-example.com/processes/Staging_S2L1C/jobs"
     },
     {
       "id": "Staging_S2L1C-mock-docker",
@@ -68,9 +68,9 @@
       "outputTransmission": [
         "value"
       ],
-      "processDescriptionURL": "http://localhost:4002/processes/Staging_S2L1C-mock-docker",
-      "processEndpointWPS1": "http://localhost:4002/ows/wps",
-      "executeEndpoint": "http://localhost:4002/processes/Staging_S2L1C-mock-docker/jobs"
+      "processDescriptionURL": "http://schema-example.com/processes/Staging_S2L1C-mock-docker",
+      "processEndpointWPS1": "http://schema-example.com/ows/wps",
+      "executeEndpoint": "http://schema-example.com/processes/Staging_S2L1C-mock-docker/jobs"
     },
     {
       "id": "WaterExtent_S2-mock-docker",
@@ -87,9 +87,9 @@
       "outputTransmission": [
         "value"
       ],
-      "processDescriptionURL": "http://localhost:4002/processes/WaterExtent_S2-mock-docker",
-      "processEndpointWPS1": "http://localhost:4002/ows/wps",
-      "executeEndpoint": "http://localhost:4002/processes/WaterExtent_S2-mock-docker/jobs"
+      "processDescriptionURL": "http://schema-example.com/processes/WaterExtent_S2-mock-docker",
+      "processEndpointWPS1": "http://schema-example.com/ows/wps",
+      "executeEndpoint": "http://schema-example.com/processes/WaterExtent_S2-mock-docker/jobs"
     },
     {
       "id": "WorkflowWaterExtent",
@@ -106,9 +106,9 @@
       "outputTransmission": [
         "value"
       ],
-      "processDescriptionURL": "http://localhost:4002/processes/WorkflowWaterExtent",
-      "processEndpointWPS1": "http://localhost:4002/ows/wps",
-      "executeEndpoint": "http://localhost:4002/processes/WorkflowWaterExtent/jobs"
+      "processDescriptionURL": "http://schema-example.com/processes/WorkflowWaterExtent",
+      "processEndpointWPS1": "http://schema-example.com/ows/wps",
+      "executeEndpoint": "http://schema-example.com/processes/WorkflowWaterExtent/jobs"
     },
     {
       "id": "WorkflowWaterExtent-mock",
@@ -125,9 +125,9 @@
       "outputTransmission": [
         "value"
       ],
-      "processDescriptionURL": "http://localhost:4002/processes/WorkflowWaterExtent-mock",
-      "processEndpointWPS1": "http://localhost:4002/ows/wps",
-      "executeEndpoint": "http://localhost:4002/processes/WorkflowWaterExtent-mock/jobs"
+      "processDescriptionURL": "http://schema-example.com/processes/WorkflowWaterExtent-mock",
+      "processEndpointWPS1": "http://schema-example.com/ows/wps",
+      "executeEndpoint": "http://schema-example.com/processes/WorkflowWaterExtent-mock/jobs"
     },
     {
       "id": "anti-spoofing",
@@ -161,9 +161,9 @@
       "outputTransmission": [
         "value"
       ],
-      "processDescriptionURL": "http://localhost:4002/processes/anti-spoofing",
-      "processEndpointWPS1": "http://localhost:4002/ows/wps",
-      "executeEndpoint": "http://localhost:4002/processes/anti-spoofing/jobs"
+      "processDescriptionURL": "http://schema-example.com/processes/anti-spoofing",
+      "processEndpointWPS1": "http://schema-example.com/ows/wps",
+      "executeEndpoint": "http://schema-example.com/processes/anti-spoofing/jobs"
     },
     {
       "id": "docker-demo-cat",
@@ -180,9 +180,9 @@
       "outputTransmission": [
         "value"
       ],
-      "processDescriptionURL": "http://localhost:4002/processes/docker-demo-cat",
-      "processEndpointWPS1": "http://localhost:4002/ows/wps",
-      "executeEndpoint": "http://localhost:4002/processes/docker-demo-cat/jobs"
+      "processDescriptionURL": "http://schema-example.com/processes/docker-demo-cat",
+      "processEndpointWPS1": "http://schema-example.com/ows/wps",
+      "executeEndpoint": "http://schema-example.com/processes/docker-demo-cat/jobs"
     },
     {
       "id": "docker-python-script",
@@ -197,9 +197,9 @@
       "outputTransmission": [
         "value"
       ],
-      "processDescriptionURL": "http://localhost:4002/processes/docker-python-script",
-      "processEndpointWPS1": "http://localhost:4002/ows/wps",
-      "executeEndpoint": "http://localhost:4002/processes/docker-python-script/jobs"
+      "processDescriptionURL": "http://schema-example.com/processes/docker-python-script",
+      "processEndpointWPS1": "http://schema-example.com/ows/wps",
+      "executeEndpoint": "http://schema-example.com/processes/docker-python-script/jobs"
     },
     {
       "id": "file2string_array",
@@ -214,9 +214,9 @@
       "outputTransmission": [
         "value"
       ],
-      "processDescriptionURL": "http://localhost:4002/processes/file2string_array",
-      "processEndpointWPS1": "http://localhost:4002/ows/wps",
-      "executeEndpoint": "http://localhost:4002/processes/file2string_array/jobs"
+      "processDescriptionURL": "http://schema-example.com/processes/file2string_array",
+      "processEndpointWPS1": "http://schema-example.com/ows/wps",
+      "executeEndpoint": "http://schema-example.com/processes/file2string_array/jobs"
     },
     {
       "id": "image-utils",
@@ -241,9 +241,9 @@
       "outputTransmission": [
         "value"
       ],
-      "processDescriptionURL": "http://localhost:4002/processes/image-utils",
-      "processEndpointWPS1": "http://localhost:4002/ows/wps",
-      "executeEndpoint": "http://localhost:4002/processes/image-utils/jobs"
+      "processDescriptionURL": "http://schema-example.com/processes/image-utils",
+      "processEndpointWPS1": "http://schema-example.com/ows/wps",
+      "executeEndpoint": "http://schema-example.com/processes/image-utils/jobs"
     },
     {
       "id": "jsonarray2netcdf",
@@ -260,9 +260,9 @@
       "outputTransmission": [
         "value"
       ],
-      "processDescriptionURL": "http://localhost:4002/processes/jsonarray2netcdf",
-      "processEndpointWPS1": "http://localhost:4002/ows/wps",
-      "executeEndpoint": "http://localhost:4002/processes/jsonarray2netcdf/jobs"
+      "processDescriptionURL": "http://schema-example.com/processes/jsonarray2netcdf",
+      "processEndpointWPS1": "http://schema-example.com/ows/wps",
+      "executeEndpoint": "http://schema-example.com/processes/jsonarray2netcdf/jobs"
     },
     {
       "id": "las2tif",
@@ -315,9 +315,9 @@
       "outputTransmission": [
         "value"
       ],
-      "processDescriptionURL": "http://localhost:4002/processes/las2tif",
-      "processEndpointWPS1": "http://localhost:4002/ows/wps",
-      "executeEndpoint": "http://localhost:4002/processes/las2tif/jobs"
+      "processDescriptionURL": "http://schema-example.com/processes/las2tif",
+      "processEndpointWPS1": "http://schema-example.com/ows/wps",
+      "executeEndpoint": "http://schema-example.com/processes/las2tif/jobs"
     },
     {
       "id": "metalink2netcdf",
@@ -334,9 +334,9 @@
       "outputTransmission": [
         "value"
       ],
-      "processDescriptionURL": "http://localhost:4002/processes/metalink2netcdf",
-      "processEndpointWPS1": "http://localhost:4002/ows/wps",
-      "executeEndpoint": "http://localhost:4002/processes/metalink2netcdf/jobs"
+      "processDescriptionURL": "http://schema-example.com/processes/metalink2netcdf",
+      "processEndpointWPS1": "http://schema-example.com/ows/wps",
+      "executeEndpoint": "http://schema-example.com/processes/metalink2netcdf/jobs"
     },
     {
       "id": "python-script",
@@ -354,9 +354,9 @@
       "outputTransmission": [
         "value"
       ],
-      "processDescriptionURL": "http://localhost:4002/processes/python-script",
-      "processEndpointWPS1": "http://localhost:4002/ows/wps",
-      "executeEndpoint": "http://localhost:4002/processes/python-script/jobs"
+      "processDescriptionURL": "http://schema-example.com/processes/python-script",
+      "processEndpointWPS1": "http://schema-example.com/ows/wps",
+      "executeEndpoint": "http://schema-example.com/processes/python-script/jobs"
     },
     {
       "id": "sleep",
@@ -372,9 +372,9 @@
       "outputTransmission": [
         "value"
       ],
-      "processDescriptionURL": "http://localhost:4002/processes/sleep",
-      "processEndpointWPS1": "http://localhost:4002/ows/wps",
-      "executeEndpoint": "http://localhost:4002/processes/sleep/jobs"
+      "processDescriptionURL": "http://schema-example.com/processes/sleep",
+      "processEndpointWPS1": "http://schema-example.com/ows/wps",
+      "executeEndpoint": "http://schema-example.com/processes/sleep/jobs"
     },
     {
       "id": "test_blurring",
@@ -399,9 +399,9 @@
       "outputTransmission": [
         "value"
       ],
-      "processDescriptionURL": "http://localhost:4002/processes/test_blurring",
-      "processEndpointWPS1": "http://localhost:4002/ows/wps",
-      "executeEndpoint": "http://localhost:4002/processes/test_blurring/jobs"
+      "processDescriptionURL": "http://schema-example.com/processes/test_blurring",
+      "processEndpointWPS1": "http://schema-example.com/ows/wps",
+      "executeEndpoint": "http://schema-example.com/processes/test_blurring/jobs"
     },
     {
       "id": "test_generation",
@@ -426,9 +426,9 @@
       "outputTransmission": [
         "value"
       ],
-      "processDescriptionURL": "http://localhost:4002/processes/test_generation",
-      "processEndpointWPS1": "http://localhost:4002/ows/wps",
-      "executeEndpoint": "http://localhost:4002/processes/test_generation/jobs"
+      "processDescriptionURL": "http://schema-example.com/processes/test_generation",
+      "processEndpointWPS1": "http://schema-example.com/ows/wps",
+      "executeEndpoint": "http://schema-example.com/processes/test_generation/jobs"
     },
     {
       "id": "test_workflow",
@@ -445,9 +445,9 @@
       "outputTransmission": [
         "value"
       ],
-      "processDescriptionURL": "http://localhost:4002/processes/test_workflow",
-      "processEndpointWPS1": "http://localhost:4002/ows/wps",
-      "executeEndpoint": "http://localhost:4002/processes/test_workflow/jobs"
+      "processDescriptionURL": "http://schema-example.com/processes/test_workflow",
+      "processEndpointWPS1": "http://schema-example.com/ows/wps",
+      "executeEndpoint": "http://schema-example.com/processes/test_workflow/jobs"
     }
   ],
   "providers": [
@@ -495,21 +495,21 @@
           "type": "application/json",
           "title": "Service definition.",
           "hreflang": "en-CA",
-          "href": "http://localhost:4002/providers/catalog-46",
+          "href": "http://schema-example.com/providers/catalog-46",
           "rel": "service"
         },
         {
           "type": "application/json",
           "title": "Service definition.",
           "hreflang": "en-CA",
-          "href": "http://localhost:4002/providers/catalog-46",
+          "href": "http://schema-example.com/providers/catalog-46",
           "rel": "self"
         },
         {
           "type": "application/json",
           "title": "Listing of processes provided by this service.",
           "hreflang": "en-CA",
-          "href": "http://localhost:4002/providers/catalog-46/processes",
+          "href": "http://schema-example.com/providers/catalog-46/processes",
           "rel": "http://www.opengis.net/def/rel/ogc/1.0/processes"
         }
       ],
@@ -526,10 +526,10 @@
           "metadata": [],
           "inputs": [],
           "outputs": [],
-          "url": "http://localhost:4002/providers/catalog-46/processes/getpoint",
-          "executeEndpoint": "http://localhost:4002/providers/catalog-46/processes/getpoint/jobs",
+          "url": "http://schema-example.com/providers/catalog-46/processes/getpoint",
+          "executeEndpoint": "http://schema-example.com/providers/catalog-46/processes/getpoint/jobs",
           "processEndpointWPS1": "https://host-140-46.rdext.crim.ca/twitcher/ows/proxy/catalog?service=WPS&request=DescribeProcess&version=1.0.0&identifier=getpoint",
-          "processDescriptionURL": "http://localhost:4002/providers/catalog-46/processes/getpoint",
+          "processDescriptionURL": "http://schema-example.com/providers/catalog-46/processes/getpoint",
           "type": "wps-remote",
           "package": {
             "cwlVersion": "v1.0",
@@ -557,10 +557,10 @@
           "metadata": [],
           "inputs": [],
           "outputs": [],
-          "url": "http://localhost:4002/providers/catalog-46/processes/ncplotly",
-          "executeEndpoint": "http://localhost:4002/providers/catalog-46/processes/ncplotly/jobs",
+          "url": "http://schema-example.com/providers/catalog-46/processes/ncplotly",
+          "executeEndpoint": "http://schema-example.com/providers/catalog-46/processes/ncplotly/jobs",
           "processEndpointWPS1": "https://host-140-46.rdext.crim.ca/twitcher/ows/proxy/catalog?service=WPS&request=DescribeProcess&version=1.0.0&identifier=ncplotly",
-          "processDescriptionURL": "http://localhost:4002/providers/catalog-46/processes/ncplotly",
+          "processDescriptionURL": "http://schema-example.com/providers/catalog-46/processes/ncplotly",
           "type": "wps-remote",
           "package": {
             "cwlVersion": "v1.0",
@@ -588,10 +588,10 @@
           "metadata": [],
           "inputs": [],
           "outputs": [],
-          "url": "http://localhost:4002/providers/catalog-46/processes/pavicrawler",
-          "executeEndpoint": "http://localhost:4002/providers/catalog-46/processes/pavicrawler/jobs",
+          "url": "http://schema-example.com/providers/catalog-46/processes/pavicrawler",
+          "executeEndpoint": "http://schema-example.com/providers/catalog-46/processes/pavicrawler/jobs",
           "processEndpointWPS1": "https://host-140-46.rdext.crim.ca/twitcher/ows/proxy/catalog?service=WPS&request=DescribeProcess&version=1.0.0&identifier=pavicrawler",
-          "processDescriptionURL": "http://localhost:4002/providers/catalog-46/processes/pavicrawler",
+          "processDescriptionURL": "http://schema-example.com/providers/catalog-46/processes/pavicrawler",
           "type": "wps-remote",
           "package": {
             "cwlVersion": "v1.0",
@@ -619,10 +619,10 @@
           "metadata": [],
           "inputs": [],
           "outputs": [],
-          "url": "http://localhost:4002/providers/catalog-46/processes/pavicsearch",
-          "executeEndpoint": "http://localhost:4002/providers/catalog-46/processes/pavicsearch/jobs",
+          "url": "http://schema-example.com/providers/catalog-46/processes/pavicsearch",
+          "executeEndpoint": "http://schema-example.com/providers/catalog-46/processes/pavicsearch/jobs",
           "processEndpointWPS1": "https://host-140-46.rdext.crim.ca/twitcher/ows/proxy/catalog?service=WPS&request=DescribeProcess&version=1.0.0&identifier=pavicsearch",
-          "processDescriptionURL": "http://localhost:4002/providers/catalog-46/processes/pavicsearch",
+          "processDescriptionURL": "http://schema-example.com/providers/catalog-46/processes/pavicsearch",
           "type": "wps-remote",
           "package": {
             "cwlVersion": "v1.0",
@@ -650,10 +650,10 @@
           "metadata": [],
           "inputs": [],
           "outputs": [],
-          "url": "http://localhost:4002/providers/catalog-46/processes/pavicsupdate",
-          "executeEndpoint": "http://localhost:4002/providers/catalog-46/processes/pavicsupdate/jobs",
+          "url": "http://schema-example.com/providers/catalog-46/processes/pavicsupdate",
+          "executeEndpoint": "http://schema-example.com/providers/catalog-46/processes/pavicsupdate/jobs",
           "processEndpointWPS1": "https://host-140-46.rdext.crim.ca/twitcher/ows/proxy/catalog?service=WPS&request=DescribeProcess&version=1.0.0&identifier=pavicsupdate",
-          "processDescriptionURL": "http://localhost:4002/providers/catalog-46/processes/pavicsupdate",
+          "processDescriptionURL": "http://schema-example.com/providers/catalog-46/processes/pavicsupdate",
           "type": "wps-remote",
           "package": {
             "cwlVersion": "v1.0",
@@ -681,10 +681,10 @@
           "metadata": [],
           "inputs": [],
           "outputs": [],
-          "url": "http://localhost:4002/providers/catalog-46/processes/pavicsvalidate",
-          "executeEndpoint": "http://localhost:4002/providers/catalog-46/processes/pavicsvalidate/jobs",
+          "url": "http://schema-example.com/providers/catalog-46/processes/pavicsvalidate",
+          "executeEndpoint": "http://schema-example.com/providers/catalog-46/processes/pavicsvalidate/jobs",
           "processEndpointWPS1": "https://host-140-46.rdext.crim.ca/twitcher/ows/proxy/catalog?service=WPS&request=DescribeProcess&version=1.0.0&identifier=pavicsvalidate",
-          "processDescriptionURL": "http://localhost:4002/providers/catalog-46/processes/pavicsvalidate",
+          "processDescriptionURL": "http://schema-example.com/providers/catalog-46/processes/pavicsvalidate",
           "type": "wps-remote",
           "package": {
             "cwlVersion": "v1.0",
@@ -712,10 +712,10 @@
           "metadata": [],
           "inputs": [],
           "outputs": [],
-          "url": "http://localhost:4002/providers/catalog-46/processes/period2indices",
-          "executeEndpoint": "http://localhost:4002/providers/catalog-46/processes/period2indices/jobs",
+          "url": "http://schema-example.com/providers/catalog-46/processes/period2indices",
+          "executeEndpoint": "http://schema-example.com/providers/catalog-46/processes/period2indices/jobs",
           "processEndpointWPS1": "https://host-140-46.rdext.crim.ca/twitcher/ows/proxy/catalog?service=WPS&request=DescribeProcess&version=1.0.0&identifier=period2indices",
-          "processDescriptionURL": "http://localhost:4002/providers/catalog-46/processes/period2indices",
+          "processDescriptionURL": "http://schema-example.com/providers/catalog-46/processes/period2indices",
           "type": "wps-remote",
           "package": {
             "cwlVersion": "v1.0",
@@ -743,10 +743,10 @@
           "metadata": [],
           "inputs": [],
           "outputs": [],
-          "url": "http://localhost:4002/providers/catalog-46/processes/pavicstestdocs",
-          "executeEndpoint": "http://localhost:4002/providers/catalog-46/processes/pavicstestdocs/jobs",
+          "url": "http://schema-example.com/providers/catalog-46/processes/pavicstestdocs",
+          "executeEndpoint": "http://schema-example.com/providers/catalog-46/processes/pavicstestdocs/jobs",
           "processEndpointWPS1": "https://host-140-46.rdext.crim.ca/twitcher/ows/proxy/catalog?service=WPS&request=DescribeProcess&version=1.0.0&identifier=pavicstestdocs",
-          "processDescriptionURL": "http://localhost:4002/providers/catalog-46/processes/pavicstestdocs",
+          "processDescriptionURL": "http://schema-example.com/providers/catalog-46/processes/pavicstestdocs",
           "type": "wps-remote",
           "package": {
             "cwlVersion": "v1.0",
@@ -814,21 +814,21 @@
           "type": "application/json",
           "title": "Service definition.",
           "hreflang": "en-CA",
-          "href": "http://localhost:4002/providers/hummingbird-69",
+          "href": "http://schema-example.com/providers/hummingbird-69",
           "rel": "service"
         },
         {
           "type": "application/json",
           "title": "Service definition.",
           "hreflang": "en-CA",
-          "href": "http://localhost:4002/providers/hummingbird-69",
+          "href": "http://schema-example.com/providers/hummingbird-69",
           "rel": "self"
         },
         {
           "type": "application/json",
           "title": "Listing of processes provided by this service.",
           "hreflang": "en-CA",
-          "href": "http://localhost:4002/providers/hummingbird-69/processes",
+          "href": "http://schema-example.com/providers/hummingbird-69/processes",
           "rel": "http://www.opengis.net/def/rel/ogc/1.0/processes"
         }
       ],
@@ -858,10 +858,10 @@
           ],
           "inputs": [],
           "outputs": [],
-          "url": "http://localhost:4002/providers/hummingbird-69/processes/ncdump",
-          "executeEndpoint": "http://localhost:4002/providers/hummingbird-69/processes/ncdump/jobs",
+          "url": "http://schema-example.com/providers/hummingbird-69/processes/ncdump",
+          "executeEndpoint": "http://schema-example.com/providers/hummingbird-69/processes/ncdump/jobs",
           "processEndpointWPS1": "https://host-140-69.rdext.crim.ca/twitcher/ows/proxy/hummingbird?service=WPS&request=DescribeProcess&version=1.0.0&identifier=ncdump",
-          "processDescriptionURL": "http://localhost:4002/providers/hummingbird-69/processes/ncdump",
+          "processDescriptionURL": "http://schema-example.com/providers/hummingbird-69/processes/ncdump",
           "type": "wps-remote",
           "package": {
             "cwlVersion": "v1.0",
@@ -908,10 +908,10 @@
           ],
           "inputs": [],
           "outputs": [],
-          "url": "http://localhost:4002/providers/hummingbird-69/processes/spotchecker",
-          "executeEndpoint": "http://localhost:4002/providers/hummingbird-69/processes/spotchecker/jobs",
+          "url": "http://schema-example.com/providers/hummingbird-69/processes/spotchecker",
+          "executeEndpoint": "http://schema-example.com/providers/hummingbird-69/processes/spotchecker/jobs",
           "processEndpointWPS1": "https://host-140-69.rdext.crim.ca/twitcher/ows/proxy/hummingbird?service=WPS&request=DescribeProcess&version=1.0.0&identifier=spotchecker",
-          "processDescriptionURL": "http://localhost:4002/providers/hummingbird-69/processes/spotchecker",
+          "processDescriptionURL": "http://schema-example.com/providers/hummingbird-69/processes/spotchecker",
           "type": "wps-remote",
           "package": {
             "cwlVersion": "v1.0",
@@ -976,10 +976,10 @@
           ],
           "inputs": [],
           "outputs": [],
-          "url": "http://localhost:4002/providers/hummingbird-69/processes/cchecker",
-          "executeEndpoint": "http://localhost:4002/providers/hummingbird-69/processes/cchecker/jobs",
+          "url": "http://schema-example.com/providers/hummingbird-69/processes/cchecker",
+          "executeEndpoint": "http://schema-example.com/providers/hummingbird-69/processes/cchecker/jobs",
           "processEndpointWPS1": "https://host-140-69.rdext.crim.ca/twitcher/ows/proxy/hummingbird?service=WPS&request=DescribeProcess&version=1.0.0&identifier=cchecker",
-          "processDescriptionURL": "http://localhost:4002/providers/hummingbird-69/processes/cchecker",
+          "processDescriptionURL": "http://schema-example.com/providers/hummingbird-69/processes/cchecker",
           "type": "wps-remote",
           "package": {
             "cwlVersion": "v1.0",
@@ -1032,10 +1032,10 @@
           ],
           "inputs": [],
           "outputs": [],
-          "url": "http://localhost:4002/providers/hummingbird-69/processes/cfchecker",
-          "executeEndpoint": "http://localhost:4002/providers/hummingbird-69/processes/cfchecker/jobs",
+          "url": "http://schema-example.com/providers/hummingbird-69/processes/cfchecker",
+          "executeEndpoint": "http://schema-example.com/providers/hummingbird-69/processes/cfchecker/jobs",
           "processEndpointWPS1": "https://host-140-69.rdext.crim.ca/twitcher/ows/proxy/hummingbird?service=WPS&request=DescribeProcess&version=1.0.0&identifier=cfchecker",
-          "processDescriptionURL": "http://localhost:4002/providers/hummingbird-69/processes/cfchecker",
+          "processDescriptionURL": "http://schema-example.com/providers/hummingbird-69/processes/cfchecker",
           "type": "wps-remote",
           "package": {
             "cwlVersion": "v1.0",
@@ -1076,10 +1076,10 @@
           ],
           "inputs": [],
           "outputs": [],
-          "url": "http://localhost:4002/providers/hummingbird-69/processes/cmor_checker",
-          "executeEndpoint": "http://localhost:4002/providers/hummingbird-69/processes/cmor_checker/jobs",
+          "url": "http://schema-example.com/providers/hummingbird-69/processes/cmor_checker",
+          "executeEndpoint": "http://schema-example.com/providers/hummingbird-69/processes/cmor_checker/jobs",
           "processEndpointWPS1": "https://host-140-69.rdext.crim.ca/twitcher/ows/proxy/hummingbird?service=WPS&request=DescribeProcess&version=1.0.0&identifier=cmor_checker",
-          "processDescriptionURL": "http://localhost:4002/providers/hummingbird-69/processes/cmor_checker",
+          "processDescriptionURL": "http://schema-example.com/providers/hummingbird-69/processes/cmor_checker",
           "type": "wps-remote",
           "package": {
             "cwlVersion": "v1.0",
@@ -1144,10 +1144,10 @@
           ],
           "inputs": [],
           "outputs": [],
-          "url": "http://localhost:4002/providers/hummingbird-69/processes/qa_cfchecker",
-          "executeEndpoint": "http://localhost:4002/providers/hummingbird-69/processes/qa_cfchecker/jobs",
+          "url": "http://schema-example.com/providers/hummingbird-69/processes/qa_cfchecker",
+          "executeEndpoint": "http://schema-example.com/providers/hummingbird-69/processes/qa_cfchecker/jobs",
           "processEndpointWPS1": "https://host-140-69.rdext.crim.ca/twitcher/ows/proxy/hummingbird?service=WPS&request=DescribeProcess&version=1.0.0&identifier=qa_cfchecker",
-          "processDescriptionURL": "http://localhost:4002/providers/hummingbird-69/processes/qa_cfchecker",
+          "processDescriptionURL": "http://schema-example.com/providers/hummingbird-69/processes/qa_cfchecker",
           "type": "wps-remote",
           "package": {
             "cwlVersion": "v1.0",
@@ -1212,10 +1212,10 @@
           ],
           "inputs": [],
           "outputs": [],
-          "url": "http://localhost:4002/providers/hummingbird-69/processes/qa_checker",
-          "executeEndpoint": "http://localhost:4002/providers/hummingbird-69/processes/qa_checker/jobs",
+          "url": "http://schema-example.com/providers/hummingbird-69/processes/qa_checker",
+          "executeEndpoint": "http://schema-example.com/providers/hummingbird-69/processes/qa_checker/jobs",
           "processEndpointWPS1": "https://host-140-69.rdext.crim.ca/twitcher/ows/proxy/hummingbird?service=WPS&request=DescribeProcess&version=1.0.0&identifier=qa_checker",
-          "processDescriptionURL": "http://localhost:4002/providers/hummingbird-69/processes/qa_checker",
+          "processDescriptionURL": "http://schema-example.com/providers/hummingbird-69/processes/qa_checker",
           "type": "wps-remote",
           "package": {
             "cwlVersion": "v1.0",
@@ -1256,10 +1256,10 @@
           ],
           "inputs": [],
           "outputs": [],
-          "url": "http://localhost:4002/providers/hummingbird-69/processes/cdo_sinfo",
-          "executeEndpoint": "http://localhost:4002/providers/hummingbird-69/processes/cdo_sinfo/jobs",
+          "url": "http://schema-example.com/providers/hummingbird-69/processes/cdo_sinfo",
+          "executeEndpoint": "http://schema-example.com/providers/hummingbird-69/processes/cdo_sinfo/jobs",
           "processEndpointWPS1": "https://host-140-69.rdext.crim.ca/twitcher/ows/proxy/hummingbird?service=WPS&request=DescribeProcess&version=1.0.0&identifier=cdo_sinfo",
-          "processDescriptionURL": "http://localhost:4002/providers/hummingbird-69/processes/cdo_sinfo",
+          "processDescriptionURL": "http://schema-example.com/providers/hummingbird-69/processes/cdo_sinfo",
           "type": "wps-remote",
           "package": {
             "cwlVersion": "v1.0",
@@ -1300,10 +1300,10 @@
           ],
           "inputs": [],
           "outputs": [],
-          "url": "http://localhost:4002/providers/hummingbird-69/processes/cdo_operation",
-          "executeEndpoint": "http://localhost:4002/providers/hummingbird-69/processes/cdo_operation/jobs",
+          "url": "http://schema-example.com/providers/hummingbird-69/processes/cdo_operation",
+          "executeEndpoint": "http://schema-example.com/providers/hummingbird-69/processes/cdo_operation/jobs",
           "processEndpointWPS1": "https://host-140-69.rdext.crim.ca/twitcher/ows/proxy/hummingbird?service=WPS&request=DescribeProcess&version=1.0.0&identifier=cdo_operation",
-          "processDescriptionURL": "http://localhost:4002/providers/hummingbird-69/processes/cdo_operation",
+          "processDescriptionURL": "http://schema-example.com/providers/hummingbird-69/processes/cdo_operation",
           "type": "wps-remote",
           "package": {
             "cwlVersion": "v1.0",
@@ -1344,10 +1344,10 @@
           ],
           "inputs": [],
           "outputs": [],
-          "url": "http://localhost:4002/providers/hummingbird-69/processes/cdo_copy",
-          "executeEndpoint": "http://localhost:4002/providers/hummingbird-69/processes/cdo_copy/jobs",
+          "url": "http://schema-example.com/providers/hummingbird-69/processes/cdo_copy",
+          "executeEndpoint": "http://schema-example.com/providers/hummingbird-69/processes/cdo_copy/jobs",
           "processEndpointWPS1": "https://host-140-69.rdext.crim.ca/twitcher/ows/proxy/hummingbird?service=WPS&request=DescribeProcess&version=1.0.0&identifier=cdo_copy",
-          "processDescriptionURL": "http://localhost:4002/providers/hummingbird-69/processes/cdo_copy",
+          "processDescriptionURL": "http://schema-example.com/providers/hummingbird-69/processes/cdo_copy",
           "type": "wps-remote",
           "package": {
             "cwlVersion": "v1.0",
@@ -1394,10 +1394,10 @@
           ],
           "inputs": [],
           "outputs": [],
-          "url": "http://localhost:4002/providers/hummingbird-69/processes/cdo_bbox",
-          "executeEndpoint": "http://localhost:4002/providers/hummingbird-69/processes/cdo_bbox/jobs",
+          "url": "http://schema-example.com/providers/hummingbird-69/processes/cdo_bbox",
+          "executeEndpoint": "http://schema-example.com/providers/hummingbird-69/processes/cdo_bbox/jobs",
           "processEndpointWPS1": "https://host-140-69.rdext.crim.ca/twitcher/ows/proxy/hummingbird?service=WPS&request=DescribeProcess&version=1.0.0&identifier=cdo_bbox",
-          "processDescriptionURL": "http://localhost:4002/providers/hummingbird-69/processes/cdo_bbox",
+          "processDescriptionURL": "http://schema-example.com/providers/hummingbird-69/processes/cdo_bbox",
           "type": "wps-remote",
           "package": {
             "cwlVersion": "v1.0",
@@ -1438,10 +1438,10 @@
           ],
           "inputs": [],
           "outputs": [],
-          "url": "http://localhost:4002/providers/hummingbird-69/processes/cdo_indices",
-          "executeEndpoint": "http://localhost:4002/providers/hummingbird-69/processes/cdo_indices/jobs",
+          "url": "http://schema-example.com/providers/hummingbird-69/processes/cdo_indices",
+          "executeEndpoint": "http://schema-example.com/providers/hummingbird-69/processes/cdo_indices/jobs",
           "processEndpointWPS1": "https://host-140-69.rdext.crim.ca/twitcher/ows/proxy/hummingbird?service=WPS&request=DescribeProcess&version=1.0.0&identifier=cdo_indices",
-          "processDescriptionURL": "http://localhost:4002/providers/hummingbird-69/processes/cdo_indices",
+          "processDescriptionURL": "http://schema-example.com/providers/hummingbird-69/processes/cdo_indices",
           "type": "wps-remote",
           "package": {
             "cwlVersion": "v1.0",
@@ -1494,10 +1494,10 @@
           ],
           "inputs": [],
           "outputs": [],
-          "url": "http://localhost:4002/providers/hummingbird-69/processes/ensembles",
-          "executeEndpoint": "http://localhost:4002/providers/hummingbird-69/processes/ensembles/jobs",
+          "url": "http://schema-example.com/providers/hummingbird-69/processes/ensembles",
+          "executeEndpoint": "http://schema-example.com/providers/hummingbird-69/processes/ensembles/jobs",
           "processEndpointWPS1": "https://host-140-69.rdext.crim.ca/twitcher/ows/proxy/hummingbird?service=WPS&request=DescribeProcess&version=1.0.0&identifier=ensembles",
-          "processDescriptionURL": "http://localhost:4002/providers/hummingbird-69/processes/ensembles",
+          "processDescriptionURL": "http://schema-example.com/providers/hummingbird-69/processes/ensembles",
           "type": "wps-remote",
           "package": {
             "cwlVersion": "v1.0",
@@ -1550,10 +1550,10 @@
           ],
           "inputs": [],
           "outputs": [],
-          "url": "http://localhost:4002/providers/hummingbird-69/processes/cdo_inter_mpi",
-          "executeEndpoint": "http://localhost:4002/providers/hummingbird-69/processes/cdo_inter_mpi/jobs",
+          "url": "http://schema-example.com/providers/hummingbird-69/processes/cdo_inter_mpi",
+          "executeEndpoint": "http://schema-example.com/providers/hummingbird-69/processes/cdo_inter_mpi/jobs",
           "processEndpointWPS1": "https://host-140-69.rdext.crim.ca/twitcher/ows/proxy/hummingbird?service=WPS&request=DescribeProcess&version=1.0.0&identifier=cdo_inter_mpi",
-          "processDescriptionURL": "http://localhost:4002/providers/hummingbird-69/processes/cdo_inter_mpi",
+          "processDescriptionURL": "http://schema-example.com/providers/hummingbird-69/processes/cdo_inter_mpi",
           "type": "wps-remote",
           "package": {
             "cwlVersion": "v1.0",

--- a/weaver/wps_restapi/swagger_definitions.py
+++ b/weaver/wps_restapi/swagger_definitions.py
@@ -5108,7 +5108,8 @@ get_single_job_status_responses = {
     "200": OkGetJobStatusResponse(description="success", examples={
         "JobStatusSuccess": {
             "summary": "Successful job status response.",
-            "value": EXAMPLES["job_status_success.json"]},
+            "value": EXAMPLES["job_status_success.json"],
+        },
         "JobStatusFailure": {
             "summary": "Failed job status response.",
             "value": EXAMPLES["job_status_failed.json"],
@@ -5123,7 +5124,12 @@ get_prov_single_job_status_responses.update({
     "403": ForbiddenProviderLocalResponseSchema(),
 })
 delete_job_responses = {
-    "200": OkDismissJobResponse(description="success"),
+    "200": OkDismissJobResponse(description="success", examples={
+        "JobDismissedSuccess": {
+            "summary": "Successful job dismissed response.",
+            "value": EXAMPLES["job_dismissed_success.json"]
+        },
+    }),
     "400": InvalidJobResponseSchema(),
     "404": NotFoundJobResponseSchema(),
     "410": GoneJobResponseSchema(),

--- a/weaver/wps_restapi/swagger_definitions.py
+++ b/weaver/wps_restapi/swagger_definitions.py
@@ -4630,6 +4630,12 @@ class CreatedJobLocationHeader(ResponseHeaders):
 
 class CreatedLaunchJobResponse(ExtendedMappingSchema):
     description = "Job successfully submitted to processing queue. Execution should begin when resources are available."
+    examples = {
+        "JobAccepted": {
+            "summary": "Job accepted for execution.",
+            "value": EXAMPLES["job_status_accepted.json"]
+        }
+    }
     header = CreatedJobLocationHeader()
     body = CreatedJobStatusSchema()
 
@@ -4962,7 +4968,12 @@ get_processes_responses = {
     "500": InternalServerErrorResponseSchema(),
 }
 post_processes_responses = {
-    "201": OkPostProcessesResponse(),
+    "201": OkPostProcessesResponse(examples={
+        "ProcessDeployed": {
+            "summary": "Process successfully deployed.",
+            "value": EXAMPLES["local_process_deploy_success.json"],
+        }
+    }),
     "500": InternalServerErrorResponseSchema(),
 }
 get_process_responses = {
@@ -5012,7 +5023,12 @@ put_process_visibility_responses = {
     "500": InternalServerErrorResponseSchema(),
 }
 delete_process_responses = {
-    "200": OkDeleteProcessResponse(),
+    "200": OkDeleteProcessResponse(examples={
+        "ProcessUndeployed": {
+            "summary": "Process successfully undeployed.",
+            "value": EXAMPLES["local_process_undeploy_success.json"],
+        }
+    }),
     "403": ForbiddenProcessAccessResponseSchema(),
     "500": InternalServerErrorResponseSchema(),
 }


### PR DESCRIPTION
Changes:
--------
- Add `CLI` *Authentication Handler* parameters and corresponding ``auth`` argument of instantiated classes for
  ``WeaverClient`` methods that allows inline request authentication and authorization resolution to access a
  protected service. Any *Authentication Handler* implementation can be used to fulfill required server functionalities.
- Replaced `CLI` option ``-t`` by ``-T`` (`Docker` token) during ``deploy`` operation to match naming convention of
  other options (resolves #400).
- Replaced `CLI` option ``-H`` by ``nH`` (``--no-headers``) and ``wH`` (``--with-headers``) to respectively
  enable or (explicitly) disable return of headers from response of the executed operation.
- Replaced `CLI` option ``-L`` by ``nL`` (``--no-links``) and ``wL`` (``--with-links``) to respectively
  enable (explicitly) or disable return of links from response of the executed operation.
- Replaced previously defined ``-H`` option by new ``-H/--header`` argument allowing insertion of explicitly provided
  request headers for relevant requests called by the executed operation.

Fixes:
------
- Fix `CLI` operations assuming valid JSON response to instead return error response content and status code.
- Fix `CLI` rendering of various optional arguments and groups when displaying help messages.

References
------
Resolves [DAC-460](https://crim-ca.atlassian.net/browse/DAC-460)
