### PR TITLE
update to docs about existing (though undocumented) features

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,8 +10,23 @@ Changes
 `Unreleased <https://github.com/crim-ca/weaver/tree/master>`_ (latest)
 ========================================================================
 
+.. _`OGC Application Package`: https://raw.githubusercontent.com/opengeospatial/ogcapi-processes/master/extensions/deploy_replace_undeploy/standard/openapi/schemas/ogcapppkg.yaml
+
 Changes:
 --------
+- Add support of official `CWL` IANA types to allow `Process` deployment with the relevant ``Content-Type`` header
+  for the submitted payload (see `common-workflow-language/common-workflow-language#421 (comment)
+  <https://github.com/common-workflow-language/common-workflow-language/issues/421#issuecomment-1122010820>`_,
+  relates to `opengeospatial/NamingAuthority#169 <https://github.com/opengeospatial/NamingAuthority/issues/169>`_,
+  resolves `#434 <https://github.com/crim-ca/weaver/issues/434>`_).
+- Support `Process` deployment using only `CWL` content provided it contains an ``id`` field representing the target
+  `Process` ID as per recommendation in `OGC Best Practice for Earth Observation Application Package, CWL Document
+  <https://docs.ogc.org/bp/20-089r1.html#toc26>`_ (resolves `#434 <https://github.com/crim-ca/weaver/issues/434>`_).
+- Support `Process` deployment with a payload using ``YAML`` content instead of ``JSON``. This ``YAML`` content
+  **MUST** be submitted in the request with a ``Content-Type`` header either equal to ``application/x-yaml`` or
+  ``application/ogcapppkg+yaml`` for the `OGC Application Package`_ schema, or using ``application/cwl+yaml`` for
+  a `CWL`-only definition. The definition will be loaded and converted to ``JSON`` for schema validation. Otherwise,
+  ``JSON`` contents is assumed to be directly provided in the request payload for validation as previously accomplished.
 - Add `CLI` *Authentication Handler* parameters and corresponding ``auth`` argument of instantiated classes for
   ``WeaverClient`` methods that allows inline request authentication and authorization resolution to access a
   protected service. Any *Authentication Handler* implementation can be used to fulfill required server functionalities.
@@ -29,6 +44,7 @@ Changes:
 
 Fixes:
 ------
+- Fix ``Process.payload`` improperly encoded in case of special characters where allowed such as in `CWL` definition.
 - Fix `CLI` operations assuming valid JSON response to instead return error response content and status code.
 - Fix `CLI` rendering of various optional arguments and groups when displaying help messages.
 - Fix invalid handling of ``Constants`` definitions mixed with ``classproperty`` such as in ``OutputFormat`` causing

--- a/config/weaver.ini.example
+++ b/config/weaver.ini.example
@@ -81,6 +81,10 @@ weaver.quote_sync_max_wait = 20
 # (default: use cwltool auto-resolution according to running machine and current user/group)
 weaver.cwl_euid =
 weaver.cwl_egid =
+# directory where to load predefined process definitions defined with CWL files
+# default configuration directory is used if this entry is removed
+# only CWL files are considered, lookup in directory is recursive
+weaver.cwl_processes_dir =
 
 # --- Weaver WPS settings ---
 weaver.wps = true

--- a/docs/source/appendix.rst
+++ b/docs/source/appendix.rst
@@ -169,7 +169,8 @@ Glossary
         later retrieval using an access token.
 
         .. seealso::
-            :ref:`vault_upload`
+            - :ref:`vault_upload`
+            - :ref:`file_vault_inputs`
 
     WKT
         Well-Known Text geometry representation.

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -1,6 +1,9 @@
 .. include:: references.rst
 .. _configuration:
 
+.. default location to quickly reference items without the explicit and long prefix
+.. py:currentmodule:: weaver.config
+
 ******************
 Configuration
 ******************
@@ -76,8 +79,21 @@ they are optional and which default value or operation is applied in each situat
 
 .. versionadded:: 4.0.0
 
+- | ``weaver.cwl_euid = <int>`` [:class:`int`, *experimental*]
+  | (default: ``None``, auto-resolved by :term:`CWL` with effective machine user)
+  |
+  | Define the effective machine user ID to be used for running the :term:`Application Package`.
 
-- | ``weaver.wps = true|false``
+.. versionadded:: 1.9.0
+
+- | ``weaver.cwl_egid = <int>`` [:class:`int`, *experimental*]
+  | (default: ``None``, auto-resolved by :term:`CWL` with the group of the effective user)
+  |
+  | Define the effective machine group ID to be used for running the :term:`Application Package`.
+
+.. versionadded:: 1.9.0
+
+- | ``weaver.wps = true|false`` [:class:`bool`-like]
   | (default: ``true``)
   |
   | Enables the WPS-1/2 endpoint.
@@ -177,7 +193,7 @@ they are optional and which default value or operation is applied in each situat
   |
   | Prefix where process :term:`Job` worker should execute the :term:`Process` from.
 
-- | ``weaver.wps_restapi = true|false``
+- | ``weaver.wps_restapi = true|false`` [:class:`bool`-like]
   | (default: ``true``)
   |
   | Enable the WPS-REST endpoint.
@@ -215,8 +231,8 @@ they are optional and which default value or operation is applied in each situat
 
 .. versionadded:: 4.15.0
 
-- | ``weaver.exec_sync_max_wait``
-  | (default: ``20``, :class:`int`, seconds)
+- | ``weaver.exec_sync_max_wait = <int>`` [:class:`int`, seconds]
+  | (default: ``20``)
   |
   | Defines the maximum duration allowed for running a :term:`Job` execution in `synchronous` mode.
   |
@@ -225,8 +241,8 @@ they are optional and which default value or operation is applied in each situat
 
 .. versionadded:: 4.15.0
 
-- | ``weaver.quote_sync_max_wait``
-  | (default: ``20``, :class:`int`, seconds)
+- | ``weaver.quote_sync_max_wait = <int>`` [:class:`int`, seconds]
+  | (default: ``20``)
   |
   | Defines the maximum duration allowed for running a :term:`Quote` estimation in `synchronous` mode.
   |
@@ -321,6 +337,8 @@ using the ``Weaver.data_sources`` configuration setting.
 .. seealso::
     More details about the implication of :term:`Data Source` are provided in :ref:`data-source`.
 
+.. _conf_wps_processes:
+
 Configuration of WPS Processes
 =======================================
 
@@ -347,19 +365,65 @@ Please refer to `wps_processes.yml.example`_ for explicit format, keywords suppo
     Using this registration method, the processes will always reflect the latest modification from the
     remote WPS provider.
 
-To specify a custom YAML file, you can define the setting named ``weaver.wps_processes_file`` with the appropriate path
-within the employed ``weaver.ini`` file that starts your application. By default, this setting will look for the
-provided path as absolute location, then will attempt to resolve relative path (corresponding to where the application
-is started from), and will also look within the |weaver-config|_ directory. If none of the files can be found, the
-operation is skipped.
 
-To ensure that this feature is disabled and to avoid any unexpected auto-deployment provided by this functionality,
-simply set setting ``weaver.wps_processes_file`` as *undefined* (i.e.: nothing after ``=`` in ``weaver.ini``).
+- | ``weaver.wps_processes_file = <file-path>``
+  | (default: :py:data:`WEAVER_DEFAULT_WPS_PROCESSES_CONFIG` located in :py:data:`WEAVER_CONFIG_DIR`)
+  |
+  | Defines a custom :term:`YAML` file corresponding to `wps_processes.yml.example`_ schema to pre-load :term:`WPS`
+    processes and/or providers for registration at application startup.
+  |
+  | The value defined by this setting will look for the provided path as absolute location, then will attempt to
+    resolve relative path (corresponding to where the application is started from), and will also look within
+    the |weaver-config|_ directory. If none of the files can be found, the operation is skipped.
+  |
+  | To ensure that this feature is disabled and to avoid any unexpected auto-deployment provided by this functionality,
+    simply set setting ``weaver.wps_processes_file`` as *undefined* (i.e.: nothing after ``=`` in ``weaver.ini``).
+    The default value is employed if the setting is not defined at all.
 
 .. seealso::
     - `weaver.ini.example`_
     - `wps_processes.yml.example`_
 
+.. _conf_cwl_processes:
+
+Configuration of CWL Processes
+=======================================
+
+.. versionadded:: 4.19.0
+
+Although `Weaver` supports :ref:`Deployment <proc_op_deploy>` and dynamic management of :term:`Process` definitions
+while the web application is running, it is sometime more convenient for service providers to offer a set of predefined
+:ref:`application-package` definitions. In order to automatically register such definitions (or update them if changed),
+without having to repeat any deployment requests after the application was started, it is possible to employ the
+configuration setting ``weaver.cwl_processes_dir``. Registration of a :term:`Process` using this approach will result
+in an identical definition as if it was :ref:`Deployed <proc_op_deploy>` using :term:`API` requests or using the
+:ref:`cli` interfaces.
+
+- | ``weaver.cwl_processes_dir = <dir-path>``
+  | (default: :py:data:`WEAVER_CONFIG_DIR`)
+  |
+  | Defines the root directory where to *recursively* and *alphabetically* (as flat list) load any :term:`CWL` file
+    to deploy the corresponding :term:`Process` definitions.
+  |
+  | The value defined by this setting will look for the provided path as absolute location, then will attempt to
+    resolve relative path (corresponding to where the application is started from). If none of the files can be found,
+    the operation is skipped.
+  |
+  | To ensure that this feature is disabled and to avoid any unexpected auto-deployment provided by this functionality,
+    simply set setting ``weaver.cwl_processes_dir`` as *undefined* (i.e.: nothing after ``=`` in ``weaver.ini``).
+    The default value is employed if the setting is not defined at all.
+
+.. note::
+    When registering processes using :term:`CWL`, it is mandatory for those definitions to provide an ``id`` within
+    the file along other :term:`CWL` details to let `Weaver` know which :term:`Process` reference to use for deployment.
+
+.. warning::
+    If a :term:`Process` depends on another definition, such as in the case of a :ref:`proc_workflow` definition, all
+    dependencies must be registered prior to this :term:`Process`. Consider naming your :term:`CWL` files to take
+    advantage of loading order to resolve such situations.
+
+.. seealso::
+    - `weaver.ini.example`_
 
 .. _conf_request_options:
 
@@ -391,7 +455,7 @@ etc. on a per-request basis, leave other requests unaffected and generally more 
   | Path of the :term:`Request Options` definitions to employ.
 
 
-- | ``weaver.ssl_verify = true|false``
+- | ``weaver.ssl_verify = true|false`` [:class:`bool`-like]
   | (default: ``true``)
   |
   | Toggle the SSL certificate verification across all requests.
@@ -402,6 +466,35 @@ etc. on a per-request basis, leave other requests unaffected and generally more 
     access or personal user data references. This should be employed only for quickly resolving issues during
     development. Consider fixing SSL certificates on problematic servers, or disable the verification on a per-request
     basis using :term:`Request Options` for acceptable cases.
+
+
+.. _conf_vault:
+
+Configuration of File Vault
+=======================================
+
+.. versionadded:: 4.9.0
+
+Configuration of the :term:`Vault` is required in order to obtain access to its functionalities
+and to enable its :term:`API` endpoints. This feature is notably employed to push local files to a remote `Weaver`
+instance when using the :ref:`cli` utilities, in order to use them for the :term:`Job` execution. Please refer to
+below references for more details.
+
+.. seealso::
+    - :ref:`vault_upload`
+    - :ref:`file_vault_inputs`
+
+- | ``weaver.vault = true|false`` [:class:`bool`-like]
+  | (default: ``true``)
+  |
+  | Toggles the :term:`Vault` feature.
+
+- | ``weaver.vault_dir = <dir-path>``
+  | (default: ``/tmp/vault``)
+  |
+  | Defines the default location where to write :ref:`files uploaded to the Vault <vault_upload>`.
+  |
+  | If the directory does not exist, it is created on demand by the feature making use of it.
 
 
 Starting the Application

--- a/docs/source/processes.rst
+++ b/docs/source/processes.rst
@@ -1325,12 +1325,15 @@ Note again that the more the :term:`Process` is verbose, the more tracking will 
 Uploading File to the Vault
 -----------------------------
 
+The :term:`Vault` is available as secured storage for uploading files to be employed later for :term:`Process`
+execution (see also :ref:`file_vault_inputs`).
+
 .. note::
     The :term:`Vault` is a specific feature of `Weaver`. Other :term:`ADES`, :term:`EMS` and :term:`OGC API - Processes`
     servers are not expected to provide this endpoint nor support the |vault_ref| reference format.
 
-The :term:`Vault` is available as secured storage for uploading files to be employed later for :term:`Process`
-execution (see also :ref:`file_vault_inputs`).
+.. seealso::
+    Refer to :ref:`conf_vault` for applicable settings for this feature.
 
 When upload succeeds, the response will return a :term:`Vault` UUID and an ``access_token`` to access the file.
 Uploaded files cannot be accessed unless the proper credentials are provided. Requests toward the :term:`Vault` should
@@ -1346,7 +1349,7 @@ the file from the :term:`Vault`. For both HTTP methods, the ``X-Auth-Vault`` hea
 
 .. note::
     The :term:`Vault` acts only as temporary file storage. For this reason, once the file has been downloaded, it is
-    immediately deleted. Download can only occur once. It is assumed that the resource that must employ it will have
+    *immediately deleted*. Download can only occur once. It is assumed that the resource that must employ it will have
     created a local copy from the download and the :term:`Vault` doesn't require to preserve it anymore. This behaviour
     intends to limit the duration for which potentially sensitive data remains available in the :term:`Vault` as well
     as performing cleanup to limit storage space.

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,6 +1,6 @@
 import pytest
 
-from weaver.base import Constants, ExtendedEnum
+from weaver.base import Constants, ExtendedEnum, classproperty
 
 
 class DummyConstant(Constants):
@@ -11,6 +11,8 @@ class DummyConstant(Constants):
     t4 = "T4"
     T5 = "random5"  # ensure name is case-insensitive (not matched via the lowercase value)
     t6 = "RANDOM6"  # ensure name is case-insensitive (not matched via the uppercase value)
+    T7 = classproperty(fget=lambda self: "t7")
+    t8 = classproperty(fget=lambda self: "T8")
 
 
 def test_constants_get_by_name_or_value_case_insensitive():
@@ -30,6 +32,28 @@ def test_constants_get_by_name_or_value_case_insensitive():
     assert DummyConstant.get("RANDOM5") == DummyConstant.T5
     assert DummyConstant.get("random6") == DummyConstant.t6
     assert DummyConstant.get("RANDOM6") == DummyConstant.t6
+    assert DummyConstant.get("t7") == DummyConstant.T7
+    assert DummyConstant.get("T7") == DummyConstant.T7
+    assert DummyConstant.get("t8") == DummyConstant.t8
+    assert DummyConstant.get("T8") == DummyConstant.t8
+
+
+def test_constants_get_by_attribute():
+    assert DummyConstant.get(DummyConstant.T1) == DummyConstant.T1
+    assert DummyConstant.get(DummyConstant.T2) == DummyConstant.T2
+    assert DummyConstant.get(DummyConstant.t3) == DummyConstant.t3
+    assert DummyConstant.get(DummyConstant.t4) == DummyConstant.t4
+    assert DummyConstant.get(DummyConstant.T5) == DummyConstant.T5
+    assert DummyConstant.get(DummyConstant.t6) == DummyConstant.t6
+    assert DummyConstant.get(DummyConstant.T7) == DummyConstant.T7
+    assert DummyConstant.get(DummyConstant.t8) == DummyConstant.t8
+
+
+def test_constants_classproperty_as_string():
+    assert isinstance(DummyConstant.get("T7"), str)
+    assert isinstance(DummyConstant.T7, str)
+    assert isinstance(DummyConstant.get("T8"), str)
+    assert isinstance(DummyConstant.t8, str)
 
 
 def test_constants_in_by_name_or_value():
@@ -41,6 +65,14 @@ def test_constants_in_by_name_or_value():
     assert "T3" in DummyConstant
     assert "t4" in DummyConstant
     assert "T4" in DummyConstant
+    assert "t5" in DummyConstant
+    assert "T5" in DummyConstant
+    assert "t6" in DummyConstant
+    assert "T6" in DummyConstant
+    assert "t7" in DummyConstant
+    assert "T7" in DummyConstant
+    assert "t8" in DummyConstant
+    assert "T8" in DummyConstant
 
 
 def test_constants_immutable():

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -989,7 +989,7 @@ def mocked_process_package():
     Provides mocks that bypasses execution when calling :module:`weaver.processes.wps_package` functions.
     """
     return (
-        mock.patch("weaver.processes.wps_package._load_package_file", return_value={"class": "test"}),
+        mock.patch("weaver.processes.wps_package.load_package_file", return_value={"class": "test"}),
         mock.patch("weaver.processes.wps_package._load_package_content", return_value=(None, "test", None)),
         mock.patch("weaver.processes.wps_package._get_package_inputs_outputs", return_value=(None, None)),
         mock.patch("weaver.processes.wps_package._merge_package_inputs_outputs", return_value=([], [])),

--- a/weaver/base.py
+++ b/weaver/base.py
@@ -7,9 +7,11 @@ import inspect
 from typing import TYPE_CHECKING, NewType
 
 if TYPE_CHECKING:
-    from typing import Any, Callable, Dict, List, Optional, Union
+    from typing import Any, Callable, Dict, List, Optional, Type, TypeVar, Union
 
     from weaver.typedefs import AnyKey
+
+    PropertyDataType = TypeVar("PropertyDataType")
 
 # pylint: disable=E1120,no-value-for-parameter
 
@@ -42,7 +44,7 @@ class Constants(object, metaclass=_Const):
 
     @classmethod
     def get(cls, key_or_value, default=None):
-        # type: (Union[AnyKey, EnumType], Optional[Any]) -> Any
+        # type: (Union[AnyKey, EnumType, PropertyDataType], Optional[Any]) -> PropertyDataType
         if isinstance(key_or_value, str):
             upper_key = key_or_value.upper()
             lower_key = key_or_value.lower()
@@ -108,8 +110,8 @@ class classproperty(property):  # pylint: disable=C0103,invalid-name
     """
 
     def __init__(self,
-                 fget=None,     # type: Optional[Callable[[object], Any]]
-                 fset=None,     # type: Optional[Callable[[object, Any], None]]
+                 fget=None,     # type: Optional[Callable[[object], PropertyDataType]]
+                 fset=None,     # type: Optional[Callable[[object, PropertyDataType], None]]
                  fdel=None,     # type: Optional[Callable[[object], None]]
                  doc="",        # type: str
                  ):             # type: (...) -> None
@@ -117,6 +119,7 @@ class classproperty(property):  # pylint: disable=C0103,invalid-name
         self.__doc__ = inspect.cleandoc(doc)
 
     def __get__(self, cls, owner):  # noqa
+        # type: (Type[object], Any) -> PropertyDataType
         return classmethod(self.fget).__get__(None, owner)()
 
 

--- a/weaver/config.py
+++ b/weaver/config.py
@@ -12,6 +12,8 @@ from weaver.utils import get_settings
 if TYPE_CHECKING:
     from typing import Optional
 
+    from pyramid.config import Configurator
+
     from weaver.typedefs import AnySettingsContainer
 
 LOGGER = logging.getLogger(__name__)
@@ -77,8 +79,8 @@ def get_weaver_config_file(file_path, default_config_file, generate_default_from
     """
     Validates that the specified configuration file can be found, or falls back to the default one.
 
-    Handles 'relative' paths for settings in ``WEAVER_DEFAULT_INI_CONFIG`` referring to other configuration files.
-    Default file must be one of ``WEAVER_DEFAULT_CONFIGS``.
+    Handles 'relative' paths for settings in :data:`WEAVER_DEFAULT_INI_CONFIG` referring to other configuration files.
+    Default file must be one of :data:`WEAVER_DEFAULT_CONFIGS`.
 
     If both the specified file and the default file cannot be found, default file under ``WEAVER_DEFAULT_INI_CONFIG`` is
     auto-generated from the corresponding ``.example`` file if :paramref:`generate_default_from_example` is ``True``.
@@ -119,4 +121,5 @@ def get_weaver_config_file(file_path, default_config_file, generate_default_from
 
 
 def includeme(config):  # noqa: E811
+    # type: (Configurator) -> None
     LOGGER.debug("Loading weaver configuration.")

--- a/weaver/database/__init__.py
+++ b/weaver/database/__init__.py
@@ -7,22 +7,26 @@ from weaver.database.mongodb import MongoDatabase
 from weaver.utils import get_registry, get_settings
 
 if TYPE_CHECKING:
-    from typing import Optional
+    from typing import Optional, Union
 
     from pyramid.config import Configurator
 
-    from weaver.typedefs import AnyRegistryContainer
+    from weaver.typedefs import AnyRegistryContainer, AnySettingsContainer
 
 LOGGER = logging.getLogger(__name__)
 
 
 def get_db(container=None, reset_connection=False):
-    # type: (Optional[AnyRegistryContainer], bool) -> MongoDatabase
+    # type: (Optional[Union[AnyRegistryContainer, AnySettingsContainer]], bool) -> MongoDatabase
     """
     Obtains the database connection from configured application settings.
 
     If :paramref:`reset_connection` is ``True``, the :paramref:`container` must be the application :class:`Registry` or
     any container that can retrieve it to accomplish reference reset. Otherwise, any settings container can be provided.
+
+    .. note::
+        It is preferable to provide a registry reference to reuse any available connection whenever possible.
+        Giving application settings will require establishing a new connection.
     """
     registry = get_registry(container, nothrow=True)
     if not reset_connection and registry and isinstance(getattr(registry, "db", None), MongoDatabase):

--- a/weaver/database/__init__.py
+++ b/weaver/database/__init__.py
@@ -6,13 +6,18 @@ from pyramid.settings import asbool
 from weaver.database.mongodb import MongoDatabase
 from weaver.utils import get_registry, get_settings
 
-LOGGER = logging.getLogger(__name__)
 if TYPE_CHECKING:
-    from weaver.typedefs import AnySettingsContainer
+    from typing import Optional
+
+    from pyramid.config import Configurator
+
+    from weaver.typedefs import AnyRegistryContainer
+
+LOGGER = logging.getLogger(__name__)
 
 
-def get_db(container, reset_connection=False):
-    # type: (AnySettingsContainer, bool) -> MongoDatabase
+def get_db(container=None, reset_connection=False):
+    # type: (Optional[AnyRegistryContainer], bool) -> MongoDatabase
     """
     Obtains the database connection from configured application settings.
 
@@ -24,12 +29,12 @@ def get_db(container, reset_connection=False):
         return registry.db
     database = MongoDatabase(container)
     if reset_connection:
-        registry = get_registry(container)
         registry.db = database
     return database
 
 
 def includeme(config):
+    # type: (Configurator) -> None
     settings = get_settings(config)
     if asbool(settings.get("weaver.build_docs", False)):
         LOGGER.info("Skipping database when building docs...")

--- a/weaver/datatype.py
+++ b/weaver/datatype.py
@@ -1999,17 +1999,23 @@ class Process(Base):
 
     @property
     def payload(self):
-        # type: () -> JSON
+        # type: () -> Union[JSON, str]
         """
-        Deployment specification as JSON body.
+        Deployment specification as :term:`JSON` body or raw :term:`YAML` content.
         """
         body = self.get("payload", {})
         return self._decode(body) if isinstance(body, dict) else body
 
     @payload.setter
     def payload(self, body):
-        # type: (JSON) -> None
-        self["payload"] = self._decode(body) if isinstance(body, dict) else {}
+        # type: (Union[JSON, str]) -> None
+        if isinstance(body, dict):
+            payload = self._decode(body)
+        elif body and isinstance(body, str):
+            payload = body
+        else:
+            payload = {}
+        self["payload"] = payload
 
     # encode(->)/decode(<-) characters that cannot be in a key during save to db
     _character_codes = [("$", "\uFF04"), (".", "\uFF0E")]

--- a/weaver/datatype.py
+++ b/weaver/datatype.py
@@ -1999,23 +1999,17 @@ class Process(Base):
 
     @property
     def payload(self):
-        # type: () -> Union[JSON, str]
+        # type: () -> JSON
         """
-        Deployment specification as :term:`JSON` body or raw :term:`YAML` content.
+        Deployment specification as :term:`JSON`.
         """
         body = self.get("payload", {})
         return self._decode(body) if isinstance(body, dict) else body
 
     @payload.setter
     def payload(self, body):
-        # type: (Union[JSON, str]) -> None
-        if isinstance(body, dict):
-            payload = self._decode(body)
-        elif body and isinstance(body, str):
-            payload = body
-        else:
-            payload = {}
-        self["payload"] = payload
+        # type: (JSON) -> None
+        self["payload"] = self._encode(body) if isinstance(body, dict) else {}
 
     # encode(->)/decode(<-) characters that cannot be in a key during save to db
     _character_codes = [("$", "\uFF04"), (".", "\uFF0E")]

--- a/weaver/formats.py
+++ b/weaver/formats.py
@@ -43,12 +43,16 @@ class ContentType(Constants):
         <type> "/" [x- | <tree> "."] <subtype> ["+" suffix] *[";" parameter=value]
     """
 
-    APP_CWL = "application/x-cwl"
+    APP_CWL = "application/cwl"
+    APP_CWL_JSON = "application/cwl+json"
+    APP_CWL_YAML = "application/cwl+yaml"
+    APP_X_CWL = "application/x-cwl"  # backward compatible format, others are official
     APP_FORM = "application/x-www-form-urlencoded"
     APP_GEOJSON = "application/geo+json"
     APP_GZIP = "application/gzip"
     APP_HDF5 = "application/x-hdf5"
     APP_JSON = "application/json"
+    APP_OGC_PKG_JSON = "application/ogcapppkg+json"
     APP_NETCDF = "application/x-netcdf"
     APP_OCTET_STREAM = "application/octet-stream"
     APP_PDF = "application/pdf"
@@ -72,6 +76,7 @@ class ContentType(Constants):
     VIDEO_MPEG = "video/mpeg"
 
     # special handling
+    ANY_CWL = {APP_CWL, APP_CWL_JSON, APP_CWL_YAML, APP_X_CWL}
     ANY_XML = {APP_XML, TEXT_XML}
     ANY = "*/*"
 
@@ -321,13 +326,23 @@ IANA_KNOWN_MEDIA_TYPES = {
 # but prefer the IANA resolution with is the primary reference for Media-Types
 IANA_MAPPING = {
     ContentType.APP_JSON: ContentType.APP_JSON,
+    # CWL now has an official IANA definition:
+    # https://www.iana.org/assignments/media-types/application/cwl
+    ContentType.APP_CWL: ContentType.APP_CWL,
+    ContentType.APP_CWL_JSON: ContentType.APP_CWL,
+    ContentType.APP_CWL_YAML: ContentType.APP_CWL,
+    ContentType.APP_X_CWL: ContentType.APP_CWL,
 }
 EDAM_NAMESPACE = "edam"
 EDAM_NAMESPACE_URL = "http://edamontology.org/"
 EDAM_NAMESPACE_DEFINITION = {EDAM_NAMESPACE: EDAM_NAMESPACE_URL}
 EDAM_SCHEMA = "http://edamontology.org/EDAM_1.24.owl"
 EDAM_MAPPING = {
+    # preserve CWL EDAM definitions for backward compatibility in case they were used in deployed processes
     ContentType.APP_CWL: "format_3857",
+    ContentType.APP_CWL_JSON: "format_3857",
+    ContentType.APP_CWL_YAML: "format_3857",
+    ContentType.APP_X_CWL: "format_3857",
     ContentType.IMAGE_GIF: "format_3467",
     ContentType.IMAGE_JPEG: "format_3579",
     ContentType.APP_HDF5: "format_3590",

--- a/weaver/formats.py
+++ b/weaver/formats.py
@@ -46,13 +46,14 @@ class ContentType(Constants):
     APP_CWL = "application/cwl"
     APP_CWL_JSON = "application/cwl+json"
     APP_CWL_YAML = "application/cwl+yaml"
-    APP_X_CWL = "application/x-cwl"  # backward compatible format, others are official
+    APP_CWL_X = "application/x-cwl"  # backward compatible format, others are official
     APP_FORM = "application/x-www-form-urlencoded"
     APP_GEOJSON = "application/geo+json"
     APP_GZIP = "application/gzip"
     APP_HDF5 = "application/x-hdf5"
     APP_JSON = "application/json"
     APP_OGC_PKG_JSON = "application/ogcapppkg+json"
+    APP_OGC_PKG_YAML = "application/ogcapppkg+yaml"
     APP_NETCDF = "application/x-netcdf"
     APP_OCTET_STREAM = "application/octet-stream"
     APP_PDF = "application/pdf"
@@ -76,7 +77,7 @@ class ContentType(Constants):
     VIDEO_MPEG = "video/mpeg"
 
     # special handling
-    ANY_CWL = {APP_CWL, APP_CWL_JSON, APP_CWL_YAML, APP_X_CWL}
+    ANY_CWL = {APP_CWL, APP_CWL_JSON, APP_CWL_YAML, APP_CWL_X}
     ANY_XML = {APP_XML, TEXT_XML}
     ANY = "*/*"
 
@@ -331,7 +332,7 @@ IANA_MAPPING = {
     ContentType.APP_CWL: ContentType.APP_CWL,
     ContentType.APP_CWL_JSON: ContentType.APP_CWL,
     ContentType.APP_CWL_YAML: ContentType.APP_CWL,
-    ContentType.APP_X_CWL: ContentType.APP_CWL,
+    ContentType.APP_CWL_X: ContentType.APP_CWL,
 }
 EDAM_NAMESPACE = "edam"
 EDAM_NAMESPACE_URL = "http://edamontology.org/"
@@ -342,7 +343,7 @@ EDAM_MAPPING = {
     ContentType.APP_CWL: "format_3857",
     ContentType.APP_CWL_JSON: "format_3857",
     ContentType.APP_CWL_YAML: "format_3857",
-    ContentType.APP_X_CWL: "format_3857",
+    ContentType.APP_CWL_X: "format_3857",
     ContentType.IMAGE_GIF: "format_3467",
     ContentType.IMAGE_JPEG: "format_3579",
     ContentType.APP_HDF5: "format_3590",

--- a/weaver/formats.py
+++ b/weaver/formats.py
@@ -19,6 +19,7 @@ from weaver.base import Constants, classproperty
 if TYPE_CHECKING:
     from typing import Any, Dict, List, Optional, Tuple, Union
 
+    from weaver.base import PropertyDataType
     from weaver.typedefs import JSON, AnyRequestType
 
 LOGGER = logging.getLogger(__name__)
@@ -120,8 +121,11 @@ class OutputFormat(Constants):
     """)
 
     @classmethod
-    def get(cls, format_or_version, default=JSON, allow_version=True):  # pylint: disable=W0221,W0237
-        # type: (Union[str, AnyOutputFormat], AnyOutputFormat, bool) -> AnyOutputFormat
+    def get(cls,                    # pylint: disable=W0221,W0237  # arguments differ/renamed
+            format_or_version,      # type: Union[str, AnyOutputFormat, PropertyDataType]
+            default=JSON,           # type: AnyOutputFormat
+            allow_version=True,     # type: bool
+            ):                      # type: (...) ->  Union[AnyOutputFormat, PropertyDataType]
         """
         Resolve the applicable output format.
 

--- a/weaver/processes/__init__.py
+++ b/weaver/processes/__init__.py
@@ -1,3 +1,9 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pyramid.config import Configurator
+
 
 def includeme(config):  # noqa: E811
+    # type: (Configurator) -> None
     pass

--- a/weaver/processes/builtin/__init__.py
+++ b/weaver/processes/builtin/__init__.py
@@ -25,9 +25,11 @@ from weaver.wps.utils import get_wps_url
 from weaver.wps_restapi.utils import get_wps_restapi_base_url
 
 if TYPE_CHECKING:
-    from weaver.typedefs import AnySettingsContainer, CWL
-    from cwltool.context import RuntimeContext
     from typing import Any, Dict, Type, Union
+
+    from cwltool.context import RuntimeContext
+
+    from weaver.typedefs import AnyRegistryContainer, CWL
 
 LOGGER = logging.getLogger(__name__)
 
@@ -103,7 +105,7 @@ def _get_builtin_package(process_id, package):
 
 
 def register_builtin_processes(container):
-    # type: (AnySettingsContainer) -> None
+    # type: (AnyRegistryContainer) -> None
     """
     Registers every ``builtin`` CWL package to the processes database.
 

--- a/weaver/processes/utils.py
+++ b/weaver/processes/utils.py
@@ -54,8 +54,9 @@ if TYPE_CHECKING:
     from pyramid.request import Request
 
     from weaver.typedefs import (
-        AnyContainer,
         AnyHeadersContainer,
+        AnyRegistryContainer,
+        AnyRequestType,
         AnySettingsContainer,
         CWL,
         FileSystemPathType,
@@ -245,7 +246,7 @@ def _validate_deploy_process_info(process_info, reference, package, settings, he
 
 
 def deploy_process_from_payload(payload, container, overwrite=False):
-    # type: (JSON, AnyContainer, bool) -> HTTPException
+    # type: (JSON, Union[AnySettingsContainer, AnyRequestType], bool) -> HTTPException
     """
     Deploy the process after resolution of all references and validation of the parameters from payload definition.
 
@@ -253,8 +254,10 @@ def deploy_process_from_payload(payload, container, overwrite=False):
     matching :class:`weaver.wps_restapi.swagger_definitions.ProcessDescription`.
 
     :param payload: JSON payload that was specified during the process deployment request.
-    :param container: container to retrieve application settings.
-    :param overwrite: whether to allow override of an existing process definition if conflict occurs.
+    :param container:
+        Container to retrieve application settings.
+        If it is a ``request``-like object, additional parameters may be used to identify the payload schema.
+    :param overwrite: Whether to allow override of an existing process definition if conflict occurs.
     :returns: HTTPOk if the process registration was successful.
     :raises HTTPException: for any invalid process deployment step.
     """
@@ -419,7 +422,7 @@ def parse_wps_process_config(config_entry):
 
 
 def register_wps_processes_static(service_url, service_name, service_visibility, service_processes, container):
-    # type: (str, str, bool, List[str], AnySettingsContainer) -> None
+    # type: (str, str, bool, List[str], AnyRegistryContainer) -> None
     """
     Register WPS-1 :term:`Process` under a service :term:`Provider` as static references.
 
@@ -490,7 +493,7 @@ def register_wps_processes_static(service_url, service_name, service_visibility,
 
 
 def register_wps_processes_dynamic(service_name, service_url, service_visibility, container):
-    # type: (str, str, bool, AnySettingsContainer) -> None
+    # type: (str, str, bool, AnyRegistryContainer) -> None
     """
     Register a WPS service ``provider`` such that ``processes`` under it are dynamically accessible on demand.
 

--- a/weaver/processes/utils.py
+++ b/weaver/processes/utils.py
@@ -1,4 +1,6 @@
+import os
 import logging
+import pathlib
 import warnings
 from copy import deepcopy
 from distutils.version import LooseVersion
@@ -20,6 +22,7 @@ from pyramid.httpexceptions import (
 from pyramid.settings import asbool
 
 from weaver.config import (
+    WEAVER_CONFIG_DIR,
     WEAVER_DEFAULT_WPS_PROCESSES_CONFIG,
     WeaverFeature,
     get_weaver_config_file,
@@ -39,9 +42,17 @@ from weaver.exceptions import (
     ServiceNotFound,
     log_unhandled_exceptions
 )
+from weaver.formats import ContentType
 from weaver.processes.types import ProcessType
 from weaver.store.base import StoreProcesses, StoreServices
-from weaver.utils import fully_qualified_name, generate_diff, get_sane_name, get_settings, get_url_without_query
+from weaver.utils import (
+    fully_qualified_name,
+    generate_diff,
+    get_header,
+    get_sane_name,
+    get_settings,
+    get_url_without_query
+)
 from weaver.visibility import Visibility
 from weaver.wps.utils import get_wps_client
 from weaver.wps_restapi import swagger_definitions as sd
@@ -275,6 +286,8 @@ def deploy_process_from_payload(payload, container, overwrite=False):
     ows_context = process_info.pop("owsContext", None)
     reference = None
     package = None
+    headers = getattr(container, "headers", {})  # container is any request (as when called from API Deploy request)
+    c_type = get_header("Content-Type", headers, default=ContentType.APP_OGC_PKG_JSON)
     found = False
     if process_href:
         reference = process_href  # reference type handled downstream
@@ -289,7 +302,10 @@ def deploy_process_from_payload(payload, container, overwrite=False):
         package = None
         reference = content.get("href")
         found = isinstance(reference, str)
-    else:
+    elif c_type in (ContentType.ANY_CWL + [ContentType.APP_JSON]) and "cwlVersion" in payload:
+        package = payload
+        process_info = {}
+    else:  # ogc-apppkg type, but no explicit check since used by default (backward compat)
         if deployment_profile_name:  # optional hint
             allowed_profile_suffix = [ProcessType.APPLICATION, ProcessType.WORKFLOW]
             if not any(deployment_profile_name.lower().endswith(typ) for typ in allowed_profile_suffix):
@@ -327,7 +343,6 @@ def deploy_process_from_payload(payload, container, overwrite=False):
 
     # update and validate process information using WPS process offering, CWL/WPS reference or CWL package definition
     settings = get_settings(container)
-    headers = getattr(container, "headers", {})  # container is any request (as when called from API Deploy request)
     process_info = _validate_deploy_process_info(process_info, reference, package, settings, headers)
 
     restapi_url = get_wps_restapi_base_url(settings)
@@ -544,25 +559,47 @@ def register_wps_processes_dynamic(service_name, service_url, service_visibility
         LOGGER.exception("Exception during provider registration: [%s] [%r]. Skipping...", service_name, ex)
 
 
-def register_wps_processes_from_config(wps_processes_file_path, container):
-    # type: (Optional[FileSystemPathType], AnySettingsContainer) -> None
+def register_wps_processes_from_config(container, wps_processes_file_path=None):
+    # type: (AnyRegistryContainer, Optional[FileSystemPathType]) -> None
     """
-    Registers remote `WPS` providers and/or processes as specified from the configuration file.
+    Registers remote :term:`WPS` providers and/or processes as specified from the configuration file.
 
-    Loads a `wps_processes.yml` file and registers `WPS-1` providers processes to the
-    current `Weaver` instance as equivalent `WPS-2` processes.
+    Loads a ``wps_processes.yml`` file and registers  processes under `WPS-1/2`_ providers to the
+    current `Weaver` instance as equivalent :term:`OGC API - Processes` instances.
 
-    References listed under ``processes`` are registered.
-    When the reference is a service (provider), registration of each WPS process is done individually
-    for each of the specified providers with ID ``[service]_[process]`` per listed process by ``GetCapabilities``.
+    References listed under ``processes`` are registered statically (by themselves, unchanging snapshot).
+    References listed under ``providers``, the :term:`WPS` themselves are registered, making each :term:`Process`
+    listed in their ``GetCapabilities`` available. In this case, registered processes are defined dynamically,
+    meaning they will be fetched on the provider each time a request refers to them, keeping their definition
+    up-to-date with the remote server.
 
     .. versionadded:: 1.14.0
         When references are specified using ``providers`` section instead of ``processes``, the registration
-        only saves the remote WPS provider endpoint to dynamically populate WPS processes on demand.
+        only saves the remote WPS provider endpoint to dynamically populate :term:`WPS` processes on demand.
+        Previous behavior was to register each :term:`WPS` process individually with ID ``[service]_[process]``.
+
+    .. versionchanged:: 4.19.0
+        Parameter position are inverted.
+        If :paramref:`wps_processes_file_path` is explicitly provided, it is used directly without considering settings.
+        Otherwise, automatically employ the definition in setting: ``weaver.wps_processes_file``.
 
     .. seealso::
-        - `weaver.wps_processes.yml.example` for additional file format details
+        - `weaver.wps_processes.yml.example` for additional file format details.
+
+    .. note::
+        Settings with an explicit empty ``weaver.wps_processes_file`` entry will be considered as *nothing to load*.
+        If the entry is omitted, default location :data:`WEAVER_DEFAULT_WPS_PROCESSES_CONFIG` is attempted instead.
+
+    :param container: Registry container to obtain database reference as well as application settings.
+    :param wps_processes_file_path: Override file path to employ instead of default settings definition.
     """
+    if wps_processes_file_path is not None:
+        LOGGER.info("Using WPS-1 explicit override parameter to obtain file reference.")
+    else:
+        LOGGER.info("Using WPS-1 file reference from configuration settings.")
+        settings = get_settings(container)
+        wps_processes_file_path = settings.get("weaver.wps_processes_file")
+
     if wps_processes_file_path is None:
         warnings.warn("No file specified for WPS-1 providers registration.", RuntimeWarning)
         wps_processes_file_path = get_weaver_config_file("", WEAVER_DEFAULT_WPS_PROCESSES_CONFIG,
@@ -607,3 +644,75 @@ def register_wps_processes_from_config(wps_processes_file_path, container):
         msg = f"Invalid WPS-1 providers configuration file caused: [{fully_qualified_name(exc)}]({exc!s})."
         LOGGER.exception(msg)
         raise RuntimeError(msg)
+
+
+def register_cwl_processes_from_config(container):
+    # type: (AnyRegistryContainer) -> None
+    """
+    Load multiple :term:`CWL` definitions from a directory to register corresponding :term:`Process`.
+
+    .. versionadded:: 4.19.0
+
+    Each individual :term:`CWL` definition must fully describe a :term:`Process` by itself. Therefore, an ``id`` must
+    be available in the file to indicate the target deployment reference. In case of conflict, the existing database
+    :term:`Process` will be overridden to ensure file updates are applied.
+
+    Files are loaded in alphabetical order. If a :term:`Workflow` needs to refer to other processes, they should be
+    named in way that dependencies will be resolvable prior to the registration of the :term:`Workflow` :term:`Process`.
+    The resolved directory to search for :term:`CWL` will be traversed recursively.
+    This, along with the name of :term:`CWL` files themselves, can be used to resolve order-dependent loading cases.
+    Only ``.cwl`` extensions are considered to avoid invalid parsing of other files that could be defined in the shared
+    configuration directory.
+
+    .. note::
+        Settings with an explicit empty ``weaver.cwl_processes_dir`` entry will be considered as *nothing to load*.
+        If the entry is omitted, default location :data:`WEAVER_CONFIG_DIR` is used to search for :term:`CWL` files.
+
+    :param container: Registry container to obtain database reference as well as application settings.
+    """
+    from weaver.processes.wps_package import load_package_file
+
+    settings = get_settings(container)
+    cwl_processes_dir = settings.get("weaver.cwl_processes_dir")
+
+    if cwl_processes_dir is None:
+        warnings.warn("No configuration setting [weaver.cwl_processes_dir] specified for CWL processes registration. "
+                      f"Will use default location: [{WEAVER_CONFIG_DIR}]", RuntimeWarning)
+        cwl_processes_dir = WEAVER_CONFIG_DIR
+    elif cwl_processes_dir == "":
+        warnings.warn("Configuration setting [weaver.cwl_processes_dir] for CWL processes registration "
+                      "is explicitly defined as empty. Not loading anything.", RuntimeWarning)
+        return
+
+    if not os.path.isdir(cwl_processes_dir):
+        warnings.warn(
+            "Configuration setting [weaver.cwl_processes_dir] for CWL processes registration "
+            f"is not an existing directory: [{cwl_processes_dir}]. Not loading anything.", RuntimeWarning
+        )
+        return
+    cwl_processes_dir = os.path.abspath(cwl_processes_dir)
+    cwl_files = sorted(pathlib.Path(cwl_processes_dir).rglob("*.cwl"))
+    if not cwl_files:
+        warnings.warn(
+            f"Configuration directory [{cwl_processes_dir}] for CWL processes registration "
+            "does not contain any CWL file. Not loading anything.", RuntimeWarning
+        )
+        return
+
+    register_count = 0
+    register_total = len(cwl_files)
+    for cwl_path in cwl_files:
+        try:
+            cwl = load_package_file(str(cwl_path))
+            deploy_process_from_payload(cwl, settings, overwrite=True)
+        except (HTTPException, PackageRegistrationError) as exc:
+            warnings.warn(
+                f"Failed registration of process from CWL file: [{cwl_path!s}] "
+                f"caused by [{fully_qualified_name(exc)}]({exc!s}). "
+                "Skipping definition.", RuntimeWarning
+            )
+            continue
+    if register_count and register_count == register_total:
+        LOGGER.info("Successfully registered %s processes from CWL files.", register_total)
+    elif register_count != register_total:
+        LOGGER.warning("Partial registration of CWL processes, only %s/%s succeeded.", register_count, register_total)

--- a/weaver/processes/wps_package.py
+++ b/weaver/processes/wps_package.py
@@ -335,7 +335,7 @@ def _check_package_file(cwl_file_path_or_url):
     return cwl_path
 
 
-def _load_package_file(file_path):
+def load_package_file(file_path):
     # type: (str) -> CWL
     """
     Loads the package in YAML/JSON format specified by the file path.
@@ -541,7 +541,7 @@ def _generate_process_with_cwl_from_reference(reference):
     reference_path, reference_ext = os.path.splitext(reference)
     reference_name = os.path.split(reference_path)[-1]
     if reference_ext.replace(".", "") in PACKAGE_EXTENSIONS:
-        cwl_package = _load_package_file(reference)
+        cwl_package = load_package_file(reference)
         process_info = {"identifier": reference_name}
 
     # match against WPS-1/2 reference
@@ -581,11 +581,11 @@ def _generate_process_with_cwl_from_reference(reference):
             if "process" in payload or "owsContext" in payload:
                 process_info = payload.get("process", payload)
                 ows_ref = process_info.get("owsContext", {}).get("offering", {}).get("content", {}).get("href")
-                cwl_package = _load_package_file(ows_ref)
+                cwl_package = load_package_file(ows_ref)
             # if somehow the CWL was referenced without an extension, handle it here
             # also handle parsed WPS-3 process description also with a reference
             elif "cwlVersion" in payload:
-                cwl_package = _load_package_file(reference)
+                cwl_package = load_package_file(reference)
                 process_info = {"identifier": reference_name}
         else:
             raise ValueError(f"Unknown parsing methodology of Content-Type [{content_type}] for reference resolution.")

--- a/weaver/quotation/__init__.py
+++ b/weaver/quotation/__init__.py
@@ -1,3 +1,9 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pyramid.config import Configurator
+
 
 def includeme(config):  # noqa: E811
+    # type: (Configurator) -> None
     pass

--- a/weaver/typedefs.py
+++ b/weaver/typedefs.py
@@ -178,6 +178,7 @@ if TYPE_CHECKING:
         "class": CWL_Class,
         "label": str,
         "doc": str,
+        "id": Optional[str],
         "s:keywords": List[str],
         "baseCommand": Optional[Union[str, List[str]]],
         "parameters": Optional[List[str]],

--- a/weaver/typedefs.py
+++ b/weaver/typedefs.py
@@ -56,7 +56,7 @@ if TYPE_CHECKING:
     from celery.app import Celery
     from celery.result import AsyncResult, EagerResult, GroupResult, ResultSet
     from owslib.wps import BoundingBoxDataInput, ComplexDataInput, Process as ProcessOWS, WPSExecution
-    from pyramid.httpexceptions import HTTPSuccessful, HTTPRedirection
+    from pyramid.httpexceptions import HTTPException, HTTPSuccessful, HTTPRedirection
     from pyramid.registry import Registry
     from pyramid.request import Request as PyramidRequest
     from pyramid.response import Response as PyramidResponse
@@ -259,8 +259,9 @@ if TYPE_CHECKING:
     HeaderCookiesTuple = Union[Tuple[None, None], Tuple[HeadersBaseType, CookiesBaseType]]
     AnyHeadersContainer = Union[HeadersBaseType, ResponseHeaders, EnvironHeaders, CaseInsensitiveDict]
     AnyCookiesContainer = Union[CookiesBaseType, WPSRequest, PyramidRequest, AnyHeadersContainer]
-    AnyResponseType = Union[PyramidResponse, WebobResponse, RequestsResponse, TestResponse]
     AnyRequestType = Union[PyramidRequest, WerkzeugRequest, PreparedRequest, RequestsRequest, DummyRequest]
+    AnyResponseType = Union[PyramidResponse, WebobResponse, RequestsResponse, TestResponse]
+    AnyViewResponse = Union[PyramidResponse, WebobResponse, HTTPException]
     RequestMethod = Literal[
         "HEAD", "GET", "POST", "PUT", "PATCH", "DELETE",
         "head", "get", "post", "put", "patch", "delete",

--- a/weaver/vault/__init__.py
+++ b/weaver/vault/__init__.py
@@ -1,4 +1,5 @@
 import logging
+from typing import TYPE_CHECKING
 
 from pyramid.settings import asbool
 
@@ -6,10 +7,14 @@ from weaver.utils import get_settings
 from weaver.vault import views as v
 from weaver.wps_restapi import swagger_definitions as sd
 
+if TYPE_CHECKING:
+    from pyramid.config import Configurator
+
 LOGGER = logging.getLogger(__name__)
 
 
 def includeme(config):
+    # type: (Configurator) -> None
     settings = get_settings(config)
     if asbool(settings.get("weaver.vault", True)):
         LOGGER.info("Adding file vault...")

--- a/weaver/wps_restapi/jobs/__init__.py
+++ b/weaver/wps_restapi/jobs/__init__.py
@@ -1,13 +1,18 @@
 import logging
+from typing import TYPE_CHECKING
 
 from weaver.formats import OutputFormat
 from weaver.wps_restapi import swagger_definitions as sd
 from weaver.wps_restapi.jobs import jobs as j
 
+if TYPE_CHECKING:
+    from pyramid.config import Configurator
+
 LOGGER = logging.getLogger(__name__)
 
 
 def includeme(config):
+    # type: (Configurator) -> None
     LOGGER.info("Adding WPS REST API jobs...")
     settings = config.registry.settings
     config.add_route(**sd.service_api_route_info(sd.jobs_service, settings))

--- a/weaver/wps_restapi/processes/__init__.py
+++ b/weaver/wps_restapi/processes/__init__.py
@@ -1,9 +1,15 @@
 import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pyramid.config import Configurator
 
 LOGGER = logging.getLogger(__name__)
 
 
 def includeme(config):
+    # type: (Configurator) -> None
+
     from weaver.formats import OutputFormat
     from weaver.wps_restapi import swagger_definitions as sd
     from weaver.wps_restapi.processes import processes as p

--- a/weaver/wps_restapi/processes/processes.py
+++ b/weaver/wps_restapi/processes/processes.py
@@ -28,7 +28,7 @@ from weaver.wps_restapi.processes.utils import get_process_list_links, get_proce
 from weaver.wps_restapi.providers.utils import get_provider_services
 
 if TYPE_CHECKING:
-    from weaver.typedefs import JSON
+    from weaver.typedefs import JSON, AnyViewResponse, PyramidRequest
 
 LOGGER = logging.getLogger(__name__)
 
@@ -37,6 +37,7 @@ LOGGER = logging.getLogger(__name__)
                           response_schemas=sd.get_processes_responses)
 @log_unhandled_exceptions(logger=LOGGER, message=sd.InternalServerErrorResponseSchema.description)
 def get_processes(request):
+    # type: (PyramidRequest) -> AnyViewResponse
     """
     List registered processes (GetCapabilities).
 
@@ -136,6 +137,7 @@ def get_processes(request):
                            schema=sd.PostProcessesEndpoint(), response_schemas=sd.post_processes_responses)
 @log_unhandled_exceptions(logger=LOGGER, message=sd.InternalServerErrorResponseSchema.description)
 def add_local_process(request):
+    # type: (PyramidRequest) -> AnyViewResponse
     """
     Register a local process.
     """
@@ -146,6 +148,7 @@ def add_local_process(request):
                         schema=sd.ProcessEndpoint(), response_schemas=sd.get_process_responses)
 @log_unhandled_exceptions(logger=LOGGER, message=sd.InternalServerErrorResponseSchema.description)
 def get_local_process(request):
+    # type: (PyramidRequest) -> AnyViewResponse
     """
     Get a registered local process information (DescribeProcess).
     """
@@ -164,6 +167,7 @@ def get_local_process(request):
                                 schema=sd.ProcessPackageEndpoint(), response_schemas=sd.get_process_package_responses)
 @log_unhandled_exceptions(logger=LOGGER, message=sd.InternalServerErrorResponseSchema.description)
 def get_local_process_package(request):
+    # type: (PyramidRequest) -> AnyViewResponse
     """
     Get a registered local process package definition.
     """
@@ -175,6 +179,7 @@ def get_local_process_package(request):
                                 schema=sd.ProcessPayloadEndpoint(), response_schemas=sd.get_process_payload_responses)
 @log_unhandled_exceptions(logger=LOGGER, message=sd.InternalServerErrorResponseSchema.description)
 def get_local_process_payload(request):
+    # type: (PyramidRequest) -> AnyViewResponse
     """
     Get a registered local process payload definition.
     """
@@ -187,6 +192,7 @@ def get_local_process_payload(request):
                                    response_schemas=sd.get_process_visibility_responses)
 @log_unhandled_exceptions(logger=LOGGER, message=sd.InternalServerErrorResponseSchema.description)
 def get_process_visibility(request):
+    # type: (PyramidRequest) -> AnyViewResponse
     """
     Get the visibility of a registered local process.
     """
@@ -199,6 +205,7 @@ def get_process_visibility(request):
                                    response_schemas=sd.put_process_visibility_responses)
 @log_unhandled_exceptions(logger=LOGGER, message=sd.InternalServerErrorResponseSchema.description)
 def set_process_visibility(request):
+    # type: (PyramidRequest) -> AnyViewResponse
     """
     Set the visibility of a registered local process.
     """
@@ -228,6 +235,7 @@ def set_process_visibility(request):
                            schema=sd.ProcessEndpoint(), response_schemas=sd.delete_process_responses)
 @log_unhandled_exceptions(logger=LOGGER, message=sd.InternalServerErrorResponseSchema.description)
 def delete_local_process(request):
+    # type: (PyramidRequest) -> AnyViewResponse
     """
     Unregister a local process.
     """
@@ -269,6 +277,7 @@ def delete_local_process(request):
                               schema=sd.PostProcessJobsEndpoint(), response_schemas=sd.post_process_jobs_responses)
 @log_unhandled_exceptions(logger=LOGGER, message=sd.InternalServerErrorResponseSchema.description)
 def submit_local_job(request):
+    # type: (PyramidRequest) -> AnyViewResponse
     """
     Execute a process registered locally.
 

--- a/weaver/wps_restapi/processes/processes.py
+++ b/weaver/wps_restapi/processes/processes.py
@@ -141,7 +141,7 @@ def add_local_process(request):
     """
     Register a local process.
     """
-    return deploy_process_from_payload(request.json, request)
+    return deploy_process_from_payload(request.body, request)
 
 
 @sd.process_service.get(tags=[sd.TAG_PROCESSES, sd.TAG_DESCRIBEPROCESS], renderer=OutputFormat.JSON,

--- a/weaver/wps_restapi/providers/__init__.py
+++ b/weaver/wps_restapi/providers/__init__.py
@@ -1,13 +1,18 @@
 import logging
+from typing import TYPE_CHECKING
 
 from weaver.formats import OutputFormat
 from weaver.wps_restapi import swagger_definitions as sd
 from weaver.wps_restapi.providers import providers as p
 
+if TYPE_CHECKING:
+    from pyramid.config import Configurator
+
 LOGGER = logging.getLogger(__name__)
 
 
 def includeme(config):
+    # type: (Configurator) -> None
     LOGGER.info("Adding WPS REST API providers...")
     settings = config.registry.settings
     config.add_route(**sd.service_api_route_info(sd.providers_service, settings))

--- a/weaver/wps_restapi/providers/providers.py
+++ b/weaver/wps_restapi/providers/providers.py
@@ -26,9 +26,7 @@ from weaver.wps_restapi.providers.utils import check_provider_requirements, get_
 from weaver.wps_restapi.utils import get_schema_ref, handle_schema_validation
 
 if TYPE_CHECKING:
-    from pyramid.request import Request
-
-    from weaver.typedefs import AnyResponseType
+    from weaver.typedefs import AnyViewResponse, PyramidRequest
 
 LOGGER = logging.getLogger(__name__)
 
@@ -38,7 +36,7 @@ LOGGER = logging.getLogger(__name__)
 @log_unhandled_exceptions(logger=LOGGER, message=sd.InternalServerErrorResponseSchema.description)
 @check_provider_requirements
 def get_providers(request):
-    # type: (Request) -> AnyResponseType
+    # type: (PyramidRequest) -> AnyViewResponse
     """
     Lists registered providers.
     """
@@ -60,7 +58,7 @@ def get_providers(request):
 @log_unhandled_exceptions(logger=LOGGER, message=sd.InternalServerErrorResponseSchema.description)
 @check_provider_requirements
 def add_provider(request):
-    # type: (Request) -> AnyResponseType
+    # type: (PyramidRequest) -> AnyViewResponse
     """
     Register a new service provider.
     """
@@ -121,7 +119,7 @@ def add_provider(request):
 @log_unhandled_exceptions(logger=LOGGER, message=sd.InternalServerErrorResponseSchema.description)
 @check_provider_requirements
 def remove_provider(request):
-    # type: (Request) -> AnyResponseType
+    # type: (PyramidRequest) -> AnyViewResponse
     """
     Remove an existing service provider.
     """
@@ -140,7 +138,7 @@ def remove_provider(request):
 @log_unhandled_exceptions(logger=LOGGER, message=sd.InternalServerErrorResponseSchema.description)
 @check_provider_requirements
 def get_provider(request):
-    # type: (Request) -> AnyResponseType
+    # type: (PyramidRequest) -> AnyViewResponse
     """
     Get a provider definition (GetCapabilities).
     """
@@ -154,7 +152,7 @@ def get_provider(request):
 @log_unhandled_exceptions(logger=LOGGER, message=sd.InternalServerErrorResponseSchema.description)
 @check_provider_requirements
 def get_provider_processes(request):
-    # type: (Request) -> AnyResponseType
+    # type: (PyramidRequest) -> AnyViewResponse
     """
     Retrieve available provider processes (GetCapabilities).
     """
@@ -170,7 +168,7 @@ def get_provider_processes(request):
 
 @check_provider_requirements
 def describe_provider_process(request):
-    # type: (Request) -> Process
+    # type: (PyramidRequest) -> Process
     """
     Obtains a remote service process description in a compatible local process format.
 
@@ -193,7 +191,7 @@ def describe_provider_process(request):
 @handle_schema_validation()
 @check_provider_requirements
 def get_provider_process(request):
-    # type: (Request) -> AnyResponseType
+    # type: (PyramidRequest) -> AnyViewResponse
     """
     Retrieve a process description (DescribeProcess).
     """
@@ -212,7 +210,7 @@ def get_provider_process(request):
 @log_unhandled_exceptions(logger=LOGGER, message=sd.InternalServerErrorResponseSchema.description)
 @check_provider_requirements
 def submit_provider_job(request):
-    # type: (Request) -> AnyResponseType
+    # type: (PyramidRequest) -> AnyViewResponse
     """
     Execute a remote provider process.
     """

--- a/weaver/wps_restapi/quotation/__init__.py
+++ b/weaver/wps_restapi/quotation/__init__.py
@@ -1,13 +1,18 @@
 import logging
+from typing import TYPE_CHECKING
 
 from weaver.formats import OutputFormat
 from weaver.wps_restapi import swagger_definitions as sd
 from weaver.wps_restapi.quotation import bills as b, quotes as q
 
+if TYPE_CHECKING:
+    from pyramid.config import Configurator
+
 LOGGER = logging.getLogger(__name__)
 
 
 def includeme(config):
+    # type: (Configurator) -> None
     LOGGER.info("Adding WPS REST API quotation...")
     settings = config.registry.settings
     config.add_route(**sd.service_api_route_info(sd.process_quotes_service, settings))

--- a/weaver/wps_restapi/quotation/bills.py
+++ b/weaver/wps_restapi/quotation/bills.py
@@ -1,4 +1,5 @@
 import logging
+from typing import TYPE_CHECKING
 
 from pyramid.httpexceptions import HTTPNotFound, HTTPOk
 
@@ -8,6 +9,9 @@ from weaver.formats import OutputFormat
 from weaver.store.base import StoreBills
 from weaver.wps_restapi import swagger_definitions as sd
 
+if TYPE_CHECKING:
+    from weaver.typedefs import AnyViewResponse, PyramidRequest
+
 LOGGER = logging.getLogger(__name__)
 
 
@@ -15,6 +19,7 @@ LOGGER = logging.getLogger(__name__)
                       schema=sd.BillsEndpoint(), response_schemas=sd.get_bill_list_responses)
 @log_unhandled_exceptions(logger=LOGGER, message=sd.InternalServerErrorResponseSchema.description)
 def get_bill_list(request):
+    # type: (PyramidRequest) -> AnyViewResponse
     """
     Get list of bills IDs.
     """
@@ -27,6 +32,7 @@ def get_bill_list(request):
                      schema=sd.BillEndpoint(), response_schemas=sd.get_bill_responses)
 @log_unhandled_exceptions(logger=LOGGER, message=sd.InternalServerErrorResponseSchema.description)
 def get_bill_info(request):
+    # type: (PyramidRequest) -> AnyViewResponse
     """
     Get bill information.
     """

--- a/weaver/wps_restapi/quotation/quotes.py
+++ b/weaver/wps_restapi/quotation/quotes.py
@@ -23,7 +23,7 @@ from weaver.wps_restapi.processes.processes import submit_local_job
 if TYPE_CHECKING:
     from weaver.datatype import Process
 
-    from weaver.typedefs import AnyResponseType, PyramidRequest
+    from weaver.typedefs import AnyViewResponse, PyramidRequest
 
 LOGGER = logging.getLogger(__name__)
 
@@ -32,7 +32,7 @@ LOGGER = logging.getLogger(__name__)
                                 schema=sd.PostProcessQuoteRequestEndpoint(), response_schemas=sd.post_quotes_responses)
 @log_unhandled_exceptions(logger=LOGGER, message=sd.InternalServerErrorResponseSchema.description)
 def request_quote(request):
-    # type: (PyramidRequest) -> AnyResponseType
+    # type: (PyramidRequest) -> AnyViewResponse
     """
     Request a quotation for a process.
     """
@@ -124,7 +124,7 @@ def request_quote(request):
                        schema=sd.QuotesEndpoint(), response_schemas=sd.get_quote_list_responses)
 @log_unhandled_exceptions(logger=LOGGER, message=sd.InternalServerErrorResponseSchema.description)
 def get_quote_list(request):
-    # type: (PyramidRequest) -> AnyResponseType
+    # type: (PyramidRequest) -> AnyViewResponse
     """
     Get list of quotes IDs.
     """
@@ -153,7 +153,7 @@ def get_quote_list(request):
                       schema=sd.QuoteEndpoint(), response_schemas=sd.get_quote_responses)
 @log_unhandled_exceptions(logger=LOGGER, message=sd.InternalServerErrorResponseSchema.description)
 def get_quote_info(request):
-    # type: (PyramidRequest) -> AnyResponseType
+    # type: (PyramidRequest) -> AnyViewResponse
     """
     Get quote information.
     """
@@ -172,7 +172,7 @@ def get_quote_info(request):
                        schema=sd.PostQuote(), response_schemas=sd.post_quote_responses)
 @log_unhandled_exceptions(logger=LOGGER, message=sd.InternalServerErrorResponseSchema.description)
 def execute_quote(request):
-    # type: (PyramidRequest) -> AnyResponseType
+    # type: (PyramidRequest) -> AnyViewResponse
     """
     Execute a quoted process.
     """


### PR DESCRIPTION
## Changes

- Add support of official `CWL` IANA types to allow `Process` deployment with the relevant ``Content-Type`` header
  for the submitted payload.
- Support `Process` deployment using only `CWL` content provided it contains an ``id`` field representing the target
  `Process` ID as per recommendation in `OGC Best Practice for Earth Observation Application Package, CWL Document
  <https://docs.ogc.org/bp/20-089r1.html#toc26>`.
- Support `Process` deployment with a payload using ``YAML`` content instead of ``JSON``. This ``YAML`` content
  **MUST** be submitted in the request with a ``Content-Type`` header either equal to ``application/x-yaml`` or
  ``application/ogcapppkg+yaml`` for the `OGC Application Package <https://github.com/opengeospatial/ogcapi-processes/blob/master/extensions/deploy_replace_undeploy/standard/openapi/schemas/ogcapppkg.yaml>` schema, or using ``application/cwl+yaml`` for a `CWL`-only definition. The definition will be loaded and converted to ``JSON`` for schema validation. Otherwise, ``JSON`` contents is assumed to be directly provided in the request payload for validation as previously accomplished.


## References

- Fixes #434 
- Relates to #141 
- Relates to #11
- Relates to https://github.com/opengeospatial/NamingAuthority/issues/169
- Relates to https://github.com/common-workflow-language/common-workflow-language/issues/421#issuecomment-1122010820