### PR TITLE
fix cli docker username/password/token args resolution

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -299,7 +299,10 @@ docstring-quote=double
 expected-line-ending-format=
 
 # Regexp for a line that is allowed to be longer than the limit.
-ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+# - Ignore HTTP(S) URL
+# - Ignore RST references (e.g.: long method path)
+# Both could be indented (e.g.: within a docstring, class, function, etc.)
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$|^\s*\:\w+\:\`\S+\`$
 
 # Number of spaces of indent required inside a hanging or continued line.
 indent-after-paren=4

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,7 +16,8 @@ Changes:
 
 Fixes:
 ------
-- No change.
+- Fix `CLI` not allowing expected combination of ``--username`` and ``--password`` for Docker authentication when
+  deploying a `Process` that needs it to retrieve the referenced repository and image in its `CWL` definition.
 
 .. _changes_4.19.0:
 

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -605,7 +605,8 @@ class TestWeaverCLI(TestWeaverClientBase):
         """
         Validate some special handling to generate special combinations of help argument details.
         """
-        lines = run_command([
+        lines = run_command(
+            [
                 # "weaver",
                 "deploy",
                 "--help",
@@ -760,7 +761,7 @@ class TestWeaverCLI(TestWeaverClientBase):
             expect_error=True,
         )
         assert "usage: weaver deploy" in lines[0]
-        assert "weaver deploy: error: argument -T/--token: not allowed with argument -U/--username" == lines[-1]
+        assert lines[-1] == "weaver deploy: error: argument -T/--token: not allowed with argument -U/--username"
 
         lines = mocked_sub_requests(
             self.app, run_command,
@@ -779,7 +780,7 @@ class TestWeaverCLI(TestWeaverClientBase):
             expect_error=True,
         )
         assert "usage: weaver deploy" in lines[0]
-        assert "weaver deploy: error: argument -T/--token: not allowed with argument -P/--password" == lines[-1]
+        assert lines[-1] == "weaver deploy: error: argument -T/--token: not allowed with argument -P/--password"
 
         lines = mocked_sub_requests(
             self.app, run_command,
@@ -800,8 +801,8 @@ class TestWeaverCLI(TestWeaverClientBase):
         )
         assert "usage: weaver deploy" in lines[0]
         assert (  # any first that disallows
-            "weaver deploy: error: argument -T/--token: not allowed with argument -U/--username" == lines[-1] or
-            "weaver deploy: error: argument -T/--token: not allowed with argument -P/--password" == lines[-1]
+            lines[-1] == "weaver deploy: error: argument -T/--token: not allowed with argument -U/--username" or
+            lines[-1] == "weaver deploy: error: argument -T/--token: not allowed with argument -P/--password"
         )
 
     def test_deploy_docker_auth_username_or_password_missing_invalid(self):
@@ -836,7 +837,7 @@ class TestWeaverCLI(TestWeaverClientBase):
             expect_error=True,
         )
         assert "usage: weaver deploy" in lines[0]
-        assert "weaver deploy: error: argument -U/--username: must be combined with -P/--password" == lines[-1]
+        assert lines[-1] == "weaver deploy: error: argument -U/--username: must be combined with -P/--password"
 
         lines = mocked_sub_requests(
             self.app, run_command,
@@ -854,7 +855,7 @@ class TestWeaverCLI(TestWeaverClientBase):
             expect_error=True,
         )
         assert "usage: weaver deploy" in lines[0]
-        assert "weaver deploy: error: argument -U/--username: must be combined with -P/--password" == lines[-1]
+        assert lines[-1] == "weaver deploy: error: argument -U/--username: must be combined with -P/--password"
 
     def test_deploy_payload_body_cwl_embedded(self):
         test_id = f"{self.test_process_prefix}-deploy-body-no-cwl"

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -2,7 +2,6 @@
 Functional tests for :mod:`weaver.cli`.
 """
 import base64
-
 import contextlib
 import copy
 import json

--- a/tests/wps_restapi/test_processes.py
+++ b/tests/wps_restapi/test_processes.py
@@ -615,7 +615,7 @@ class WpsRestApiProcessesTest(unittest.TestCase):
 
     def test_deploy_process_CWL_DockerRequirement_auth_header_format(self):
         """
-        Test deployment ofa process with authentication to access the referenced repository.
+        Test deployment of a process with authentication to access the referenced repository.
 
         .. note::
             Use same definition as the one provided in :ref:`app_pkg_script` documentation.

--- a/weaver/cli.py
+++ b/weaver/cli.py
@@ -50,7 +50,7 @@ from weaver.visibility import Visibility
 from weaver.wps_restapi import swagger_definitions as sd
 
 if TYPE_CHECKING:
-    from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Type, Union
+    from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Set, Tuple, Type, Union
 
     from requests import Response
 
@@ -81,6 +81,10 @@ if TYPE_CHECKING:
         AnyOutputFormat = str
         ProcessSchemaType = str
         StatusType = str
+
+    ConditionalGroup = Tuple[argparse._ActionsContainer, bool, bool]  # noqa
+    PostHelpFormatter = Callable[[str], str]
+    ArgumentParserRule = Tuple[argparse._ActionsContainer, Callable[[argparse.Namespace], Optional[bool]], str]  # noqa
 
 LOGGER = logging.getLogger(__name__)
 
@@ -1699,6 +1703,14 @@ class WeaverSubParserAction(argparse._SubParsersAction):  # noqa
         parser = getattr(self, "parser", None)  # type: WeaverArgumentParser
         sub_parser._conditional_groups = parser._conditional_groups
         sub_parser._help_mode = parser._help_mode
+        parent_parsers = kwargs.get("parents", [])
+        for _parser in [parser] + parent_parsers:
+            sub_parser._formatters.update(_parser._formatters)
+        for _parser in [sub_parser] + parent_parsers:
+            # propagate sub parser such that full '<main> <mode>' is used as program name if error
+            for rule in _parser._rules:
+                rule = (sub_parser, *rule[1:])
+                parser._rules.add(rule)  # type: ignore
         return sub_parser
 
 
@@ -1711,7 +1723,9 @@ class WeaverArgumentParser(ArgumentParserFixedRequiredArgs, SubArgumentParserFix
         # type: (Any, Any) -> None
         super(WeaverArgumentParser, self).__init__(*args, **kwargs)
         self._help_mode = False
-        self._conditional_groups = []
+        self._conditional_groups = set()    # type: Set[ConditionalGroup]
+        self._formatters = set()            # type: Set[PostHelpFormatter]
+        self._rules = set()                 # type: Set[ArgumentParserRule]
 
     def add_subparsers(self, *args, **kwargs):  # type: ignore
         self.register("action", "parsers", WeaverSubParserAction)
@@ -1736,8 +1750,15 @@ class WeaverArgumentParser(ArgumentParserFixedRequiredArgs, SubArgumentParserFix
     def add_help_conditional(self, container, help_required=True, use_required=False):
         # type: (argparse._ActionsContainer, bool, bool) -> argparse._ActionsContainer  # noqa
         setattr(container, "required", use_required)
-        self._conditional_groups.append((container, help_required, use_required))
+        self._conditional_groups.add((container, help_required, use_required))
         return container
+
+    def add_formatter(self, formatter):
+        # type: (Callable[[str], str]) -> None
+        """
+        Define a POST-help formatter.
+        """
+        self._formatters.add(formatter)
 
     def _get_formatter(self):
         # type: () -> argparse.HelpFormatter
@@ -1749,8 +1770,22 @@ class WeaverArgumentParser(ArgumentParserFixedRequiredArgs, SubArgumentParserFix
         # type: () -> str
         self.help_mode = True
         text = super(WeaverArgumentParser, self).format_help() + "\n"
+        for fmt in self._formatters:
+            text = fmt(text)
         self.help_mode = False
         return text
+
+    def add_rule(self, rule, failure):
+        # type: (Callable[[argparse.Namespace], Optional[bool]], str) -> None
+        self._rules.add((self, rule, failure))
+
+    def parse_args(self, args=None, namespace=None):
+        # type: (Optional[Sequence[str]], Optional[argparse.Namespace]) -> argparse.Namespace
+        ns = super(WeaverArgumentParser, self).parse_args(args=args, namespace=namespace)
+        for container, rule, failure in self._rules:
+            if rule(ns) not in [None, True]:
+                container.error(failure)
+        return ns
 
 
 def make_parser():
@@ -1822,17 +1857,16 @@ def make_parser():
         title=docker_auth_title,
         description=docker_auth_desc,
     )
-    op_deploy_token = op_deploy_group.add_mutually_exclusive_group()
-    op_deploy_token.add_argument(
+    op_deploy_token = op_deploy_group.add_argument_group(title=docker_auth_title, description=docker_auth_desc)
+    op_deploy_creds = op_deploy_token.add_argument_group(title=docker_auth_title, description=docker_auth_desc)
+    op_deploy_tkt = op_deploy_token.add_argument(
         "-T", "--token", dest="token",
         help="Authentication token to retrieve a Docker image reference from a protected registry during execution."
     )
-    op_deploy_creds = op_deploy_token.add_argument_group(docker_auth_title, docker_auth_desc)
     op_deploy_usr = op_deploy_creds.add_argument(
         "-U", "--username", dest="username",
         help="Username to compute the authentication token for Docker image retrieval from a protected registry."
     )
-    op_deploy_group._group_actions.append(op_deploy_usr)
     op_deploy_pwd = op_deploy_creds.add_argument(
         "-P", "--password", dest="password",
         help="Password to compute the authentication token for Docker image retrieval from a protected registry."
@@ -1843,10 +1877,26 @@ def make_parser():
     # rendered group of *mutually required* arguments
     parser.add_help_conditional(op_deploy_creds)
     # following adjust references in order to make arguments appear within sections/groups as intended
-    op_deploy._mutually_exclusive_groups.append(op_deploy_creds)  # type: ignore
+    op_deploy_mutex_usr_tkt = op_deploy_group.add_mutually_exclusive_group()
+    op_deploy_mutex_usr_tkt._group_actions.append(op_deploy_usr)
+    op_deploy_mutex_usr_tkt._group_actions.append(op_deploy_tkt)
+    op_deploy_mutex_pwd_tkt = op_deploy_group.add_mutually_exclusive_group()
+    op_deploy_mutex_pwd_tkt._group_actions.append(op_deploy_pwd)
+    op_deploy_mutex_pwd_tkt._group_actions.append(op_deploy_tkt)
+    op_deploy_group._group_actions.append(op_deploy_usr)
     op_deploy_group._group_actions.append(op_deploy_pwd)
-    op_deploy_token._group_actions.append(op_deploy_usr)
-    op_deploy_token._group_actions.append(op_deploy_pwd)
+    op_deploy_group._group_actions.append(op_deploy_tkt)
+    # force a specific representation and validation of arguments to better reflect expected combinations
+    op_deploy.add_formatter(
+        lambda _help: _help.replace(
+            "[-T TOKEN] [-U USERNAME] [-P PASSWORD]",
+            "[-T TOKEN | ( -U USERNAME -P PASSWORD )]"
+        )
+    )
+    op_deploy.add_rule(
+        lambda _ns: bool(_ns.username) == bool(_ns.password),
+        "argument -U/--username: must be combined with -P/--password"
+    )
 
     op_deploy.add_argument(
         "-D", "--delete", "--undeploy", dest="undeploy", action="store_true",


### PR DESCRIPTION
- Fix `CLI` not allowing expected combination of ``--username`` and ``--password`` for Docker authentication when
  deploying a `Process` that needs it to retrieve the referenced repository and image in its `CWL` definition.