### PR TITLE
process update endpoints and schema (relates to #107)

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -47,7 +47,8 @@ jobs:
       #     https://github.com/eshork/gitleaks-action/pull/4
       #     https://github.com/eshork/gitleaks-action/issues/3
       #- uses: fmigneault/gitleaks-action@master
-      - uses: zricethezav/gitleaks-action@master
+      #- uses: zricethezav/gitleaks-action@master
+      - uses: gitleaks/gitleaks-action@v1.6.0  # see: https://github.com/gitleaks/gitleaks-action/issues/57
       #- uses: eshork/gitleaks-action@v1.0.0
       #- uses: CySeq/gitcret@v2
       #  env:

--- a/.pylintrc
+++ b/.pylintrc
@@ -510,7 +510,7 @@ int-import-graph=
 
 # Force import order to recognize a module as part of the standard
 # compatibility libraries.
-known-standard-library=posixpath
+known-standard-library=posixpath,typing,typing_extensions
 
 # Force import order to recognize a module as part of a third party library.
 known-third-party=enchant,cornice_swagger,cwltool,cwt,docker

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,11 +12,20 @@ Changes
 
 Changes:
 --------
-- No change.
+- Add support of `Process` revisions (resolves `#107 <https://github.com/crim-ca/weaver/issues/107>`_).
+- Add``PATCH /processes/{processID}`` request, allowing `MINOR` and `PATCH` level modifications that can be applied
+  to an existing `Process` in order to revise non-execution critical information such as its documented description.
+- Add ``PUT /processes/{processID}`` request, allowing `MAJOR` revision to essentially redeploy a new `Process`,
+  but leaving some form of relationship with the older version by reusing the same `Process` ID.
+- Add support of ``{processID}:{version}`` representation in request path and `Job` ``processID`` to reference the
+  specific `Process` revisions when fetch `Process` description and `Job` status.
+- Add search query ``version`` and ``revisions`` to fetch a specific `Process` revision, or all versions history.
+- Add more entries in ``links`` referring to `Process` revisions whenever applicable.
 
 Fixes:
 ------
-- No change.
+- Fix invalid ``minimum`` and ``maximum`` OpenAPI fields that were defined as ``minLength`` and ``maxLength``
+  (duplicates definitions) for `Process` description and deployment schema validation.
 
 .. _changes_4.19.0:
 
@@ -50,8 +59,6 @@ Changes:
 
 Fixes:
 ------
-- Fix invalid ``minimum`` and ``maximum`` OpenAPI fields that were defined as ``minLength`` and ``maxLength``
-  (duplicates definitions) for `Process` description and deployment schema validation.
 - Fix `Process` deployment using a `WPS-1/2` URL reference defining a ``GetCapabilities`` request to resolve
   the corresponding ``DescribeProcess`` request if the `Process` ID can be inferred from other known locations
   (relates to `#11 <https://github.com/crim-ca/weaver/issues/11>`_).

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,6 +37,8 @@ Changes:
 
 Fixes:
 ------
+- Fix invalid ``minimum`` and ``maximum`` OpenAPI fields that were defined as ``minLength`` and ``maxLength``
+  (duplicates definitions) for `Process` description and deployment schema validation.
 - Fix `Process` deployment using a `WPS-1/2` URL reference defining a ``GetCapabilities`` request to resolve
   the corresponding ``DescribeProcess`` request if the `Process` ID can be inferred from other known locations
   (relates to `#11 <https://github.com/crim-ca/weaver/issues/11>`_).

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,13 +13,19 @@ Changes
 Changes:
 --------
 - Add support of `Process` revisions (resolves `#107 <https://github.com/crim-ca/weaver/issues/107>`_).
-- Add``PATCH /processes/{processID}`` request, allowing `MINOR` and `PATCH` level modifications that can be applied
-  to an existing `Process` in order to revise non-execution critical information such as its documented description.
-- Add ``PUT /processes/{processID}`` request, allowing `MAJOR` revision to essentially redeploy a new `Process`,
-  but leaving some form of relationship with the older version by reusing the same `Process` ID.
-- Add support of ``{processID}:{version}`` representation in request path and `Job` ``processID`` to reference the
-  specific `Process` revisions when fetch `Process` description and `Job` status.
-- Add search query ``version`` and ``revisions`` to fetch a specific `Process` revision, or all versions history.
+- Add ``PATCH /processes/{processID}`` request, allowing ``MINOR`` and ``PATCH`` level modifications that can be
+  applied to an existing `Process` in order to revise non-execution critical information. Level ``PATCH`` is used to
+  identify changes with no impact on execution whatsoever, only affecting metadata such as its documented description.
+  Level ``MINOR`` is used to update components that affect only execution *methodology* (e.g.: sync/async) or `Process`
+  retrieval, but that do not directly impact *what* is executed (i.e.: the `Application Package` does not change).
+- Add ``PUT /processes/{processID}`` request, allowing ``MAJOR`` revision to essentially redeploy a new `Process`,
+  but leaving some form of relationship with older versions by reusing the same `Process` ID. This ``MAJOR`` update
+  level implies a relatively critical change to execute the `Process`, such as the addition, removal or modification
+  of an input or output, directly impacting the `Application Package` definition and parameters the `Process` offers.
+- Add support of ``{processID}:{version}`` representation in request path and ``processID`` of the `Job` definition
+  to reference the specific `Process` revisions when fetching a `Process` description or a `Job` status.
+- Add search query ``version`` and ``revisions`` parameters to allow description of a specific `Process` revision, or
+  listing all its versions history.
 - Add more entries in ``links`` referring to `Process` revisions whenever applicable.
 
 Fixes:

--- a/README.rst
+++ b/README.rst
@@ -302,7 +302,7 @@ It is part of `PAVICS`_ and `Birdhouse`_ ecosystems and is available within the 
 .. _ogc-eo-apps-pilot-er: http://docs.opengeospatial.org/per/20-045.html
 .. |ogc-best-practices-eo-apppkg| replace:: OGC Best Practice for Earth Observation Application Package
 .. _ogc-best-practices-eo-apppkg: https://docs.ogc.org/bp/20-089r1.html
-.. |ogc-api-proc-ext-part2| replace:: `OGC API - Processes - Part 2: Deploy, Replace, Undeploy`_ (DRU) extension
+.. |ogc-api-proc-part2| replace:: `OGC API - Processes - Part 2: Deploy, Replace, Undeploy`_ (DRU) extension
 .. _`OGC API - Processes - Part 2: Deploy, Replace, Undeploy`: https://github.com/opengeospatial/ogcapi-processes/tree/master/extensions/deploy_replace_undeploy
 .. |ogc-apppkg| replace:: `OGC Application Package`
 .. _ogc-apppkg: https://github.com/opengeospatial/ogcapi-processes/blob/master/extensions/deploy_replace_undeploy/standard/openapi/schemas/ogcapppkg.yaml

--- a/docs/examples/update-process-minor.http
+++ b/docs/examples/update-process-minor.http
@@ -1,0 +1,8 @@
+PATCH /processes/test-process HTTP/1.1
+Host: weaver.example.com
+Content-Type: application/json
+
+{
+  "jobControlOptions": ["async-execute"],
+  "version": "1.4.0"
+}

--- a/docs/examples/update-process-patch.http
+++ b/docs/examples/update-process-patch.http
@@ -1,0 +1,17 @@
+PATCH /processes/test-process:1.2.3 HTTP/1.1
+Host: weaver.example.com
+Content-Type: application/json
+
+{
+  "description": "new description",
+  "inputs": {
+    "input": {
+      "description": "modified input description"
+    },
+    "outputs": {
+      "output": {
+        "title": "modified title"
+      }
+    }
+  }
+}

--- a/docs/source/processes.rst
+++ b/docs/source/processes.rst
@@ -431,7 +431,7 @@ the |getcap-req|_ request.
 Update, replace or remove an existing process (Update, Replace, Undeploy)
 -----------------------------------------------------------------------------
 
-Since `Weaver` supports |ogc-api-proc-ext-part2|_, it is able to remove a previously registered :term:`Process` using
+Since `Weaver` supports |ogc-api-proc-part2|_, it is able to remove a previously registered :term:`Process` using
 the :ref:`Deployment <proc_op_deploy>` request. The undeploy operation consist of a ``DELETE`` request targeting the
 specific ``{WEAVER_URL}/processes/{processID}`` to be removed.
 
@@ -447,7 +447,7 @@ location of the reference to modify.
 
 .. note::
     The :term:`Process` partial update operation (using ``PATCH``) is specific to `Weaver` only.
-    |ogc-api-proc-ext-part2|_ only mandates the definition of ``PUT`` request for full override of a :term:`Process`.
+    |ogc-api-proc-part2|_ only mandates the definition of ``PUT`` request for full override of a :term:`Process`.
 
 When a :term:`Process` is modified using the ``PATCH`` operation, only the new definitions need to be provided, and
 unspecified items are transferred over from the referenced :term:`Process` (i.e.: the previous revision). Using either

--- a/docs/source/references.rst
+++ b/docs/source/references.rst
@@ -121,31 +121,35 @@
 .. _deploy-req: https://pavics-weaver.readthedocs.io/en/latest/api.html#tag/Processes%2Fpaths%2F~1processes%2Fpost
 .. |getcap-req| replace:: ``GET {WEAVER_URL}/processes`` (GetCapabilities)
 .. _getcap-req: https://pavics-weaver.readthedocs.io/en/latest/api.html#tag/Processes%2Fpaths%2F~1processes%2Fget
-.. |describe-req| replace:: ``GET {WEAVER_URL}/processes/{id}`` (DescribeProcess)
+.. |describe-req| replace:: ``GET {WEAVER_URL}/processes/{processID}`` (DescribeProcess)
 .. _describe-req: https://pavics-weaver.readthedocs.io/en/latest/api.html#tag/Processes%2Fpaths%2F~1processes~1%7Bprocess_id%7D~1package%2Fget
+.. |update-req| replace:: ``PATCH {WEAVER_URL}/processes/{processID}`` (Update)
+.. _update-req: https://pavics-weaver.readthedocs.io/en/latest/api.html#tag/Processes/paths/~1processes~1{process_id}/patch
+.. |replace-req| replace:: ``PUT {WEAVER_URL}/processes/{processID}`` (Replace)
+.. _replace-req: https://pavics-weaver.readthedocs.io/en/latest/api.html#tag/Processes/paths/~1processes~1{process_id}/put
 .. |exec-req-name| replace:: Execute
 .. _exec-req-name: `exec-req`_
-.. |exec-req| replace:: ``POST {WEAVER_URL}/processes/{id}/execution`` (Execute)
+.. |exec-req| replace:: ``POST {WEAVER_URL}/processes/{processID}/execution`` (Execute)
 .. _exec-req: https://pavics-weaver.readthedocs.io/en/latest/api.html#tag/Processes/paths/~1processes~1{process_id}~1execution/post
-.. |exec-req-job| replace:: ``POST {WEAVER_URL}/processes/{id}/jobs`` (Execute)
+.. |exec-req-job| replace:: ``POST {WEAVER_URL}/processes/{processID}/jobs`` (Execute)
 .. _exec-req-job: https://pavics-weaver.readthedocs.io/en/latest/api.html#tag/Processes%2Fpaths%2F~1processes~1{process_id}~1jobs%2Fpost
-.. |vis-req| replace:: ``PUT {WEAVER_URL}/processes/{id}/visibility`` (Visibility)
+.. |vis-req| replace:: ``PUT {WEAVER_URL}/processes/{processID}/visibility`` (Visibility)
 .. _vis-req: https://pavics-weaver.readthedocs.io/en/latest/api.html#tag/Processes%2Fpaths%2F~1processes~1%7Bprocess_id%7D~1visibility%2Fput
-.. |pkg-req| replace:: ``GET {WEAVER_URL}/processes/{id}/package`` (Package)
+.. |pkg-req| replace:: ``GET {WEAVER_URL}/processes/{processID}/package`` (Package)
 .. _pkg-req: https://pavics-weaver.readthedocs.io/en/latest/api.html#tag/Processes%2Fpaths%2F~1processes~1%7Bprocess_id%7D~1package%2Fget
-.. |log-req| replace:: ``GET {WEAVER_URL}/processes/{id}/jobs/{id}/logs`` (GetLogs)
+.. |log-req| replace:: ``GET {WEAVER_URL}/processes/{processID}/jobs/{jobID}/logs`` (GetLogs)
 .. _log-req: https://pavics-weaver.readthedocs.io/en/latest/api.html#tag/Logs%2Fpaths%2F~1processes~1%7Bprocess_id%7D~1jobs~1%7Bjob_id%7D~1logs%2Fget
-.. |except-req| replace:: ``GET {WEAVER_URL}/processes/{id}/jobs/{id}/exceptions`` (GetLogs)
+.. |except-req| replace:: ``GET {WEAVER_URL}/processes/{processID}/jobs/{jobID}/exceptions`` (GetLogs)
 .. _except-req: https://pavics-weaver.readthedocs.io/en/latest/api.html#tag/Logs%2Fpaths%2F~1processes~1%7Bprocess_id%7D~1jobs~1%7Bjob_id%7D~1logs%2Fget
 .. |status-req-name| replace:: Status
 .. _status-req-name: `status-req`_
-.. |status-req| replace:: ``GET {WEAVER_URL}/processes/{id}/jobs/{id}`` (GetStatus)
+.. |status-req| replace:: ``GET {WEAVER_URL}/processes/{processID}/jobs/{jobID}`` (GetStatus)
 .. _status-req: https://pavics-weaver.readthedocs.io/en/latest/api.html#tag/Status%2Fpaths%2F~1processes~1{process_id}~1jobs~1{job_id}%2Fget
-.. |inputs-req| replace:: ``GET {WEAVER_URL}/jobs/{id}/inputs`` (Inputs)
+.. |inputs-req| replace:: ``GET {WEAVER_URL}/jobs/{jobID}/inputs`` (Inputs)
 .. _inputs-req: https://pavics-weaver.readthedocs.io/en/latest/api.html#tag/inputs/paths/~1jobs~1{job_id}~1inputs/get
-.. |outputs-req| replace:: ``GET {WEAVER_URL}/jobs/{id}/outputs`` (Outputs)
+.. |outputs-req| replace:: ``GET {WEAVER_URL}/jobs/{jobID}/outputs`` (Outputs)
 .. _outputs-req: https://pavics-weaver.readthedocs.io/en/latest/api.html#tag/outputs/paths/~1jobs~1{job_id}~1outputs/get
-.. |results-req| replace:: ``GET {WEAVER_URL}/jobs/{id}/results`` (Results)
+.. |results-req| replace:: ``GET {WEAVER_URL}/jobs/{jobID}/results`` (Results)
 .. _results-req: https://pavics-weaver.readthedocs.io/en/latest/api.html#tag/Results/paths/~1jobs~1{job_id}~1results/get
 .. |update-token-req| replace:: Update Token
 .. _update-token-req: https://pavics-weaver.readthedocs.io/en/latest/api.html#tag/UpdateToken/paths/~1processes~1{process_id}/put

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -25,8 +25,7 @@ pylint_quotes
 responses
 safety
 stopit
-# typing extension required for TypedDict
-typing_extensions; python_version < "3.8"
+typing_extensions
 WebTest
 wsgiproxy
 WSGIProxy2

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,23 +5,23 @@ tag = True
 tag_name = {new_version}
 
 [bumpversion:file:CHANGES.rst]
-search = 
+search =
 	`Unreleased <https://github.com/crim-ca/weaver/tree/master>`_ (latest)
 	========================================================================
-replace = 
+replace =
 	`Unreleased <https://github.com/crim-ca/weaver/tree/master>`_ (latest)
 	========================================================================
-	
+
 	Changes:
 	--------
 	- No change.
-	
+
 	Fixes:
 	------
 	- No change.
-	
+
 	.. _changes_{new_version}:
-	
+
 	`{new_version} <https://github.com/crim-ca/weaver/tree/{new_version}>`_ ({now:%%Y-%%m-%%d})
 	========================================================================
 
@@ -42,14 +42,14 @@ search = LABEL version="{current_version}"
 replace = LABEL version="{new_version}"
 
 [tool:pytest]
-addopts = 
+addopts =
 	--strict-markers
 	--tb=native
 	weaver/
 log_cli = false
 log_level = DEBUG
 python_files = test_*.py
-markers = 
+markers =
 	cli: mark test as related to CLI operations
 	testbed14: mark test as 'testbed14' validation
 	functional: mark test as functionality validation
@@ -67,7 +67,7 @@ lines_between_types = 0
 combine_as_imports = true
 default_section = FIRSTPARTY
 sections = FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
-known_standard_library = posixpath
+known_standard_library = posixpath,typing,typing_extensions
 known_first_party = weaver
 known_third_party = cornice_swagger,cwltool,cwt,docker
 skip = *.egg*,build,env,src,venv
@@ -80,7 +80,7 @@ targets = .
 [flake8]
 ignore = E126,E226,E402,F401,W503,W504
 max-line-length = 120
-exclude = 
+exclude =
 	src,
 	.git,
 	__pycache__,
@@ -105,14 +105,14 @@ add_select = D201,D213
 branch = true
 source = ./
 include = weaver/*
-omit = 
+omit =
 	setup.py
 	docs/*
 	tests/*
 	*_mako
 
 [coverage:report]
-exclude_lines = 
+exclude_lines =
 	pragma: no cover
 	raise AssertionError
 	raise NotImplementedError

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -245,10 +245,12 @@ class TestWeaverClient(TestWeaverClientBase):
 
     def test_describe(self):
         result = mocked_sub_requests(self.app, self.client.describe, self.test_process["Echo"])
+        assert self.test_payload["Echo"]["version"] == "1.0", "Original version submitted should be partial."
+
         assert result.success
         # see deployment file for details that are expected here
         assert result.body["id"] == self.test_process["Echo"]
-        assert result.body["version"] == "1.0"
+        assert result.body["version"] == "1.0.0", "Resulting version missing MAJOR.MINOR.PATCH parts should be padded."
         assert result.body["keywords"] == ["test", "application"]  # app is added by Weaver since not CWL Workflow
         assert "message" in result.body["inputs"]
         assert result.body["inputs"]["message"]["title"] == "message"

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -245,12 +245,14 @@ class TestWeaverClient(TestWeaverClientBase):
 
     def test_describe(self):
         result = mocked_sub_requests(self.app, self.client.describe, self.test_process["Echo"])
-        assert self.test_payload["Echo"]["version"] == "1.0", "Original version submitted should be partial."
+        assert self.test_payload["Echo"]["processDescription"]["process"]["version"] == "1.0", (
+            "Original version submitted should be partial."
+        )
 
         assert result.success
         # see deployment file for details that are expected here
         assert result.body["id"] == self.test_process["Echo"]
-        assert result.body["version"] == "1.0.0", "Resulting version missing MAJOR.MINOR.PATCH parts should be padded."
+        assert result.body["version"] == "1.0"
         assert result.body["keywords"] == ["test", "application"]  # app is added by Weaver since not CWL Workflow
         assert "message" in result.body["inputs"]
         assert result.body["inputs"]["message"]["title"] == "message"
@@ -263,7 +265,9 @@ class TestWeaverClient(TestWeaverClientBase):
         assert result.body["outputs"]["output"]["description"] == "Output file with echo message."
         assert result.body["outputs"]["output"]["formats"] == [{"default": True, "mediaType": ContentType.TEXT_PLAIN}]
         assert "undefined" not in result.message, "CLI should not have confused process description as response detail."
-        assert "description" not in result.body, "CLI should not have overridden the process description field."
+        assert result.body["description"] == (
+            "Dummy process that simply echo's back the input message for testing purposes."
+        ), "CLI should not have overridden the process description field."
 
     def run_execute_inputs_schema_variant(self, inputs_param, process="Echo",
                                           preload=False, location=False, expect_success=True, mock_exec=True):

--- a/tests/functional/utils.py
+++ b/tests/functional/utils.py
@@ -32,8 +32,9 @@ from weaver.visibility import Visibility
 
 if TYPE_CHECKING:
     from typing import Any, Dict, Optional, Union
+    from typing_extensions import Literal
 
-    from weaver.typedefs import AnyRequestMethod, AnyResponseType, JSON, Literal, SettingsType
+    from weaver.typedefs import AnyRequestMethod, AnyResponseType, JSON, SettingsType
 
     ReferenceType = Literal["deploy", "describe", "execute", "package"]
 

--- a/tests/test_datatype.py
+++ b/tests/test_datatype.py
@@ -169,3 +169,15 @@ def test_process_io_schema_ignore_uri():
     # if 'default format' "schema" exists, it must not cause an error when parsing the object
     wps_proc = proc_obj.wps()
     assert any(isinstance(out.json.get("schema"), str) for out in wps_proc.outputs)
+
+
+@pytest.mark.parametrize("process_id,result", [
+    ("urn:test:1.2.3", ("urn:test", "1.2.3")),
+    ("urn:uuid:process:test", ("urn:uuid:process:test", None)),
+    ("urn:test:random-test:1.3.4", ("urn:test:random-test", "1.3.4")),
+    ("random-test:1", ("random-test", "1")),
+    ("random-test:1.3.4", ("random-test", "1.3.4")),
+    ("random-test:not.a.version", ("random-test:not.a.version", None)),
+])
+def test_process_split_version(process_id, result):
+    assert Process.split_version(process_id) == result

--- a/tests/test_opensearch.py
+++ b/tests/test_opensearch.py
@@ -177,6 +177,7 @@ def test_deploy_opensearch():
         stack.enter_context(mock.patch("weaver.wps_restapi.processes.processes.get_db", side_effect=MockDB))
         stack.enter_context(mock.patch("weaver.wps_restapi.processes.utils.get_db", side_effect=MockDB))
         stack.enter_context(mock.patch("weaver.wps_restapi.processes.utils.get_settings", side_effect=_get_mocked))
+        stack.enter_context(mock.patch("weaver.datatype.get_settings", side_effect=_get_mocked))
         stack.enter_context(mock.patch("weaver.processes.utils.get_db", side_effect=MockDB))
         stack.enter_context(mock.patch("weaver.processes.utils.get_settings", side_effect=_get_mocked))
         # given

--- a/tests/test_opensearch.py
+++ b/tests/test_opensearch.py
@@ -177,6 +177,8 @@ def test_deploy_opensearch():
         stack.enter_context(mock.patch("weaver.wps_restapi.processes.processes.get_db", side_effect=MockDB))
         stack.enter_context(mock.patch("weaver.wps_restapi.processes.utils.get_db", side_effect=MockDB))
         stack.enter_context(mock.patch("weaver.wps_restapi.processes.utils.get_settings", side_effect=_get_mocked))
+        stack.enter_context(mock.patch("weaver.database.get_settings", side_effect=_get_mocked))
+        stack.enter_context(mock.patch("weaver.database.mongodb.get_settings", side_effect=_get_mocked))
         stack.enter_context(mock.patch("weaver.datatype.get_settings", side_effect=_get_mocked))
         stack.enter_context(mock.patch("weaver.processes.utils.get_db", side_effect=MockDB))
         stack.enter_context(mock.patch("weaver.processes.utils.get_settings", side_effect=_get_mocked))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -108,7 +108,7 @@ def test_is_update_version():
         "1.2.4",
         "1.3.1",
     ]
-    random.shuffle(versions)
+    random.shuffle(versions)  # function must not depend on input order
 
     assert not is_update_version("0.1.0", versions, VersionLevel.PATCH)
     assert not is_update_version("1.0.1", versions, VersionLevel.PATCH)
@@ -116,11 +116,14 @@ def test_is_update_version():
     assert not is_update_version("1.2.3", versions, VersionLevel.PATCH)
     assert not is_update_version("1.3.0", versions, VersionLevel.PATCH)
     assert not is_update_version("1.3.1", versions, VersionLevel.PATCH)
+    assert not is_update_version("1.4.5", versions, VersionLevel.PATCH)  # no 1.4.x to update from
 
     assert not is_update_version("0.1.0", versions, VersionLevel.MINOR)
     assert not is_update_version("0.1.4", versions, VersionLevel.MINOR)
     assert not is_update_version("1.2.5", versions, VersionLevel.MINOR)
     assert not is_update_version("1.3.2", versions, VersionLevel.MINOR)
+    assert not is_update_version("2.0.0", versions, VersionLevel.MINOR)  # no 2.x to update from
+    assert not is_update_version("2.1.3", versions, VersionLevel.MINOR)
 
     assert not is_update_version("0.1.0", versions, VersionLevel.MAJOR)
     assert not is_update_version("0.1.4", versions, VersionLevel.MAJOR)
@@ -139,8 +142,6 @@ def test_is_update_version():
     assert is_update_version("0.3.0", versions, VersionLevel.MINOR)
     assert is_update_version("1.4.0", versions, VersionLevel.MINOR)
     assert is_update_version("1.5.0", versions, VersionLevel.MINOR)
-    assert is_update_version("2.0.0", versions, VersionLevel.MINOR)
-    assert is_update_version("2.1.3", versions, VersionLevel.MINOR)
 
     assert is_update_version("2.0.0", versions, VersionLevel.MAJOR)
     assert is_update_version("2.1.3", versions, VersionLevel.MAJOR)

--- a/tests/wps_restapi/test_jobs.py
+++ b/tests/wps_restapi/test_jobs.py
@@ -909,7 +909,7 @@ class WpsRestApiJobsTest(unittest.TestCase):
         """
         uri = sd.openapi_json_service.path
         resp = self.app.get(uri, headers=self.json_headers)
-        schema_prefix = sd.GetJobsQueries.__name__
+        schema_prefix = sd.GetProcessJobsQuery.__name__
         assert not resp.json["parameters"][f"{schema_prefix}.page"]["required"]
         assert not resp.json["parameters"][f"{schema_prefix}.limit"]["required"]
 

--- a/tests/wps_restapi/test_processes.py
+++ b/tests/wps_restapi/test_processes.py
@@ -368,9 +368,9 @@ class WpsRestApiProcessesTest(unittest.TestCase):
         assert resp.status_code == 200
         body = resp.json
         assert "processes" in body and len(body["processes"]) > 0
-        info = [(proc["id"], proc["version"]) for proc in body["processes"]]
-        expect = [(p_id, ver) for ver in versions]
-        assert info == expect
+        result = [(proc["id"], proc["version"]) for proc in body["processes"]]
+        expect = list(zip(revisions, versions))
+        assert result == expect
 
     @mocked_remote_server_requests_wps1([
         resources.TEST_REMOTE_SERVER_URL,

--- a/tests/wps_restapi/test_processes.py
+++ b/tests/wps_restapi/test_processes.py
@@ -1459,7 +1459,7 @@ class WpsRestApiProcessesTest(unittest.TestCase):
         """
         p_id = "test-update-job-refs"
         self.deploy_process_CWL_direct(ContentType.APP_JSON, process_id=p_id)
-        job = self.job_store.save_job(task_id=uuid.uuid4(), process=p_id)
+        job = self.job_store.save_job(task_id=uuid.uuid4(), process=p_id, access=Visibility.PUBLIC)
 
         # verify that job initially refers to "latest" process
         path = f"/jobs/{job.id}"
@@ -1469,7 +1469,7 @@ class WpsRestApiProcessesTest(unittest.TestCase):
         path = get_path_kvp(f"/processes/{p_id}/jobs", detail=False)
         resp = self.app.get(path, headers=self.json_headers)
         body = resp.json
-        assert len(body["jobs"]) > 1 and str(job.id) in body["jobs"]
+        assert len(body["jobs"]) == 1 and str(job.id) in body["jobs"]
 
         # update process
         data = {
@@ -1478,8 +1478,8 @@ class WpsRestApiProcessesTest(unittest.TestCase):
         }
         resp = self.app.patch_json(f"/processes/{p_id}", params=data, headers=self.json_headers)
         assert resp.status_code == 200
-        p_rev = resp.json["version"]
-        assert p_rev is not None
+        body = resp.json
+        assert "version" in body["processSummary"] and body["processSummary"]["version"] not in [None, "0.0.0"]
 
         # verify job was updated with new reference
         path = f"/jobs/{job.id}"

--- a/tests/wps_restapi/test_processes.py
+++ b/tests/wps_restapi/test_processes.py
@@ -1570,7 +1570,7 @@ class WpsRestApiProcessesTest(unittest.TestCase):
                 "version": "4.3.2",  # explicitly provided to avoid auto-bump to '3.0.0'
                 # use OAS representation in this case to validate it is still valid using update request
                 "inputs": {"number": {"schema": {"type": "integer", "minimum": 1, "maximum": 3}}},
-                "visible": Visibility.PUBLIC,  # ensure we can retrieve the description later
+                "visibility": Visibility.PUBLIC,  # ensure we can retrieve the description later
             },
             "executionUnit": [{"unit": cwl_v3}],
         }

--- a/tests/wps_restapi/test_processes.py
+++ b/tests/wps_restapi/test_processes.py
@@ -1,6 +1,4 @@
 # pylint: disable=R1729  # ignore non-generator representation employed for displaying test log results
-import uuid
-
 import base64
 import contextlib
 import copy
@@ -8,6 +6,7 @@ import json
 import os
 import tempfile
 import unittest
+import uuid
 from copy import deepcopy
 from typing import TYPE_CHECKING
 

--- a/tests/wps_restapi/test_processes.py
+++ b/tests/wps_restapi/test_processes.py
@@ -270,7 +270,7 @@ class WpsRestApiProcessesTest(unittest.TestCase):
         assert resp.status_code == 400
         assert "ListingInvalidParameter" in resp.json["error"]
 
-    def test_get_processes_with_revisions(self):
+    def test_get_processes_with_tagged_revisions(self):
         """Example:
         http://localhost:4002/processes?detail=false&revisions=true
 
@@ -311,6 +311,8 @@ class WpsRestApiProcessesTest(unittest.TestCase):
             "WorkflowWaterExtent-mock:0.0.1",
             "WPS1JsonArray2NetCDF:0.0.1"
           ],
+
+        .. versionadded:: 4.20
         """
         # FIXME:
         # create some processes with different combinations of revisions, no-version, single-version
@@ -318,6 +320,14 @@ class WpsRestApiProcessesTest(unittest.TestCase):
         resp = self.app.get(path, headers=self.json_headers, expect_errors=True)
 
         raise NotImplementedError
+
+    def test_get_processes_with_history_revisions(self):
+        """
+        When requesting specific process ID with revisions, version history of this process is listed.
+
+        .. versionadded:: 4.20
+        """
+        raise NotImplementedError  # FIXME
 
     @mocked_remote_server_requests_wps1([
         resources.TEST_REMOTE_SERVER_URL,
@@ -1156,6 +1166,11 @@ class WpsRestApiProcessesTest(unittest.TestCase):
         assert resp.json["cause"] == "No parameters provided for update."
 
     def test_update_process_latest_valid(self):
+        """
+        Update the current process revision with new metadata (making it an older revision and new one becomes latest).
+
+        .. versionadded:: 4.20
+        """
         p_id = "test-update-cwl-json"
         self.deploy_process_CWL_direct(ContentType.APP_JSON, process_id=p_id)
         data = {
@@ -1173,6 +1188,11 @@ class WpsRestApiProcessesTest(unittest.TestCase):
         assert resp.json["description"] == data["description"]
 
     def test_update_process_older_valid(self):
+        """
+        Update an older process (already a previous revision) with new metadata.
+
+        .. versionadded:: 4.20
+        """
         p_id = "test-update-cwl-json"
         version = "1.2.3"
         self.deploy_process_CWL_direct(ContentType.APP_JSON, process_id=p_id, version=version)
@@ -1209,10 +1229,23 @@ class WpsRestApiProcessesTest(unittest.TestCase):
             assert resp.json["title"] == data["title"]
             assert "description" not in resp.json, (
                 "Not modified since no new value, value from reference process must be used. "
-                "Must not make use of the intermediate '1.2.4' version, as '1.2.3' was explicitly requested as reference."
+                "Must not make use of the intermediate '1.2.4' version, since '1.2.3' explicitly requested for update."
             )
 
+    def test_update_process_jobs_adjusted(self):
+        """
+        Validate that given a valid process update, associated jobs update their references to preserve links.
+
+        .. versionadded:: 4.20
+        """
+        raise NotImplementedError
+
     def test_replace_process_latest_valid(self):
+        """
+        Redeploy a process by replacing its definition (MAJOR revision update).
+
+        .. versionadded:: 4.20
+        """
         p_id = "test-update-cwl-json"
         self.deploy_process_CWL_direct(ContentType.APP_JSON, process_id=p_id)
         data = {

--- a/tests/wps_restapi/test_processes.py
+++ b/tests/wps_restapi/test_processes.py
@@ -271,7 +271,53 @@ class WpsRestApiProcessesTest(unittest.TestCase):
         assert "ListingInvalidParameter" in resp.json["error"]
 
     def test_get_processes_with_revisions(self):
-        raise NotImplementedError  # FIXME
+        """Example:
+        http://localhost:4002/processes?detail=false&revisions=true
+
+          "processes": [
+            "anti-spoofing:0.1.0",
+            "CatFile:1.0.0",
+            "ColibriFlyingpigeon_SubsetBbox",
+            "demo-cat-file:1.0.0",
+            "docker-demo-cat",
+            "docker-python-script",
+            "DockerNetCDF2Text",
+            "Echo:1.0.0",
+            "file_index_selector:1.1.0",
+            "file2string_array:1.2.0",
+            "image-utils:0.0.1",
+            "jsonarray2netcdf:1.3.0",
+            "las2tif",
+            "memory-usage",
+            "memory-usage-2",
+            "memory-usage-3",
+            "memory-usage-4",
+            "memory-usage-5",
+            "memory-usage-6",
+            "memory-usage-script",
+            "metalink2netcdf:1.2.0",
+            "OutardeFlyingpigeon_SubsetBbox",
+            "python-script",
+            "sleep",
+            "Staging_S2L1C:0.0.1",
+            "Staging_S2L1C-mock-docker:0.0.1",
+            "test_blurring:0.0.1",
+            "test_generation:0.0.1",
+            "test_workflow:0.0.1",
+            "test-echo:1.0.0",
+            "test-report",
+            "WaterExtent_S2-mock-docker:0.0.1",
+            "WorkflowWaterExtent:0.0.1",
+            "WorkflowWaterExtent-mock:0.0.1",
+            "WPS1JsonArray2NetCDF:0.0.1"
+          ],
+        """
+        # FIXME:
+        # create some processes with different combinations of revisions, no-version, single-version
+        path = get_path_kvp("/processes", revisions=True, detail=False)
+        resp = self.app.get(path, headers=self.json_headers, expect_errors=True)
+
+        raise NotImplementedError
 
     @mocked_remote_server_requests_wps1([
         resources.TEST_REMOTE_SERVER_URL,

--- a/tests/wps_restapi/test_swagger_definitions.py
+++ b/tests/wps_restapi/test_swagger_definitions.py
@@ -6,9 +6,9 @@ import pytest
 from weaver.wps_restapi import swagger_definitions as sd
 
 
-def test_process_id_with_version_invalid():
+def test_process_id_with_version_tag_deploy_invalid():
     """
-    Validate process ID with version label is not allowed.
+    Validate process ID with version label is not allowed as definition during deployment or update.
 
     To take advantage of auto-resolution of unique :meth:`StoreProcesses.fetch_by_id` with version references injected
     in the process ID stored in the database, deployment and description of processes must not allow it to avoid
@@ -26,4 +26,30 @@ def test_process_id_with_version_invalid():
             sd.ProcessIdentifier().deserialize(test_id)
     for test_id in test_id_version_invalid:
         test_id = test_id.split(":", 1)[0]
-        sd.ProcessIdentifier().deserialize(test_id)
+        assert sd.ProcessIdentifier().deserialize(test_id) == test_id
+
+
+def test_process_id_with_version_tag_get_valid():
+    """
+    Validate that process ID with tagged version is permitted for request path parameter to retrieve it.
+    """
+    test_id_version_valid = [
+        "test-ok",
+        "test-ok1",
+        "test-ok:1",
+        "test-ok:1.2.3",
+        "also_ok:1.3",
+    ]
+    test_id_version_invalid = [
+        "no-:1.2.3",
+        "not-ok1.2.3",
+        "no:",
+        "not-ok:",
+        "not-ok11:",
+        "not-ok1.2.3:",
+    ]
+    for test_id in test_id_version_invalid:
+        with pytest.raises(colander.Invalid):
+            sd.ProcessIdentifierTag().deserialize(test_id)
+    for test_id in test_id_version_valid:
+        assert sd.ProcessIdentifierTag().deserialize(test_id) == test_id

--- a/tests/wps_restapi/test_swagger_definitions.py
+++ b/tests/wps_restapi/test_swagger_definitions.py
@@ -1,0 +1,29 @@
+import uuid
+
+import colander
+import pytest
+
+from weaver.wps_restapi import swagger_definitions as sd
+
+
+def test_process_id_with_version_invalid():
+    """
+    Validate process ID with version label is not allowed.
+
+    To take advantage of auto-resolution of unique :meth:`StoreProcesses.fetch_by_id` with version references injected
+    in the process ID stored in the database, deployment and description of processes must not allow it to avoid
+    conflicts. The storage should take care of replacing the ID value transparently after it was resolved.
+    """
+    test_id_version_invalid = [
+        "process:1.2.3",
+        "test-process:4.5.6",
+        "other_process:1",
+        "invalid-process:1_2_3",
+        f"{uuid.uuid4()}:7.8.9",
+    ]
+    for test_id in test_id_version_invalid:
+        with pytest.raises(colander.Invalid):
+            sd.ProcessIdentifier().deserialize(test_id)
+    for test_id in test_id_version_invalid:
+        test_id = test_id.split(":", 1)[0]
+        sd.ProcessIdentifier().deserialize(test_id)

--- a/weaver/database/__init__.py
+++ b/weaver/database/__init__.py
@@ -1,6 +1,7 @@
 import logging
 from typing import TYPE_CHECKING
 
+from pyramid.request import Request
 from pyramid.settings import asbool
 
 from weaver.database.mongodb import MongoDatabase
@@ -28,6 +29,10 @@ def get_db(container=None, reset_connection=False):
         It is preferable to provide a registry reference to reuse any available connection whenever possible.
         Giving application settings will require establishing a new connection.
     """
+    if not reset_connection and isinstance(container, Request):
+        db = getattr(container, "db", None)
+        if isinstance(db, MongoDatabase):
+            return db
     registry = get_registry(container, nothrow=True)
     if not reset_connection and registry and isinstance(getattr(registry, "db", None), MongoDatabase):
         return registry.db

--- a/weaver/database/base.py
+++ b/weaver/database/base.py
@@ -4,10 +4,11 @@ from typing import TYPE_CHECKING, overload
 from weaver.store.base import StoreInterface
 
 if TYPE_CHECKING:
-    from typing import Any
+    from typing import Any, Type, Union
+    from typing_extensions import Literal
 
     from weaver.store.base import StoreBills, StoreJobs, StoreProcesses, StoreQuotes, StoreServices, StoreVault
-    from weaver.typedefs import AnySettingsContainer, JSON, Literal, Type, Union
+    from weaver.typedefs import AnySettingsContainer, JSON
 
     AnyStore = Union[
         StoreBills,

--- a/weaver/database/base.py
+++ b/weaver/database/base.py
@@ -65,6 +65,36 @@ class DatabaseInterface(metaclass=abc.ABCMeta):
         raise TypeError(f"Unsupported store type selector: [{store_type}] ({type(store_type)})")
 
     @overload
+    def get_store(self, store_type):
+        # type: (StoreBillsSelector) -> StoreBills
+        ...
+
+    @overload
+    def get_store(self, store_type):
+        # type: (StoreQuotesSelector) -> StoreQuotes
+        ...
+
+    @overload
+    def get_store(self, store_type):
+        # type: (StoreJobsSelector) -> StoreJobs
+        ...
+
+    @overload
+    def get_store(self, store_type):
+        # type: (StoreProcessesSelector) -> StoreProcesses
+        ...
+
+    @overload
+    def get_store(self, store_type):
+        # type: (StoreServicesSelector) -> StoreServices
+        ...
+
+    @overload
+    def get_store(self, store_type):
+        # type: (StoreVaultSelector) -> StoreVault
+        ...
+
+    @overload
     def get_store(self, store_type, *store_args, **store_kwargs):
         # type: (StoreBillsSelector, *Any, **Any) -> StoreBills
         ...

--- a/weaver/datatype.py
+++ b/weaver/datatype.py
@@ -1824,7 +1824,7 @@ class Process(Base):
         Checks if this :term:`Process` corresponds to the latest revision.
         """
         # if ID loaded from DB contains a version, it is not the latest by design
-        return ":" not in self.id
+        return self.split_version(self.id)[-1] is None
 
     @property
     def name(self):

--- a/weaver/datatype.py
+++ b/weaver/datatype.py
@@ -1929,6 +1929,13 @@ class Process(Base):
                     _input["schema"] = self._decode(input_schema)
         return inputs
 
+    @inputs.setter
+    def inputs(self, inputs):
+        # type: (List[Dict[str, JSON]]) -> None
+        if not isinstance(inputs, list):
+            raise TypeError("Inputs container expected as list to normalize process definitions.")
+        self["inputs"] = inputs
+
     @property
     def outputs(self):
         # type: () -> Optional[List[Dict[str, JSON]]]
@@ -1957,6 +1964,13 @@ class Process(Base):
             if isinstance(output_schema, dict):
                 _output["schema"] = self._decode(output_schema)
         return outputs
+
+    @outputs.setter
+    def outputs(self, outputs):
+        # type: (List[Dict[str, JSON]]) -> None
+        if not isinstance(outputs, list):
+            raise TypeError("Outputs container expected as list to normalize process definitions.")
+        self["outputs"] = outputs
 
     @property
     def jobControlOptions(self):  # noqa: N802

--- a/weaver/datatype.py
+++ b/weaver/datatype.py
@@ -12,6 +12,7 @@ import traceback
 import uuid
 import warnings
 from datetime import datetime, timedelta
+from distutils.version import LooseVersion
 from io import BytesIO
 from logging import ERROR, INFO, Logger, getLevelName, getLogger
 from secrets import compare_digest, token_hex
@@ -1785,6 +1786,15 @@ class Process(Base):
         self["id"] = value
 
     @property
+    def tag(self):
+        # type: () -> str
+        """
+        Full identifier including the version for an unique reference.
+        """
+        version = self.version or "latest"
+        return f"{self.id}:{version}"
+
+    @property
     def title(self):
         # type: () -> str
         return self.get("title", self.id)
@@ -1816,8 +1826,9 @@ class Process(Base):
 
     @property
     def version(self):
-        # type: () -> Optional[str]
-        return self.get("version")
+        # type: () -> Optional[LooseVersion]
+        version = self.get("version")
+        return LooseVersion(version) if version else None
 
     @property
     def inputs(self):
@@ -2102,7 +2113,7 @@ class Process(Base):
             "abstract": self.abstract,
             "keywords": self.keywords,
             "metadata": self.metadata,
-            "version": self.version,
+            "version": str(self.version),
             # escape potential OpenAPI JSON $ref in 'schema' also used by Mongo BSON
             "inputs": [self._encode(_input) for _input in self.inputs or []],
             "outputs": [self._encode(_output) for _output in self.outputs or []],
@@ -2131,7 +2142,7 @@ class Process(Base):
             "abstract": self.abstract,
             "keywords": self.keywords,
             "metadata": self.metadata,
-            "version": self.version,
+            "version": str(self.version),
             "inputs": self.inputs,
             "outputs": self.outputs,
             "package": self.package,

--- a/weaver/datatype.py
+++ b/weaver/datatype.py
@@ -1798,7 +1798,7 @@ class Process(Base):
         proc_id = self.id.split(":")[0]
         # bw-compat, if no version available, no update was applied (single deploy)
         # there is no need to define a tag as only one result can be found
-        # on next (if any) update request, this reversion will be updated with a default version
+        # on next (if any) update request, this revision will be updated with a default version
         if self.version is None:
             return proc_id
         version = as_version_major_minor_patch(self.version, VersionFormat.STRING)
@@ -2235,8 +2235,8 @@ class Process(Base):
             proc_hist = f"{proc_list}?detail=false&revisions=true&process={self.id}"
             links.extend([
                 {"href": proc_tag, "rel": "working-copy", "title": "Tagged version of this process description."},
-                {"href": proc_desc, "rel": "latest-version", "title": "Most recent reversion of this process."},
-                {"href": proc_hist, "rel": "version-history", "title": "Listing of all reversions of this process."},
+                {"href": proc_desc, "rel": "latest-version", "title": "Most recent revision of this process."},
+                {"href": proc_hist, "rel": "version-history", "title": "Listing of all revisions of this process."},
             ])
             versions = get_db(container).get_store(StoreProcesses).find_versions(self.id, VersionFormat.OBJECT)
             proc_ver = as_version_major_minor_patch(self.version, VersionFormat.OBJECT)
@@ -2245,12 +2245,12 @@ class Process(Base):
             if prev_ver:
                 proc_prev = f"{proc_desc}:{prev_ver[-1]!s}"
                 links.append(
-                    {"href": proc_prev, "rel": "predecessor-version", "title": "Previous reversion of this process."}
+                    {"href": proc_prev, "rel": "predecessor-version", "title": "Previous revision of this process."}
                 )
             if next_ver:
                 proc_next = f"{proc_desc}:{next_ver[0]!s}"
                 links.append(
-                    {"href": proc_next, "rel": "successor-version", "title": "Next reversion of this process."}
+                    {"href": proc_next, "rel": "successor-version", "title": "Next revision of this process."}
                 )
         if self.service:
             api_base_url = proc_list.rsplit("/", 1)[0]

--- a/weaver/processes/convert.py
+++ b/weaver/processes/convert.py
@@ -2609,9 +2609,9 @@ def normalize_ordered_io(io_section, order_hints=None):
 
     First, converts I/O definitions defined as dictionary to an equivalent :class:`list` representation,
     in order to work only with a single representation method. The :class:`list` is chosen over :class:`dict` because
-    sequences can enforce a specific order, while mapping have no particular order. The list representation ensures
-    that I/O order is preserved when written to file and reloaded afterwards regardless of each server and/or library's
-    implementation of the mapping container.
+    sequences can enforce a specific order, while mapping (when saved as :term:`JSON` or :term:`YAML`) have no specific
+    order. The list representation ensures that I/O order is preserved when written to file and reloaded afterwards
+    regardless of server and/or library's implementation of the mapping container.
 
     If this function fails to correctly order any I/O or cannot correctly guarantee such result because of the provided
     parameters (e.g.: no hints given when required), the result will not break nor change the final processing behaviour

--- a/weaver/processes/execution.py
+++ b/weaver/processes/execution.py
@@ -559,7 +559,7 @@ def submit_job(request, reference, tags=None):
     lang = request.accept_language.header_value  # can only preemptively check if local process
     if isinstance(reference, Process):
         service_url = reference.processEndpointWPS1
-        process_id = reference.tag  # use explicit 'id:version' process revision if available, otherwise simply 'id'
+        process_id = reference.identifier  # explicit 'id:version' process revision if available, otherwise simply 'id'
         visibility = reference.visibility
         is_workflow = reference.type == ProcessType.WORKFLOW
         is_local = True

--- a/weaver/processes/execution.py
+++ b/weaver/processes/execution.py
@@ -559,7 +559,7 @@ def submit_job(request, reference, tags=None):
     lang = request.accept_language.header_value  # can only preemptively check if local process
     if isinstance(reference, Process):
         service_url = reference.processEndpointWPS1
-        process_id = reference.id
+        process_id = reference.tag  # use explicit 'id:version' process revision if available, otherwise simply 'id'
         visibility = reference.visibility
         is_workflow = reference.type == ProcessType.WORKFLOW
         is_local = True

--- a/weaver/processes/utils.py
+++ b/weaver/processes/utils.py
@@ -63,8 +63,8 @@ from weaver.utils import (
 from weaver.visibility import Visibility
 from weaver.wps.utils import get_wps_client
 from weaver.wps_restapi import swagger_definitions as sd
-from weaver.wps_restapi.utils import get_wps_restapi_base_url, parse_content
 from weaver.wps_restapi.processes.utils import resolve_process_tag
+from weaver.wps_restapi.utils import get_wps_restapi_base_url, parse_content
 
 LOGGER = logging.getLogger(__name__)
 if TYPE_CHECKING:

--- a/weaver/processes/utils.py
+++ b/weaver/processes/utils.py
@@ -470,12 +470,15 @@ def _update_deploy_process_version(process, process_overwrite, update_level, con
     Handle all necessary update operations of a :term:`Process` definition.
 
     Validate that any specified version for :term:`Process` deployment is valid against any other existing versions.
-    If the replacement targets another existing process explicitly (update request), perform any necessary database
-    adjustments to replace the old process references for the creation of the updated process to ensure all versions
-    and links remain valid against their original references.
+    Perform any necessary database adjustments to replace the old :term:`Process` references for the creation of the
+    updated :term:`Process` to ensure all versions and links remain valid against their original references.
 
     :param process: Desired new process definition.
     :param process_overwrite: Old process from which update of the definition in database could be required.
+    :param update_level:
+        Minimum semantic version level required for this update operation.
+        If the new :term:`Process` definition did not provide a version explicitly, this level will be used to
+        automatically infer the following revision number based on the old :term:`Process` reference.
     :param container: Any container to retrieve a database connection.
     :returns: Process summary with definition retrieved from storage (saved) after all operations were applied.
     :raises HTTPException: Relevant error is raised in the even of any erroneous process definition (old and new).

--- a/weaver/processes/utils.py
+++ b/weaver/processes/utils.py
@@ -594,7 +594,7 @@ def _bump_process_version(version, update_level):
     return new_version
 
 
-def _apply_process_metadata(process, update_data):
+def _apply_process_metadata(process, update_data):  # pylint: disable=R1260,too-complex  # FIXME
     # type: (Process, JSON) -> VersionLevel
     """
     Apply requested changes for update of the :term:`Process`.

--- a/weaver/processes/wps_testing.py
+++ b/weaver/processes/wps_testing.py
@@ -21,7 +21,7 @@ class WpsTestProcess(Process):
 
         # remove duplicates/unsupported keywords
         title = kw.pop("title", kw.get("identifier"))
-        version = kw.pop("version", "0.0")
+        version = kw.pop("version", "0.0.0")
         kw.pop("inputs", None)
         kw.pop("outputs", None)
         kw.pop("payload", None)

--- a/weaver/sort.py
+++ b/weaver/sort.py
@@ -12,6 +12,7 @@ class Sort(Constants):
     PRICE = "price"
     ID = "id"
     ID_LONG = "identifier"  # long form employed by Processes in DB representation
+    VERSION = "version"
 
 
 class SortMethods(Constants):
@@ -20,6 +21,7 @@ class SortMethods(Constants):
         Sort.ID_LONG,  # will replace by short ID to conform with JSON representation
         Sort.PROCESS,  # since listing processes, can be an alias to ID
         Sort.CREATED,
+        Sort.VERSION,
     ])
     JOB = frozenset([
         Sort.CREATED,

--- a/weaver/store/base.py
+++ b/weaver/store/base.py
@@ -1,6 +1,7 @@
 import abc
-from distutils.version import LooseVersion
 from typing import TYPE_CHECKING
+
+from weaver.utils import VersionFormat
 
 if TYPE_CHECKING:
     import datetime
@@ -92,6 +93,8 @@ class StoreProcesses(StoreInterface):
                        limit=None,          # type: Optional[int]
                        sort=None,           # type: Optional[str]
                        total=False,         # type: bool
+                       revisions=False,     # type: bool
+                       process=None,        # type: Optional[str]
                        ):                   # type: (...) -> Union[List[Process], Tuple[List[Process], int]]
         raise NotImplementedError
 
@@ -101,8 +104,8 @@ class StoreProcesses(StoreInterface):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def find_versions(self, process_id, version_format):
-        # type: (str, VersionFormat) -> List[LooseVersion]
+    def find_versions(self, process_id, version_format=VersionFormat.OBJECT):
+        # type: (str, VersionFormat) -> List[AnyVersion]
         raise NotImplementedError
 
     @abc.abstractmethod

--- a/weaver/store/base.py
+++ b/weaver/store/base.py
@@ -5,7 +5,7 @@ from weaver.utils import VersionFormat
 
 if TYPE_CHECKING:
     import datetime
-    from typing import Dict, List, Optional, Tuple, Union
+    from typing import Any, Dict, List, Optional, Tuple, Union
 
     from pyramid.request import Request
     from pywps import Process as ProcessWPS
@@ -151,6 +151,11 @@ class StoreJobs(StoreInterface):
                  accept_language=None,      # type: Optional[str]
                  created=None,              # type: Optional[datetime.datetime]
                  ):                         # type: (...) -> Job
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def batch_update_jobs(self, job_filter, job_update):
+        # type: (Dict[str, Any], Dict[str, Any]) -> int
         raise NotImplementedError
 
     @abc.abstractmethod

--- a/weaver/store/base.py
+++ b/weaver/store/base.py
@@ -1,4 +1,5 @@
 import abc
+from distutils.version import LooseVersion
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -12,6 +13,7 @@ if TYPE_CHECKING:
     from weaver.execute import AnyExecuteResponse
     from weaver.typedefs import (
         AnyUUID,
+        AnyVersion,
         ExecutionInputs,
         ExecutionOutputs,
         DatetimeIntervalType,
@@ -96,6 +98,16 @@ class StoreProcesses(StoreInterface):
     @abc.abstractmethod
     def fetch_by_id(self, process_id, visibility=None):
         # type: (str, Optional[AnyVisibility]) -> Process
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def find_versions(self, process_id, version_format):
+        # type: (str, VersionFormat) -> List[LooseVersion]
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def update_version(self, process_id, version):
+        # type: (str, AnyVersion) -> Process
         raise NotImplementedError
 
     @abc.abstractmethod

--- a/weaver/store/mongodb.py
+++ b/weaver/store/mongodb.py
@@ -794,7 +794,7 @@ class MongodbJobStore(StoreJobs, MongodbStore, ListingMixin):
             if job_key not in filter_keys:
                 job_filter.pop(job_key)
         if not job_update:
-            raise JobUpdateError(f"No job parameters specified to apply update.")
+            raise JobUpdateError("No job parameters specified to apply update.")
         job_update = {"$set": job_update}
         LOGGER.debug("Batch jobs update:\nfilter:\n%s\nupdate:\n%s",
                      repr_json(job_filter, indent=2), repr_json(job_update, indent=2))

--- a/weaver/typedefs.py
+++ b/weaver/typedefs.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Type, Union
 
     import psutil
-    from typing_extensions import Literal, NotRequired, Protocol, TypeAlias, TypedDict, TypeGuard
+    from typing_extensions import Literal, NotRequired, Protocol, TypeAlias, TypedDict
 
     if hasattr(os, "PathLike"):
         FileSystemPathType = Union[os.PathLike, str]

--- a/weaver/typedefs.py
+++ b/weaver/typedefs.py
@@ -6,6 +6,7 @@ if TYPE_CHECKING:
     import typing
     import uuid
     from datetime import datetime
+    from distutils.version import LooseVersion
     from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Type, Union
 
     import psutil
@@ -84,6 +85,7 @@ if TYPE_CHECKING:
     AnyValueType = Optional[ValueType]  # avoid naming ambiguity with PyWPS AnyValue
     AnyKey = Union[str, int]
     AnyUUID = Union[str, uuid.UUID]
+    AnyVersion = Union[LooseVersion, Number, str, Tuple[int, ...], List[int]]
     # add more levels of explicit definitions than necessary to simulate JSON recursive structure better than 'Any'
     # amount of repeated equivalent definition makes typing analysis 'work well enough' for most use cases
     _JSON: TypeAlias = "JSON"

--- a/weaver/typedefs.py
+++ b/weaver/typedefs.py
@@ -1,5 +1,8 @@
 from typing import TYPE_CHECKING  # pragma: no cover
 
+# FIXME:
+#  replace invalid 'Optional' (type or None) used instead of 'NotRequired' (optional key) when better supported
+#  https://youtrack.jetbrains.com/issue/PY-53611/Support-PEP-655-typingRequiredtypingNotRequired-for-TypedDicts
 if TYPE_CHECKING:
     import os
     import sys
@@ -10,23 +13,8 @@ if TYPE_CHECKING:
     from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Type, Union
 
     import psutil
+    from typing_extensions import Literal, Protocol, TypeAlias, TypedDict, TypeGuard
 
-    if hasattr(typing, "TypedDict"):
-        from typing import TypedDict  # pylint: disable=E0611,no-name-in-module  # Python >= 3.8
-    else:
-        from typing_extensions import TypedDict
-    if hasattr(typing, "Literal"):
-        from typing import Literal  # pylint: disable=E0611,no-name-in-module  # Python >= 3.8
-    else:
-        from typing_extensions import Literal
-    if hasattr(typing, "Protocol"):
-        from typing import Protocol  # pylint: disable=E0611,no-name-in-module  # Python >= 3.8
-    else:
-        from typing_extensions import Protocol
-    if hasattr(typing, "TypeAlias"):
-        from typing import TypeAlias  # pylint: disable=E0611,no-name-in-module  # Python >= 3.10
-    else:
-        from typing_extensions import TypeAlias
     if hasattr(os, "PathLike"):
         FileSystemPathType = Union[os.PathLike, str]
     else:
@@ -364,7 +352,8 @@ if TYPE_CHECKING:
         "type": Optional[str],
     }, total=False)
     ExecutionResultArray = List[ExecutionResultObject]
-    ExecutionResults = Dict[str, Union[ExecutionResultObject, ExecutionResultArray]]
+    ExecutionResultValue = Union[ExecutionResultObject, ExecutionResultArray]
+    ExecutionResults = Dict[str, ExecutionResultValue]
 
     # reference employed as 'JobMonitorReference' by 'WPS1Process'
     JobExecution = TypedDict("JobExecution", {"execution": WPSExecution})

--- a/weaver/typedefs.py
+++ b/weaver/typedefs.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Type, Union
 
     import psutil
-    from typing_extensions import Literal, Protocol, TypeAlias, TypedDict, TypeGuard
+    from typing_extensions import Literal, NotRequired, Protocol, TypeAlias, TypedDict, TypeGuard
 
     if hasattr(os, "PathLike"):
         FileSystemPathType = Union[os.PathLike, str]
@@ -88,15 +88,15 @@ if TYPE_CHECKING:
         "rel": str,
         "title": str,
         "href": str,
-        "hreflang": Optional[str],
-        "type": Optional[str],  # IANA Media-Type
+        "hreflang": NotRequired[str],
+        "type": NotRequired[str],  # IANA Media-Type
     }, total=False)
     Metadata = TypedDict("Metadata", {
         "title": str,
         "role": str,  # URL
         "value": str,
-        "lang": str,
-        "type": str,  # FIXME: relevant?
+        "lang": NotRequired[str],
+        "type": NotRequired[str],  # FIXME: relevant?
     }, total=False)
 
     LogLevelStr = Literal[
@@ -107,7 +107,11 @@ if TYPE_CHECKING:
 
     # CWL definition
     GlobType = TypedDict("GlobType", {"glob": Union[str, List[str]]}, total=False)
-    CWL_IO_FileValue = TypedDict("CWL_IO_FileValue", {"class": str, "path": str, "format": Optional[str]}, total=True)
+    CWL_IO_FileValue = TypedDict("CWL_IO_FileValue", {
+        "class": str,
+        "path": str,
+        "format": NotRequired[Optional[str]],
+    }, total=True)
     CWL_IO_Value = Union[AnyValueType, List[AnyValueType], CWL_IO_FileValue, List[CWL_IO_FileValue]]
     CWL_IO_NullableType = Union[str, List[str]]  # "<type>?" or ["<type>", "null"]
     CWL_IO_NestedType = TypedDict("CWL_IO_NestedType", {"type": CWL_IO_NullableType}, total=True)
@@ -123,21 +127,21 @@ if TYPE_CHECKING:
     CWL_IO_TypeItem = Union[str, CWL_IO_NestedType, CWL_IO_ArrayType, CWL_IO_EnumType]
     CWL_IO_DataType = Union[CWL_IO_TypeItem, List[CWL_IO_TypeItem]]
     CWL_Input_Type = TypedDict("CWL_Input_Type", {
-        "id": Optional[str],    # representation used by plain CWL definition
-        "name": Optional[str],  # representation used by parsed tool instance
+        "id": NotRequired[str],     # representation used by plain CWL definition
+        "name": NotRequired[str],   # representation used by parsed tool instance
         "type": CWL_IO_DataType,
-        "items": Union[str, CWL_IO_EnumType],
-        "symbols": Optional[CWL_IO_EnumSymbols],
-        "format": Optional[Union[str, List[str]]],
-        "inputBinding": Optional[Any],
-        "default": Optional[AnyValueType],
+        "items": NotRequired[Union[str, CWL_IO_EnumType]],
+        "symbols": NotRequired[CWL_IO_EnumSymbols],
+        "format": NotRequired[Optional[Union[str, List[str]]]],
+        "inputBinding": NotRequired[Any],
+        "default": NotRequired[Optional[AnyValueType]],
     }, total=False)
     CWL_Output_Type = TypedDict("CWL_Output_Type", {
-        "id": Optional[str],    # representation used by plain CWL definition
-        "name": Optional[str],  # representation used by parsed tool instance
+        "id": NotRequired[str],    # representation used by plain CWL definition
+        "name": NotRequired[str],  # representation used by parsed tool instance
         "type": CWL_IO_DataType,
-        "format": Optional[Union[str, List[str]]],
-        "outputBinding": Optional[GlobType]
+        "format": NotRequired[Optional[Union[str, List[str]]]],
+        "outputBinding": NotRequired[GlobType]
     }, total=False)
     CWL_Inputs = Union[List[CWL_Input_Type], Dict[str, CWL_Input_Type]]
     CWL_Outputs = Union[List[CWL_Output_Type], Dict[str, CWL_Output_Type]]
@@ -170,21 +174,21 @@ if TYPE_CHECKING:
         "class": CWL_Class,
         "label": str,
         "doc": str,
-        "id": Optional[str],
-        "intent": Optional[str],
+        "id": NotRequired[str],
+        "intent": NotRequired[str],
         "s:keywords": List[str],
-        "baseCommand": Optional[Union[str, List[str]]],
-        "parameters": Optional[List[str]],
-        "requirements": CWL_AnyRequirements,
-        "hints": CWL_AnyRequirements,
+        "baseCommand": NotRequired[Optional[Union[str, List[str]]]],
+        "parameters": NotRequired[List[str]],
+        "requirements": NotRequired[CWL_AnyRequirements],
+        "hints": NotRequired[CWL_AnyRequirements],
         "inputs": CWL_Inputs,
         "outputs": CWL_Outputs,
-        "steps": Dict[CWL_WorkflowStepID, CWL_WorkflowStep],
-        "stderr": str,
-        "stdout": str,
-        "$namespaces": Dict[str, str],
-        "$schemas": Dict[str, str],
-        "$graph": CWL_Graph,
+        "steps": NotRequired[Dict[CWL_WorkflowStepID, CWL_WorkflowStep]],
+        "stderr": NotRequired[str],
+        "stdout": NotRequired[str],
+        "$namespaces": NotRequired[Dict[str, str]],
+        "$schemas": NotRequired[Dict[str, str]],
+        "$graph": NotRequired[CWL_Graph],
     }, total=False)
     CWL_WorkflowStepPackage = TypedDict("CWL_WorkflowStepPackage", {
         "id": str,          # reference ID of the package
@@ -211,12 +215,12 @@ if TYPE_CHECKING:
     CWL_RuntimeOutputFile = TypedDict("CWL_RuntimeOutputFile", {
         "class": str,
         "location": str,
-        "format": Optional[str],
+        "format": NotRequired[Optional[str]],
         "basename": str,
         "nameroot": str,
         "nameext": str,
-        "checksum": Optional[str],
-        "size": Optional[str]
+        "checksum": NotRequired[str],
+        "size": NotRequired[str]
     }, total=False)
     CWL_RuntimeInput = Union[CWL_RuntimeLiteral, CWL_RuntimeInputFile]
     CWL_RuntimeInputsMap = Dict[str, CWL_RuntimeInput]
@@ -282,39 +286,41 @@ if TYPE_CHECKING:
 
     # data source configuration
     DataSourceFileRef = TypedDict("DataSourceFileRef", {
-        "ades": str,                # target ADES to dispatch
-        "netloc": str,              # definition to match file references against
-        "default": Optional[bool],  # default ADES when no match was possible (single one allowed in config)
+        "ades": str,                    # target ADES to dispatch
+        "netloc": str,                  # definition to match file references against
+        "default": NotRequired[bool],   # default ADES when no match was possible (single one allowed in config)
     }, total=True)
     DataSourceOpenSearch = TypedDict("DataSourceOpenSearch", {
-        "ades": str,                     # target ADES to dispatch
-        "netloc": str,                   # where to send OpenSearch request
-        "collection_id": Optional[str],  # OpenSearch collection ID to match against
-        "default": Optional[bool],       # default ADES when no match was possible (single one allowed)
-        "accept_schemes": Optional[List[str]],     # allowed URL schemes (http, https, etc.)
-        "mime_types": Optional[List[str]],         # allowed Media-Types (text/xml, application/json, etc.)
-        "rootdir": str,                  # root position of the data to retrieve
-        "osdd_url": str,                 # global OpenSearch description document to employ
+        "ades": str,                                # target ADES to dispatch
+        "netloc": str,                              # where to send OpenSearch request
+        "collection_id": NotRequired[str],          # OpenSearch collection ID to match against
+        "default": NotRequired[bool],               # default ADES when no match was possible (single one allowed)
+        "accept_schemes": NotRequired[List[str]],   # allowed URL schemes (http, https, etc.)
+        "mime_types": NotRequired[List[str]],       # allowed Media-Types (text/xml, application/json, etc.)
+        "rootdir": str,                             # root position of the data to retrieve
+        "osdd_url": str,                            # global OpenSearch description document to employ
     }, total=True)
     DataSource = Union[DataSourceFileRef, DataSourceOpenSearch]
     DataSourceConfig = Dict[str, DataSource]  # JSON/YAML file contents
 
     JobValueFormat = TypedDict("JobValueFormat", {
-        "mime_type": Optional[str],
-        "media_type": Optional[str],
-        "encoding": Optional[str],
-        "schema": Optional[str],
-        "extension": Optional[str],
+        "mime_type": NotRequired[str],
+        "media_type": NotRequired[str],
+        "encoding": NotRequired[str],
+        "schema": NotRequired[str],
+        "extension": NotRequired[str],
     }, total=False)
     JobValueFile = TypedDict("JobValueFile", {
-        "href": Optional[str],
-        "format": Optional[JobValueFormat],
+        "href": str,
+        "format": NotRequired[JobValueFormat],
     }, total=False)
     JobValueData = TypedDict("JobValueData", {
-        "data": Optional[AnyValueType],
-        "value": Optional[AnyValueType],
+        "data": AnyValueType,
     }, total=False)
-    JobValueObject = Union[JobValueData, JobValueFile]
+    JobValueValue = TypedDict("JobValueValue", {
+        "value": AnyValueType,
+    }, total=False)
+    JobValueObject = Union[JobValueData, JobValueValue, JobValueFile]
     JobValueFileItem = TypedDict("JobValueFileItem", {
         "id": str,
         "href": Optional[str],
@@ -322,8 +328,11 @@ if TYPE_CHECKING:
     }, total=False)
     JobValueDataItem = TypedDict("JobValueDataItem", {
         "id": str,
-        "data": Optional[AnyValueType],
-        "value": Optional[AnyValueType],
+        "data": AnyValueType,
+    }, total=False)
+    JobValueValueItem = TypedDict("JobValueValueItem", {
+        "id": str,
+        "value": AnyValueType,
     }, total=False)
     JobValueItem = Union[JobValueDataItem, JobValueFileItem]
     JobExpectItem = TypedDict("JobExpectItem", {"id": str}, total=True)
@@ -346,11 +355,15 @@ if TYPE_CHECKING:
     ExecutionOutputsList = List[ExecutionOutputItem]
     ExecutionOutputsMap = Dict[str, ExecutionOutputObject]
     ExecutionOutputs = Union[ExecutionOutputsList, ExecutionOutputsMap]
-    ExecutionResultObject = TypedDict("ExecutionResultObject", {
-        "value": Optional[AnyValueType],
+    ExecutionResultObjectRef = TypedDict("ExecutionResultObjectRef", {
         "href": Optional[str],
-        "type": Optional[str],
+        "type": NotRequired[str],
     }, total=False)
+    ExecutionResultObjectValue = TypedDict("ExecutionResultObjectValue", {
+        "value": Optional[AnyValueType],
+        "type": NotRequired[str],
+    }, total=False)
+    ExecutionResultObject = Union[ExecutionResultObjectRef, ExecutionResultObjectValue]
     ExecutionResultArray = List[ExecutionResultObject]
     ExecutionResultValue = Union[ExecutionResultObject, ExecutionResultArray]
     ExecutionResults = Dict[str, ExecutionResultValue]
@@ -389,8 +402,8 @@ if TYPE_CHECKING:
         "sizeBytes": int,
     }, total=True)
     Statistics = TypedDict("Statistics", {
-        "application": Optional[ApplicationStatistics],
-        "process": Optional[ProcessStatistics],
+        "application": NotRequired[ApplicationStatistics],
+        "process": NotRequired[ProcessStatistics],
         "outputs": Dict[str, OutputStatistics],
     }, total=False)
 
@@ -410,36 +423,36 @@ if TYPE_CHECKING:
     }, total=False)
     OpenAPISchemaProperty = TypedDict("OpenAPISchemaProperty", {
         "type": OpenAPISchemaTypes,
-        "format": str,
-        "default": Any,
-        "example": Any,
-        "title": str,
-        "description": str,
-        "enum": List[Union[str, Number]],
-        "items": List[_OpenAPISchema, OpenAPISchemaReference],
-        "required": List[str],
-        "nullable": bool,
-        "deprecated": bool,
-        "readOnly": bool,
-        "writeOnly": bool,
-        "multipleOf": Number,
-        "minimum": Number,
-        "maximum": Number,
-        "exclusiveMinimum": bool,
-        "exclusiveMaximum": bool,
-        "minLength": Number,
-        "maxLength": Number,
-        "pattern": str,
-        "minItems": Number,
-        "maxItems": Number,
-        "uniqueItems": bool,
-        "minProperties": Number,
-        "maxProperties": Number,
-        "contentMediaType": str,
-        "contentEncoding": str,
-        "contentSchema": str,
-        "properties": Dict[str, _OpenAPISchemaProperty],
-        "additionalProperties": Union[bool, Dict[str, Union[_OpenAPISchema, OpenAPISchemaReference]]],
+        "format": NotRequired[str],
+        "default": NotRequired[Any],
+        "example": NotRequired[Any],
+        "title": NotRequired[str],
+        "description": NotRequired[str],
+        "enum": NotRequired[List[Union[str, Number]]],
+        "items": NotRequired[List[_OpenAPISchema, OpenAPISchemaReference]],
+        "required": NotRequired[List[str]],
+        "nullable": NotRequired[bool],
+        "deprecated": NotRequired[bool],
+        "readOnly": NotRequired[bool],
+        "writeOnly": NotRequired[bool],
+        "multipleOf": NotRequired[Number],
+        "minimum": NotRequired[Number],
+        "maximum": NotRequired[Number],
+        "exclusiveMinimum": NotRequired[bool],
+        "exclusiveMaximum": NotRequired[bool],
+        "minLength": NotRequired[Number],
+        "maxLength": NotRequired[Number],
+        "pattern": NotRequired[str],
+        "minItems": NotRequired[Number],
+        "maxItems": NotRequired[Number],
+        "uniqueItems": NotRequired[bool],
+        "minProperties": NotRequired[Number],
+        "maxProperties": NotRequired[Number],
+        "contentMediaType": NotRequired[str],
+        "contentEncoding": NotRequired[str],
+        "contentSchema": NotRequired[str],
+        "properties": NotRequired[Dict[str, _OpenAPISchemaProperty]],
+        "additionalProperties": NotRequired[Union[bool, Dict[str, Union[_OpenAPISchema, OpenAPISchemaReference]]]],
     }, total=False)
     OpenAPISchemaObject = TypedDict("OpenAPISchemaObject", {
         "type": Literal["object"],

--- a/weaver/typedefs.py
+++ b/weaver/typedefs.py
@@ -183,6 +183,7 @@ if TYPE_CHECKING:
         "label": str,
         "doc": str,
         "id": Optional[str],
+        "intent": Optional[str],
         "s:keywords": List[str],
         "baseCommand": Optional[Union[str, List[str]]],
         "parameters": Optional[List[str]],

--- a/weaver/utils.py
+++ b/weaver/utils.py
@@ -646,17 +646,32 @@ def is_update_version(version, taken_versions, version_level=VersionLevel.PATCH)
     """
     Determines if the version corresponds to an available update version of specified level compared to existing ones.
 
-    :param version: Version to validate.
+    If the specified version corresponds to an older version compared to available ones (i.e.: a taken more recent
+    version also exists), the specified version will have to fit within the version level range to be considered valid.
+    For example, requesting ``PATCH`` level will require that the specified version is greater than the last available
+    version against other existing versions with equivalent ``MAJOR.MINOR`` parts. If ``1.2.0`` and ``2.0.0`` were
+    taken versions, and ``1.2.3`` has to be verified as the update version, it will be considered valid since its
+    ``PATCH`` number ``3`` is greater than all other ``1.2.x`` versions (it falls within the ``[1.2.x, 1.3.x[`` range).
+    Requesting instead ``MINOR`` level will require that the specified version is greater than the last available
+    version against existing versions of same  ``MAJOR`` part only. Using again the same example values, ``1.3.0``
+    would be valid since its ``MINOR`` part ``3`` is greater than any other ``1.x`` taken versions. On the other hand,
+    version ``1.2.4`` would not be valid as ``x = 2`` is already taken by other versions considering same ``1.x``
+    portion (``PATCH`` part is ignored in this case since ``MINOR`` is requested, and ``2.0.0`` is ignored as not the
+    same ``MAJOR`` portion of ``1`` as the tested version). Finally, requesting a ``MAJOR`` level will require
+    necessarily that the specified version is greater than all other existing versions for update, since ``MAJOR`` is
+    the highest possible semantic part, and higher parts are not available to define an upper version bound.
+
+    .. note::
+        As long as the version level is respected, the actual number of this level and all following ones can be
+        anything as long as they are not taken. For example, ``PATCH`` with existing ``1.2.3`` does not require that
+        the update version be ``1.2.4``. It can be ``1.2.5``, ``1.2.24``, etc. as long as ``1.2.x`` is respected.
+        Similarly, ``MINOR`` update can provide any ``PATCH`` number, since ``1.x`` only must be respected. From
+        existing ``1.2.3``, ``MINOR`` update could specify ``1.4.99`` as valid version. The ``PATCH`` part does not
+        need to start back at ``0``.
+
+    :param version: Version to validate as potential update revision.
     :param taken_versions: Existing versions that cannot be reused.
-    :param version_level:
-        Level to consider availability of versions for update.
-        If the specified version corresponds to an older version compared to available ones, it will have fit within
-        the specified version level range to be considered valid.
-        For example, requesting 'PATCH' level will require that the specified version is greater than the last available
-        version against other existing versions of same 'MAJOR.MINOR' parts. Requesting 'MINOR' level will require that
-        the specified version is greater than last available version against other existing versions of same 'MAJOR'
-        part. Finally, requesting 'MAJOR' level will require that the specified version is greater than all other
-        existing versions for update, since 'MAJOR' is the highest possible semantic part.
+    :param version_level: Minimum level to consider availability of versions as valid revision number for update.
     :return: Status of availability of the version.
     """
 
@@ -699,12 +714,13 @@ def is_update_version(version, taken_versions, version_level=VersionLevel.PATCH)
     # if found previous version and next version was not already taken
     # the requested one must be one above previous one at same semantic level,
     # and must be one below the upper semantic level to be an available version
+    # (eg: if PATCH requested and found min=1.3.4, then max=1.4.0, version can be anything in between)
     if version_level == VersionLevel.MAJOR:
         min_version = _pad_incr(ver_min[:1], 0)
         max_version = (float("inf"), float("inf"), float("inf"))
     elif version_level == VersionLevel.MINOR:
         min_version = _pad_incr(ver_min[:2], 1)
-        max_version = _pad_incr(ver_min[:2], 0)
+        max_version = _pad_incr(ver_min[:1], 0)
     elif version_level == VersionLevel.PATCH:
         min_version = _pad_incr(ver_min[:3], 2)
         max_version = _pad_incr(ver_min[:2], 1)

--- a/weaver/utils.py
+++ b/weaver/utils.py
@@ -575,8 +575,14 @@ class VersionLevel(Constants):
     PATCH = "patch"
 
 
-def as_version_major_minor_patch(version):
-    # type: (Optional[AnyVersion]) -> Tuple[int, int, int]
+class VersionFormat(Constants):
+    OBJECT = "object"  # LooseVersion
+    STRING = "string"  # "x.y.z"
+    PARTS = "parts"    # tuple/list
+
+
+def as_version_major_minor_patch(version, version_format=VersionFormat.PARTS):
+    # type: (Optional[AnyVersion], VersionFormat) -> AnyVersion
     """
     Generates a ``MAJOR.MINOR.PATCH`` version with padded with zeros for any missing parts.
     """
@@ -585,9 +591,15 @@ def as_version_major_minor_patch(version):
     elif isinstance(version, (list, tuple)):
         ver_parts = [int(part) for part in version]
     else:
-        ver_parts = []
+        ver_parts = []  # default "0.0.0" for backward compatibility
     ver_parts = ver_parts[:3]
-    return tuple(ver_parts + [0] * max(0, 3 - len(ver_parts)))  # type: ignore
+    ver_tuple = tuple(ver_parts + [0] * max(0, 3 - len(ver_parts)))
+    if version_format in [VersionFormat.STRING, VersionFormat.OBJECT]:
+        ver_str = ".".join(str(part) for part in ver_tuple)
+        if version_format == VersionFormat.STRING:
+            return ver_str
+        return LooseVersion(ver_str)
+    return ver_tuple
 
 
 def is_update_version(version, taken_versions, version_level=VersionLevel.PATCH):

--- a/weaver/utils.py
+++ b/weaver/utils.py
@@ -15,8 +15,8 @@ import time
 import warnings
 from copy import deepcopy
 from datetime import datetime
-from typing import TYPE_CHECKING, overload
 from distutils.version import LooseVersion
+from typing import TYPE_CHECKING, overload
 from urllib.parse import ParseResult, unquote, urlparse, urlunsplit
 
 import boto3

--- a/weaver/utils.py
+++ b/weaver/utils.py
@@ -15,7 +15,7 @@ import time
 import warnings
 from copy import deepcopy
 from datetime import datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, overload
 from distutils.version import LooseVersion
 from urllib.parse import ParseResult, unquote, urlparse, urlunsplit
 
@@ -59,7 +59,19 @@ from weaver.xml_util import XML
 
 if TYPE_CHECKING:
     from types import FrameType
-    from typing import Any, Callable, Dict, List, Iterable, MutableMapping, NoReturn, Optional, Type, Tuple, Union
+    from typing import (
+        Any,
+        Callable,
+        Dict,
+        List,
+        Iterable,
+        MutableMapping,
+        NoReturn,
+        Optional,
+        Type,
+        Tuple,
+        Union
+    )
 
     from weaver.execute import AnyExecuteControlOption, AnyExecuteMode
     from weaver.status import Status
@@ -70,15 +82,18 @@ if TYPE_CHECKING:
         AnyRegistryContainer,
         AnyRequestMethod,
         AnyResponseType,
+        AnyUUID,
         AnyValueType,
         AnyVersion,
         HeadersType,
         JSON,
         KVP,
         KVP_Item,
+        Literal,
         OpenAPISchema,
         Number,
-        SettingsType
+        SettingsType,
+        TypeGuard
     )
 
 LOGGER = logging.getLogger(__name__)
@@ -562,7 +577,7 @@ def get_url_without_query(url):
 
 
 def is_valid_url(url):
-    # type: (Optional[str]) -> bool
+    # type: (Optional[str]) -> TypeGuard[str]
     try:
         return bool(urlparse(url).scheme)
     except Exception:  # noqa: W0703 # nosec: B110
@@ -579,6 +594,30 @@ class VersionFormat(Constants):
     OBJECT = "object"  # LooseVersion
     STRING = "string"  # "x.y.z"
     PARTS = "parts"    # tuple/list
+
+
+@overload
+def as_version_major_minor_patch(version, version_format):
+    # type: (AnyVersion, Literal[VersionFormat.OBJECT]) -> LooseVersion
+    ...
+
+
+@overload
+def as_version_major_minor_patch(version, version_format):
+    # type: (AnyVersion, Literal[VersionFormat.STRING]) -> str
+    ...
+
+
+@overload
+def as_version_major_minor_patch(version, version_format):
+    # type: (AnyVersion, Literal[VersionFormat.PARTS]) -> Tuple[int, int, int]
+    ...
+
+
+@overload
+def as_version_major_minor_patch(version):
+    # type: (AnyVersion) -> Tuple[int, int, int]
+    ...
 
 
 def as_version_major_minor_patch(version, version_format=VersionFormat.PARTS):
@@ -603,7 +642,7 @@ def as_version_major_minor_patch(version, version_format=VersionFormat.PARTS):
 
 
 def is_update_version(version, taken_versions, version_level=VersionLevel.PATCH):
-    # type: (AnyVersion, Iterable[AnyVersion], VersionLevel) -> bool
+    # type: (AnyVersion, Iterable[AnyVersion], VersionLevel) -> TypeGuard[AnyVersion]
     """
     Determines if the version corresponds to an available update version of specified level compared to existing ones.
 
@@ -675,7 +714,7 @@ def is_update_version(version, taken_versions, version_level=VersionLevel.PATCH)
 
 
 def is_uuid(maybe_uuid):
-    # type: (Any) -> bool
+    # type: (Any) -> TypeGuard[AnyUUID]
     """
     Evaluates if the provided input is a UUID-like string.
     """
@@ -1735,7 +1774,7 @@ def load_file(file_path, text=False):
 
 
 def is_remote_file(file_location):
-    # type: (str) -> bool
+    # type: (str) -> TypeGuard[str]
     """
     Parses to file location to figure out if it is remotely available or a local path.
     """

--- a/weaver/utils.py
+++ b/weaver/utils.py
@@ -72,6 +72,7 @@ if TYPE_CHECKING:
         Tuple,
         Union
     )
+    from typing_extensions import TypeGuard
 
     from weaver.execute import AnyExecuteControlOption, AnyExecuteMode
     from weaver.status import Status
@@ -92,8 +93,7 @@ if TYPE_CHECKING:
         Literal,
         OpenAPISchema,
         Number,
-        SettingsType,
-        TypeGuard
+        SettingsType
     )
 
 LOGGER = logging.getLogger(__name__)

--- a/weaver/wps_restapi/examples/local_process_not_found.json
+++ b/weaver/wps_restapi/examples/local_process_not_found.json
@@ -1,0 +1,7 @@
+{
+    "title": "NoSuchProcess",
+    "type": "http://www.opengis.net/def/exceptions/ogcapi-processes-1/1.0/no-such-process",
+    "detail": "Process with specified reference identifier does not exist.",
+    "status": 404,
+    "cause": "does-not-exist"
+}

--- a/weaver/wps_restapi/jobs/utils.py
+++ b/weaver/wps_restapi/jobs/utils.py
@@ -18,7 +18,7 @@ from pyramid.response import FileResponse
 from pyramid_celery import celery_app
 
 from weaver.database import get_db
-from weaver.datatype import Job
+from weaver.datatype import Job, Process
 from weaver.exceptions import (
     InvalidIdentifierValue,
     JobGone,
@@ -122,7 +122,6 @@ def get_job(request):
         process_tag = resolve_process_tag(request)  # find version if available as well
     else:
         process_tag = job.process
-    process_id = process_tag.split(":")[0]
     if provider_id:
         forbid_local_only(request)
 
@@ -140,6 +139,8 @@ def get_job(request):
             },
             code=title, locator="provider", description=desc  # old format
         )
+
+    process_id = Process.split_version(process_tag)[0]
     if job.process not in [process_id, process_tag]:
         title = "NoSuchProcess"
         desc = "Could not find job reference corresponding to specified process reference."

--- a/weaver/wps_restapi/jobs/utils.py
+++ b/weaver/wps_restapi/jobs/utils.py
@@ -48,6 +48,7 @@ from weaver.visibility import Visibility
 from weaver.wps.utils import get_wps_output_dir, get_wps_output_url, map_wps_output_location
 from weaver.wps_restapi import swagger_definitions as sd
 from weaver.wps_restapi.constants import JobInputsOutputsSchema
+from weaver.wps_restapi.processes.utils import resolve_process_tag
 from weaver.wps_restapi.providers.utils import forbid_local_only
 
 if TYPE_CHECKING:
@@ -76,8 +77,17 @@ LOGGER = get_task_logger(__name__)
 def get_job(request):
     # type: (PyramidRequest) -> Job
     """
-    Obtain a job from request parameters.
+    Obtain a :term:`Job` from request parameters.
 
+    .. versionchanged:: 4.20
+        When looking for :term:`Job` that refers to a local :term:`Process`, allow implicit resolution of the
+        unspecified ``version`` portion to automatically resolve the identifier. Consider that validation of
+        the expected :term:`Process` for this :term:`Job` is "good enough", since the specific ID is not actually
+        required to obtain the :term:`Job` (could be queried by ID only on the ``/jobs/{jobId}`` endpoint.
+        If the ``version`` is provided though (either query parameter or tagged representation), the validation
+        will ensure that it matches explicitly.
+
+    :param request: Request with path and query parameters to retrieve the desired job.
     :returns: Job information if found.
     :raise HTTPNotFound: with JSON body details on missing/non-matching job, process, provider IDs.
     """
@@ -107,7 +117,12 @@ def get_job(request):
         )
 
     provider_id = request.matchdict.get("provider_id", job.service)
-    process_id = request.matchdict.get("process_id", job.process)
+    process_tag = request.matchdict.get("process_id")
+    if process_tag:
+        process_tag = resolve_process_tag(request)  # find version if available as well
+    else:
+        process_tag = job.process
+    process_id = process_tag.split(":")[0]
     if provider_id:
         forbid_local_only(request)
 
@@ -121,11 +136,11 @@ def get_job(request):
                 "type": "http://www.opengis.net/def/exceptions/ogcapi-processes-1/1.0/no-such-job",
                 "detail": desc,
                 "status": OWSNotFound.code,
-                "cause": str(process_id)
+                "cause": str(provider_id)
             },
             code=title, locator="provider", description=desc  # old format
         )
-    if job.process != process_id:
+    if job.process not in [process_id, process_tag]:
         title = "NoSuchProcess"
         desc = "Could not find job reference corresponding to specified process reference."
         raise OWSNotFound(
@@ -136,7 +151,7 @@ def get_job(request):
                 "type": "http://www.opengis.net/def/exceptions/ogcapi-processes-1/1.0/no-such-job",
                 "detail": desc,
                 "status": OWSNotFound.code,
-                "cause": str(process_id)
+                "cause": str(process_tag)
             },
             code=title, locator="process", description=desc  # old format
         )
@@ -415,7 +430,7 @@ def get_job_results_response(job, container, headers=None):
     is_raw = job.execution_response == ExecuteResponse.RAW
     results, refs = get_results(job, container, value_key="value",
                                 schema=JobInputsOutputsSchema.OGC,  # not strict to provide more format details
-                                link_references=is_raw)  # type: Union[ExecutionResults, HeadersTupleType]
+                                link_references=is_raw)
     headers = headers or {}
     if "location" not in headers:
         headers["Location"] = job.status_url(container)
@@ -434,10 +449,11 @@ def get_job_results_response(job, container, headers=None):
         refs.extend(headers.items())
         return HTTPNoContent(headers=refs)
 
-    # raw response can be only data value, only link or a mix of them
+    # raw response can be data-only value, link-only or a mix of them
     if results:
         # https://docs.ogc.org/is/18-062r2/18-062r2.html#req_core_process-execute-sync-raw-value-one
-        out_info = list(results.items())[0][-1]
+        out_vals = list(results.items())
+        out_info = out_vals[0][-1]
         out_type = get_any_value(out_info, key=True)
         out_data = get_any_value(out_info)
 

--- a/weaver/wps_restapi/processes/__init__.py
+++ b/weaver/wps_restapi/processes/__init__.py
@@ -33,6 +33,10 @@ def includeme(config):
                     request_method="POST", renderer=OutputFormat.JSON)
     config.add_view(p.get_local_process, route_name=sd.process_service.name,
                     request_method="GET", renderer=OutputFormat.JSON)
+    config.add_view(p.patch_local_process, route_name=sd.process_service.name,
+                    request_method="PATCH", renderer=OutputFormat.JSON)
+    config.add_view(p.put_local_process, route_name=sd.process_service.name,
+                    request_method="PUT", renderer=OutputFormat.JSON)
     config.add_view(p.delete_local_process, route_name=sd.process_service.name,
                     request_method="DELETE", renderer=OutputFormat.JSON)
     config.add_view(p.get_local_process_package, route_name=sd.process_package_service.name,

--- a/weaver/wps_restapi/processes/processes.py
+++ b/weaver/wps_restapi/processes/processes.py
@@ -278,7 +278,7 @@ def delete_local_process(request):
     """
     db = get_db(request)
     proc_store = db.get_store(StoreProcesses)
-    process = get_process(request=request, store=proc_store)
+    process = get_process(request=request)
     process_id = process.id
     if not process.mutable:
         raise HTTPForbidden(json={

--- a/weaver/wps_restapi/processes/processes.py
+++ b/weaver/wps_restapi/processes/processes.py
@@ -1,12 +1,9 @@
-import copy
-
 import logging
 from typing import TYPE_CHECKING
 
 import colander
 from pyramid.httpexceptions import (
     HTTPBadRequest,
-    HTTPConflict,
     HTTPException,
     HTTPForbidden,
     HTTPNotFound,
@@ -21,15 +18,14 @@ from weaver.exceptions import ProcessNotFound, ServiceException, log_unhandled_e
 from weaver.formats import OutputFormat, repr_json
 from weaver.processes import opensearch
 from weaver.processes.execution import submit_job
-from weaver.processes.utils import deploy_process_from_payload, get_process
+from weaver.processes.utils import deploy_process_from_payload, get_process, update_process_metadata
 from weaver.status import Status
 from weaver.store.base import StoreJobs, StoreProcesses
-from weaver.utils import VersionLevel, as_version_major_minor_patch, fully_qualified_name, get_any_id, is_update_version
+from weaver.utils import clean_json_text_body, fully_qualified_name, get_any_id
 from weaver.visibility import Visibility
 from weaver.wps_restapi import swagger_definitions as sd
 from weaver.wps_restapi.processes.utils import get_process_list_links, get_processes_filtered_by_valid_schemas
 from weaver.wps_restapi.providers.utils import get_provider_services
-from weaver.wps_restapi.utils import parse_content
 
 if TYPE_CHECKING:
     from weaver.typedefs import JSON, AnyViewResponse, PyramidRequest
@@ -132,9 +128,15 @@ def get_processes(request):
         })
     except HTTPException:
         raise
-    # FIXME: handle colander invalid directly in tween (https://github.com/crim-ca/weaver/issues/112)
-    except colander.Invalid as ex:
-        raise HTTPBadRequest(f"Invalid schema: [{ex!s}]")
+    except colander.Invalid as exc:
+        raise HTTPBadRequest(json={
+            "type": "InvalidParameterValue",
+            "title": "Invalid parameter value.",
+            "description": "Submitted request parameters are invalid or could not be processed.",
+            "cause": clean_json_text_body(f"Invalid schema: [{exc.msg or exc!s}]"),
+            "error": exc.__class__.__name__,
+            "value": repr_json(exc.value, force_string=False),
+        })
 
 
 @sd.processes_service.post(tags=[sd.TAG_PROCESSES, sd.TAG_DEPLOY], renderer=OutputFormat.JSON,
@@ -146,6 +148,21 @@ def add_local_process(request):
     Register a local process.
     """
     return deploy_process_from_payload(request.text, request)  # use text to allow parsing as JSON or YAML
+
+
+@sd.process_service.put(tags=[sd.TAG_PROCESSES, sd.TAG_DEPLOY], renderer=OutputFormat.JSON,
+                        schema=sd.PutProcessEndpoint(), response_schemas=sd.put_process_responses)
+@log_unhandled_exceptions(logger=LOGGER, message=sd.InternalServerErrorResponseSchema.description)
+def put_local_process(request):
+    # type: (PyramidRequest) -> AnyViewResponse
+    """
+    Update a registered local process with a new definition.
+
+    Updates the new process MAJOR semantic version from the previous one if not specified explicitly.
+    For MINOR or PATCH changes to metadata of the process definition, consider using the PATCH request.
+    """
+    process = get_process(request=request)
+    return deploy_process_from_payload(request.text, request, overwrite=process)
 
 
 @sd.process_service.patch(tags=[sd.TAG_PROCESSES, sd.TAG_DEPLOY], renderer=OutputFormat.JSON,
@@ -161,110 +178,7 @@ def patch_local_process(request):
     Changes to properties that might impact process operation such as supported formats implies MINOR update.
     Changes that completely redefine the process require a MAJOR update using PUT request.
     """
-    data = parse_content(request, content_schema=sd.PatchProcessBodySchema)
-    store = get_db(request).get_store(StoreProcesses)
-    process = get_process(request=request, store=store)  # latest if only 'processId', or specific version if using tag
-    if not process.mutable:
-        raise HTTPForbidden(json={
-            "title": "Process immutable.",
-            "type": "ProcessImmutable",
-            "detail": "Cannot update an immutable process.",
-            "status": HTTPForbidden.code,
-            "cause": {"mutable": False}
-        })
-
-    # apply requested changes for update
-    # (see 'PatchProcessBodySchema' for specific handling based on unspecified/null/empty-list)
-    description = data.get("description")
-    keywords = data.get("keywords")
-    metadata = data.get("metadata")
-    links = data.get("links")
-    update_level = VersionLevel.PATCH  # metadata only
-    try:
-        any_update = False
-        if description is not None:
-            any_update = True
-            process.description = description
-        if isinstance(keywords, list):
-            any_update = True
-            if not len(keywords):
-                process.keywords = []
-            else:
-                keys = copy.deepcopy(process.keywords)
-                keys.extend(keywords)
-                process.keywords = keys
-        if isinstance(metadata, list):
-            any_update = True
-            if not len(metadata):
-                process.metadata = []
-            else:
-                meta = copy.deepcopy(process.metadata)
-                meta.extend(metadata)
-                process.metadata = meta
-        if isinstance(links, list):
-            any_update = True
-            if not len(links):
-                process.additional_links = []
-            else:
-                x_links = copy.deepcopy(process.additional_links)
-                x_links.extend(links)
-                process.additional_links = x_links
-        if not any_update:
-            raise colander.Invalid(None, msg="No parameters provided for update.")
-    except colander.Invalid as exc:
-        raise HTTPBadRequest(json={
-            "code": "ProcessInvalidParameter",
-            "description": "Process update parameters failed validation.",
-            "error": colander.Invalid.__name__,
-            "cause": str(exc),
-            "value": repr_json(exc.value, force_string=False),
-        })
-
-    # employ user provided version or bump to next PATCH version from selected process
-    # must be tested in both cases against available versions since selected process is not necessarily the latest
-    version = data.get("version")
-    old_version = process.version
-    if not version:
-        new_version = as_version_major_minor_patch(old_version)
-        if update_level == VersionLevel.PATCH:
-            new_version[2] += 1  # bump PATCH
-        elif update_level == VersionLevel.MINOR:
-            new_version[1] += 1  # bump MINOR
-    else:
-        new_version = as_version_major_minor_patch(version)
-    # version must be within available range against selected process for needed update level
-    process_versions = store.find_versions(process.id)
-    if not is_update_version(new_version, process_versions, update_level):
-        raise HTTPUnprocessableEntity()
-    process.version = new_version
-
-    try:
-        old_process = store.update_version(process.id, old_version)
-        new_process = store.save_process(process)
-    except ProcessNotFound:
-        pass
-    else:
-        raise HTTPConflict()
-
-
-    return HTTPOk()
-
-
-@sd.process_service.put(tags=[sd.TAG_PROCESSES, sd.TAG_DEPLOY], renderer=OutputFormat.JSON,
-                        schema=sd.PostProcessesEndpoint(), response_schemas=sd.patch_process_responses)
-@log_unhandled_exceptions(logger=LOGGER, message=sd.InternalServerErrorResponseSchema.description)
-def put_local_process(request):
-    # type: (PyramidRequest) -> AnyViewResponse
-    """
-    Update a registered local process with a new definition.
-
-    Updates the new process MAJOR semantic version from the previous one if not specified explicitly.
-    For MINOR or PATCH changes to metadata definitions, consider using the PATCH request.
-    """
-    data = parse_content(request, content_schema=sd.PutProcessBodySchema)
-    store = get_db(request).get_store(StoreProcesses)
-    process = get_process(request=request, store=store)
-    return HTTPOk()
+    return update_process_metadata(request)
 
 
 @sd.process_service.get(tags=[sd.TAG_PROCESSES, sd.TAG_DESCRIBEPROCESS], renderer=OutputFormat.JSON,

--- a/weaver/wps_restapi/processes/processes.py
+++ b/weaver/wps_restapi/processes/processes.py
@@ -161,7 +161,7 @@ def put_local_process(request):
     Updates the new process MAJOR semantic version from the previous one if not specified explicitly.
     For MINOR or PATCH changes to metadata of the process definition, consider using the PATCH request.
     """
-    process = get_process(request=request)
+    process = get_process(request=request, revision=False)  # ignore tagged version since must always be latest
     return deploy_process_from_payload(request.text, request, overwrite=process)
 
 

--- a/weaver/wps_restapi/processes/utils.py
+++ b/weaver/wps_restapi/processes/utils.py
@@ -26,7 +26,24 @@ LOGGER = logging.getLogger(__name__)
 def resolve_process_tag(request, process_query=False):
     # type: (PyramidRequest, bool) -> str
     """
-    Obtain the tagged process reference from request path and/or query according to available information.
+    Obtain the tagged :term:`Process` reference from request path and/or query according to available information.
+
+    Whether the :term:`Process` is specified by path or query, another ``version`` query can be provided to specify
+    the desired revision by itself. This ``version`` query is considered only if another version indication is not
+    already specified in the :term:`Process` reference using the tagged semantic.
+
+    When ``process_query = False``, possible combinations are as follows:
+
+    - ``/processes/{processID}:{version}``
+    - ``/processes/{processID}?version={version}``
+
+    When ``process_query = True``, possible combinations are as follows:
+
+    - ``/...?process={processID}:{version}``
+    - ``/...?process={processID}&version={version}``
+
+    :param request: Request from which to retrieve the process reference.
+    :param process_query: Whether the process ID reference is located in request path or ``process={id}`` query.
     """
     if process_query:
         process_id = request.params.get("process")

--- a/weaver/wps_restapi/processes/utils.py
+++ b/weaver/wps_restapi/processes/utils.py
@@ -18,7 +18,7 @@ from weaver.wps_restapi import swagger_definitions as sd
 if TYPE_CHECKING:
     from typing import Dict, List, Optional, Tuple
 
-    from weaver.datatype import Service
+    from weaver.datatype import Service, Process
     from weaver.typedefs import JSON
 
 LOGGER = logging.getLogger(__name__)
@@ -35,6 +35,8 @@ def get_processes_filtered_by_valid_schemas(request):
     with_providers = False
     if get_weaver_configuration(settings) in WeaverFeature.REMOTE:
         with_providers = asbool(request.params.get("providers", False))
+    revisions_param = sd.ProcessRevisionsQuery(unknown="ignore").deserialize(request.params)
+    with_revisions = revisions_param.get("revisions")
     paging_query = sd.ProcessPagingQuery()
     paging_value = {param.name: param.default for param in paging_query.children}
     paging_names = set(paging_value)
@@ -47,14 +49,20 @@ def get_processes_filtered_by_valid_schemas(request):
         })
 
     store = get_db(request).get_store(StoreProcesses)
-    processes, total_local_processes = store.list_processes(visibility=Visibility.PUBLIC, total=True, **paging_param)
+    processes, total_local_processes = store.list_processes(
+        visibility=Visibility.PUBLIC,
+        total=True,
+        **revisions_param,
+        **paging_param
+    )
     valid_processes = []
     invalid_processes_ids = []
-    for process in processes:
+    for process in processes:  # type: Process
         try:
-            valid_processes.append(process.summary())
+            valid_processes.append(process.summary(revision=with_revisions))
         except colander.Invalid as invalid:
-            LOGGER.debug("Invalid process [%s] because:\n%s", process.identifier, invalid)
+            process_ref = process.tag if with_revisions else process.identifier
+            LOGGER.debug("Invalid process [%s] because:\n%s", process_ref, invalid)
             invalid_processes_ids.append(process.identifier)
     return valid_processes, invalid_processes_ids, paging_param, with_providers, total_local_processes
 

--- a/weaver/wps_restapi/swagger_definitions.py
+++ b/weaver/wps_restapi/swagger_definitions.py
@@ -4395,15 +4395,18 @@ class PatchProcessBodySchema(UpdateVersion):
     ))
     jobControlOptions = JobControlOptionsList(missing=drop, description=(
         "New job control options supported by this process for its execution. "
-        "Minimum required at least MINOR update."
+        "All desired job control options must be provided (full override, not appending). "
+        "Order is important to define the default behaviour (first item) to use when unspecified during job execution. "
+        "Minimum required change version level: MINOR."
     ))
     outputTransmission = TransmissionModeList(missing=drop, description=(
         "New output transmission methods supported following this process execution. "
-        "Minimum required at least MINOR update."
+        "All desired output transmission modes must be provided (full override, not appending). "
+        "Minimum required change version level: MINOR."
     ))
     visibility = VisibilityValue(missing=drop, description=(
         "New process visibility. "
-        "Minimum required at least MINOR update."
+        "Minimum required change version level: MINOR."
     ))
 
 

--- a/weaver/wps_restapi/swagger_definitions.py
+++ b/weaver/wps_restapi/swagger_definitions.py
@@ -1147,7 +1147,7 @@ class DeployMinMaxOccurs(ExtendedMappingSchema):
 # does not inherit from 'DescriptionLinks' because other 'ProcessDescription<>' schema depend from this without 'links'
 class ProcessDescriptionType(DescriptionBase, DescriptionExtra):
     id = ProcessIdentifier()
-    version = Version(missing=drop, example="1.2.3")
+    version = Version(missing=None, example="1.2.3")
     mutable = ExtendedSchemaNode(Boolean(), default=True, description=(
         "Indicates if the process is mutable (dynamically deployed), or immutable (builtin with this instance)."
     ))

--- a/weaver/wps_restapi/utils.py
+++ b/weaver/wps_restapi/utils.py
@@ -5,15 +5,23 @@ from copy import deepcopy
 from typing import TYPE_CHECKING
 
 import colander
-from pyramid.httpexceptions import HTTPBadRequest, HTTPSuccessful, status_map
+from pyramid.httpexceptions import (
+    HTTPBadRequest,
+    HTTPInternalServerError,
+    HTTPSuccessful,
+    HTTPUnsupportedMediaType,
+    status_map
+)
+import yaml
 
 from weaver.utils import get_header, get_settings, get_weaver_url
 from weaver.wps_restapi import swagger_definitions as sd
 
 if TYPE_CHECKING:
-    from typing import Any, Callable, Dict, Optional
+    from typing import Any, Callable, Dict, Optional, Union
 
-    from weaver.typedefs import AnySettingsContainer, HeadersType
+    from weaver.formats import ContentType
+    from weaver.typedefs import CWL, JSON, AnyRequestType, AnySettingsContainer, HeadersType
 
 LOGGER = logging.getLogger(__name__)
 
@@ -153,3 +161,51 @@ def handle_schema_validation(schema=None):
                 raise HTTPBadRequest(json=data)
         return wrapped
     return decorator
+
+
+def parse_content(request=None,                                         # type: Optional[AnyRequestType]
+                  content=None,                                         # type: Optional[Union[JSON, str]]
+                  content_schema=None,                                  # type: Optional[colander.SchemaNode]
+                  content_type=sd.RequestContentTypeHeader.default,     # type: Optional[ContentType]
+                  content_type_schema=sd.RequestContentTypeHeader,      # type: Optional[colander.SchemaNode]
+                  ):                                                    # type: (...) -> Union[JSON, CWL]
+    """
+    Load the request content with validation of expected content type and their schema.
+    """
+    if request is None and content is None:  # pragma: no cover  # safeguard for early detect invalid implementation
+        raise HTTPInternalServerError(json={
+            "title": "Internal Server Error",
+            "type": "InternalServerError",
+            "detail": "Cannot parse undefined contents.",
+            "status": HTTPInternalServerError.code,
+            "cause": "Request content and content argument are undefined.",
+        })
+    try:
+        if request is not None:
+            content = request.text
+            content_type = request.content_type
+        if content_type is not None and content_type_schema is not None:
+            content_type = content_type_schema().deserialize(content_type)
+        if isinstance(content, str):
+            content = yaml.safe_load(content)
+        if content_schema is not None:
+            content = content_schema().deserialize(content)
+        if not isinstance(content, dict):
+            raise TypeError("Not a valid JSON body for process deployment.")
+    except colander.Invalid as exc:
+        raise HTTPUnsupportedMediaType(json={
+            "title": "Unsupported Media Type",
+            "type": "UnsupportedMediaType",
+            "detail": str(exc),
+            "status": HTTPUnsupportedMediaType.code,
+            "cause": {"Content-Type": None if content_type is None else str(content_type)},
+        })
+    except Exception as exc:
+        raise HTTPBadRequest(json={
+            "title": "Bad Request",
+            "type": "BadRequest",
+            "detail": "Unable to parse contents.",
+            "status": HTTPBadRequest.code,
+            "cause": str(exc),
+        })
+    return content

--- a/weaver/wps_restapi/utils.py
+++ b/weaver/wps_restapi/utils.py
@@ -5,6 +5,7 @@ from copy import deepcopy
 from typing import TYPE_CHECKING
 
 import colander
+import yaml
 from pyramid.httpexceptions import (
     HTTPBadRequest,
     HTTPInternalServerError,
@@ -13,7 +14,6 @@ from pyramid.httpexceptions import (
     HTTPUnsupportedMediaType,
     status_map
 )
-import yaml
 
 from weaver.formats import repr_json
 from weaver.utils import get_header, get_settings, get_weaver_url


### PR DESCRIPTION
## Description & Solution Reasoning

Provide support of revisions to existing processes with metadata updates or application redefinition. 
When a new revision is created, a "duplicate" `processID` is generated. The duplicates are distinguished amongst each other using the combination of `{processID}:{version}` values. 

Because `processes` collection has a unique rule on `identifier` in the DB, and for backward compatibility because some processes did not make use of `version` (and it still is optional), the "latest" revision is stored as `identifier = processID` while older ones are stored as `identifier = processID:version`. This respects the uniqueness while having "duplicate" process definitions. The only moment `version` becomes required is when revisions are involved, which is a required or auto-resolved field for PUT/PATCH requests (with specific version validation checks). The "previous latest" is updated in the DB by adding the version part to its `identifier` field, and the "new latest" revision can then be stored directly as `identifier = processID`. Using this approach, fetching the latest or an older revision is also natural from the API, as IDs are directly formatted appropriately. Jobs also make use of this `processID:version` format to properly refer to the right process that was executed.

The only adjustment that was required to retrieve a process was if the latest one was explicitly requested with `processID:version`. The fetch method of the storage therefore searches with both `identifier = processID:version` and `identifier = processID && version = version` combinations.

Changes:
--------
- Add support of `Process` revisions (resolves #107).
- Add``PATCH /processes/{processID}`` request, allowing `MINOR` and `PATCH` level modifications that can be applied
  to an existing `Process` in order to revise non-execution critical information such as its documented description.
- Add ``PUT /processes/{processID}`` request, allowing `MAJOR` revision to essentially redeploy a new `Process`,
  but leaving some form of relationship with the older version by reusing the same `Process` ID.
- Add support of ``{processID}:{version}`` representation in request path and `Job` ``processID`` to reference the
  specific `Process` revisions when fetch `Process` description and `Job` status.
- Add search query ``version`` and ``revisions`` to fetch a specific `Process` revision, or all versions history.
- Add more entries in ``links`` referring to `Process` revisions whenever applicable.

Fixes:
------
- Fix invalid ``minimum`` and ``maximum`` OpenAPI fields that were defined as ``minLength`` and ``maxLength``
  (duplicates definitions) for `Process` description and deployment schema validation.


- Resolves [DAC-199](https://crim-ca.atlassian.net/browse/DAC-199)
- Resolves [DAC-200](https://crim-ca.atlassian.net/browse/DAC-200)

## To Do

- [x] validate that MAJOR PUT update becomes the latest, even if older process reference was used
    - make sure that correct previous "latest" is replaced (ie: not necessarily the older process reference)
      => when PUT, always use the "latest" (drop `:{version}` part) since deployed from scratch instead of update anyway?
    - make sure that compared version with target new version or auto-bumped uses the highest known version
- [x] delete (undeploy) process with revision should make sure that new latest is updated if targeted revision was the current latest
- [ ] ~when listing revisions history, provide the diffs between them (use `generate_diff` function with generated process descriptions)~
  moved to https://github.com/crim-ca/weaver/issues/448
- [ ] ~propagate PATCH request updates to corresponding *package* metadata as specified from *process* metadata
  (eg: `description` -> CWL `doc`)~
  moved to https://github.com/crim-ca/weaver/issues/449
- [x] test PATCH request to allow update of `title`, `description`, `keywords`, `metadata` of any input/output
- [x] test listing of revisions 
- [x] more tests/complete missing implementations?
- [x] update docs with new features 
    - new small section in https://github.com/crim-ca/weaver/blob/master/docs/source/processes.rst
    - describe process versioning capabilities (what can be updated, listing revisions, fetching/executing a specific revision)
    - difference PATCH/PUT endpoints vs MAJOR/MINOR/PATCH updates (use same description as in changes 0a8c13bfe)
    - distinction deploy/undeploy vs deploy/update
