### PR TITLE
add CLI/WeaverClient job retrieval operations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,7 @@ Changes:
 --------
 - Add `CLI` and `WeaverClient` support of ``logs``, ``exceptions`` and ``statistics`` retrieval.
 - Add `CLI` and `WeaverClient` support of `Job` search filtered by ``tags``, ``process`` and ``providers`` queries.
-- Add `CLI` and `WeaverClient` support of `Job` search filtered by multiple ``status`` values.
+- Add `CLI`, `WeaverClient` and `API` support of `Job` search filtered by multiple ``status`` values.
 - Adjust OpenAPI schema definitions for `Process` deployment to allow ``owsContext`` by itself without duplicated
   information that was required by mandatory ``executionUnit`` definition.
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,11 +12,14 @@ Changes
 
 Changes:
 --------
+- Add `CLI` and `WeaverClient` support of ``logs``, ``exceptions`` and ``statistics`` retrieval.
+- Add `CLI` and `WeaverClient` support of `Job` search filtered by ``tags``, ``process`` and ``providers`` queries.
 - Adjust OpenAPI schema definitions for `Process` deployment to allow ``owsContext`` by itself without duplicated
   information that was required by mandatory ``executionUnit`` definition.
 
 Fixes:
 ------
+- Fix ``tags`` query parameter not applied to filter `Job` search requests.
 - Fix implementation of functional ``DockerRequirement`` test cases for `Process` deployment when references are
   provided by ``href`` within the ``executionUnit`` or ``owsContext``
   (relates to `#11 <https://github.com/crim-ca/weaver/issues/11>`_).

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ Changes:
 --------
 - Add `CLI` and `WeaverClient` support of ``logs``, ``exceptions`` and ``statistics`` retrieval.
 - Add `CLI` and `WeaverClient` support of `Job` search filtered by ``tags``, ``process`` and ``providers`` queries.
+- Add `CLI` and `WeaverClient` support of `Job` search filtered by multiple ``status`` values.
 - Adjust OpenAPI schema definitions for `Process` deployment to allow ``owsContext`` by itself without duplicated
   information that was required by mandatory ``executionUnit`` definition.
 

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -266,7 +266,7 @@ class TestWeaverClient(TestWeaverClientBase):
         assert resp.request.headers["Custom-Authorization"] == f"token={token}&user=test"
 
     def test_deploy_payload_body_cwl_embedded(self):
-        test_id = f"{self.test_process_prefix}-deploy-body-no-cwl"
+        test_id = f"{self.test_process_prefix}deploy-body-no-cwl"
         payload = self.retrieve_payload("Echo", "deploy", local=True)
         package = self.retrieve_payload("Echo", "package", local=True)
         payload["executionUnit"][0] = {"unit": package}
@@ -280,7 +280,7 @@ class TestWeaverClient(TestWeaverClientBase):
         assert "undefined" not in result.message
 
     def test_deploy_payload_file_cwl_embedded(self):
-        test_id = f"{self.test_process_prefix}-deploy-file-no-cwl"
+        test_id = f"{self.test_process_prefix}deploy-file-no-cwl"
         payload = self.retrieve_payload("Echo", "deploy", local=True)
         package = self.retrieve_payload("Echo", "package", local=True, ref_found=True)
         payload["executionUnit"][0] = {"href": package}
@@ -298,7 +298,7 @@ class TestWeaverClient(TestWeaverClientBase):
         assert "undefined" not in result.message
 
     def test_deploy_payload_inject_cwl_body(self):
-        test_id = f"{self.test_process_prefix}-deploy-body-with-cwl-body"
+        test_id = f"{self.test_process_prefix}deploy-body-with-cwl-body"
         payload = self.retrieve_payload("Echo", "deploy", local=True)
         package = self.retrieve_payload("Echo", "package", local=True)
         payload.pop("executionUnit", None)
@@ -312,7 +312,7 @@ class TestWeaverClient(TestWeaverClientBase):
         assert "undefined" not in result.message
 
     def test_deploy_payload_inject_cwl_file(self):
-        test_id = f"{self.test_process_prefix}-deploy-body-with-cwl-file"
+        test_id = f"{self.test_process_prefix}deploy-body-with-cwl-file"
         payload = self.retrieve_payload("Echo", "deploy", local=True)
         package = self.retrieve_payload("Echo", "package", local=True, ref_found=True)
         payload.pop("executionUnit", None)
@@ -326,7 +326,7 @@ class TestWeaverClient(TestWeaverClientBase):
         assert "undefined" not in result.message
 
     def test_deploy_with_undeploy(self):
-        test_id = f"{self.test_process_prefix}-deploy-undeploy-flag"
+        test_id = f"{self.test_process_prefix}deploy-undeploy-flag"
         deploy = self.test_payload["Echo"]
         result = mocked_sub_requests(self.app, self.client.deploy, test_id, deploy)
         assert result.success
@@ -990,7 +990,7 @@ class TestWeaverCLI(TestWeaverClientBase):
         assert lines[-1] == "weaver deploy: error: argument -U/--username: must be combined with -P/--password"
 
     def test_deploy_payload_body_cwl_embedded(self):
-        test_id = f"{self.test_process_prefix}-deploy-body-no-cwl"
+        test_id = f"{self.test_process_prefix}deploy-body-no-cwl"
         payload = self.retrieve_payload("Echo", "deploy", local=True)
         package = self.retrieve_payload("Echo", "package", local=True)
         payload["executionUnit"][0] = {"unit": package}
@@ -1012,7 +1012,7 @@ class TestWeaverCLI(TestWeaverClientBase):
         assert any("\"deploymentDone\": true" in line for line in lines)
 
     def test_deploy_payload_file_cwl_embedded(self):
-        test_id = f"{self.test_process_prefix}-deploy-file-no-cwl"
+        test_id = f"{self.test_process_prefix}deploy-file-no-cwl"
         payload = self.retrieve_payload("Echo", "deploy", local=True)
         package = self.retrieve_payload("Echo", "package", local=True, ref_found=True)
         payload["executionUnit"][0] = {"href": package}
@@ -1039,7 +1039,7 @@ class TestWeaverCLI(TestWeaverClientBase):
             assert any("\"deploymentDone\": true" in line for line in lines)
 
     def test_deploy_payload_inject_cwl_body(self):
-        test_id = f"{self.test_process_prefix}-deploy-body-with-cwl-body"
+        test_id = f"{self.test_process_prefix}deploy-body-with-cwl-body"
         payload = self.retrieve_payload("Echo", "deploy", local=True)
         package = self.retrieve_payload("Echo", "package", local=True)
         payload.pop("executionUnit", None)
@@ -1062,7 +1062,7 @@ class TestWeaverCLI(TestWeaverClientBase):
         assert any("\"deploymentDone\": true" in line for line in lines)
 
     def test_deploy_payload_inject_cwl_file(self):
-        test_id = f"{self.test_process_prefix}-deploy-body-with-cwl-file"
+        test_id = f"{self.test_process_prefix}deploy-body-with-cwl-file"
         payload = self.retrieve_payload("Echo", "deploy", local=True)
         package = self.retrieve_payload("Echo", "package", local=True, ref_found=True)
         payload.pop("executionUnit", None)
@@ -1106,7 +1106,7 @@ class TestWeaverCLI(TestWeaverClientBase):
 
         # use both combination of process description to validate resolution
         for i, payload in enumerate([payload_direct, payload_nested]):
-            test_id = f"{self.test_process_prefix}-deploy-body-with-process-info-{i}"
+            test_id = f"{self.test_process_prefix}deploy-body-with-process-info-{i}"
             package = self.retrieve_payload("Echo", "package", local=True)
             package["outputs"]["output"]["format"] = cwl_fmt
             package["$namespaces"] = cwl_ns

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -1518,6 +1518,7 @@ class TestWeaverCLI(TestWeaverClientBase):
         assert "links" not in body
 
     def test_jobs_filter_status_multi(self):
+        self.job_store.clear_jobs()
         job = self.job_store.save_job(task_id=uuid.uuid4(), process="test-process", access=Visibility.PUBLIC)
         job.status = Status.SUCCEEDED
         job_s = self.job_store.update_job(job)

--- a/tests/functional/utils.py
+++ b/tests/functional/utils.py
@@ -26,6 +26,7 @@ from tests.utils import (
 )
 from weaver import WEAVER_ROOT_DIR
 from weaver.database import get_db
+from weaver.datatype import Job
 from weaver.formats import ContentType
 from weaver.processes.constants import ProcessSchema
 from weaver.status import Status
@@ -36,8 +37,7 @@ if TYPE_CHECKING:
     from typing import Any, Dict, Iterable, Optional, Union
     from typing_extensions import Literal
 
-    from weaver.datatype import Job
-    from weaver.typedefs import AnyRequestMethod, AnyResponseType, JSON, SettingsType
+    from weaver.typedefs import AnyRequestMethod, AnyResponseType, AnyUUID, JSON, SettingsType
 
     ReferenceType = Literal["deploy", "describe", "execute", "package"]
 
@@ -163,16 +163,25 @@ class JobUtils(object):
     job_info = None  # type: Iterable[Job]
 
     def message_with_jobs_mapping(self, message="", indent=2):
+        # type: (str, int) -> str
         """
         For helping debugging of auto-generated job ids.
         """
         mapping = OrderedDict(sorted((str(j.task_id), str(j.id)) for j in self.job_store.list_jobs()))
         return f"{message}\nMapping Task-ID/Job-ID:\n{json.dumps(mapping, indent=indent)}"
 
-    def assert_equal_with_jobs_diffs(self, jobs_result, jobs_expect,
-                                     test_values=None, message="", indent=2, index=None, invert=False, jobs=None):
-        jobs_result = [str(job_id) for job_id in jobs_result]
-        jobs_expect = [str(job_id) for job_id in jobs_expect]
+    def assert_equal_with_jobs_diffs(self,
+                                     jobs_result,           # type: Iterable[Union[AnyUUID, Job]]
+                                     jobs_expect,           # type: Iterable[Union[AnyUUID, Job]]
+                                     test_values=None,      # type: Union[JSON, str]
+                                     message="",            # type: str
+                                     indent=2,              # type: int
+                                     index=None,            # type: Optional[int]
+                                     invert=False,          # type: bool
+                                     jobs=None,             # type: Iterable[Job]
+                                     ):                     # type: (...) -> None
+        jobs_result = [str(job.id) if isinstance(job, Job) else str(job) for job in jobs_result]
+        jobs_expect = [str(job.id) if isinstance(job, Job) else str(job) for job in jobs_expect]
         mapping = {str(job.id): str(job.task_id) for job in (jobs or self.job_info)}
         missing = set(jobs_expect) - set(jobs_result)
         unknown = set(jobs_result) - set(jobs_expect)

--- a/tests/processes/test_utils.py
+++ b/tests/processes/test_utils.py
@@ -61,6 +61,14 @@ def test_register_wps_processes_from_config_empty():
             pytest.fail("File with empty 'providers' and 'processes' sections should not raise any error")
 
 
+def test_register_wps_processes_from_config_omitted():
+    with mock.patch("weaver.processes.utils.register_wps_processes_static") as mocked_static:
+        with mock.patch("weaver.processes.utils.register_wps_processes_dynamic") as mocked_dynamic:
+            assert register_wps_processes_from_config({"weaver.wps_processes_file": ""}) is None
+            assert not mocked_static.called
+            assert not mocked_dynamic.called
+
+
 def test_register_wps_processes_from_config_missing():
     try:
         register_wps_processes_from_config({}, "/this/path/des/not/exist")

--- a/tests/resources/__init__.py
+++ b/tests/resources/__init__.py
@@ -1,7 +1,7 @@
 import os
 from typing import TYPE_CHECKING
 
-from weaver import WEAVER_MODULE_DIR
+from weaver import WEAVER_MODULE_DIR, xml_util
 from weaver.utils import load_file
 
 if TYPE_CHECKING:
@@ -59,13 +59,20 @@ WPS_NO_INPUTS_URL = DESCRIBE_PROCESS_TEMPLATE_URL.format(
 )
 
 
-def load_example(file_name, text=False):
-    # type: (str, bool) -> Union[JSON, str]
+def _load_path(file_path, text=False, xml=False):
+    # type: (str, bool, bool) -> Union[JSON, xml_util.XML, str]
+    if xml:
+        return xml_util.parse(file_path)
+    return load_file(file_path, text=text)
+
+
+def load_example(file_name, text=False, xml=False):
+    # type: (str, bool, bool) -> Union[JSON, xml_util.XML, str]
     file_path = os.path.join(EXAMPLES_PATH, file_name)
-    return load_file(file_path, text=text)
+    return _load_path(file_path, text=text, xml=xml)
 
 
-def load_resource(file_name, text=False):
-    # type: (str, bool) -> Union[JSON, str]
+def load_resource(file_name, text=False, xml=False):
+    # type: (str, bool, bool) -> Union[JSON, xml_util.XML, str]
     file_path = os.path.join(RESOURCES_PATH, file_name)
-    return load_file(file_path, text=text)
+    return _load_path(file_path, text=text, xml=xml)

--- a/tests/wps_restapi/test_jobs.py
+++ b/tests/wps_restapi/test_jobs.py
@@ -230,7 +230,10 @@ class WpsRestApiJobsTest(unittest.TestCase):
             ("\nExpected: " + json.dumps(sorted(jobs_expect), indent=indent)) +
             ("\nMissing: " + json.dumps(sorted(f"{job} ({mapping[job]})" for job in missing), indent=indent)) +
             ("\nUnknown: " + json.dumps(sorted(f"{job} ({mapping[job]})" for job in unknown), indent=indent)) +
-            ("\nTesting: " + (test_values if test_values else "")) +
+            ("\nTesting: " + (
+                (json.dumps(test_values, indent=indent) if isinstance(test_values, (dict, list)) else test_values)
+                if test_values else ""
+            )) +
             (self.message_with_jobs_mapping())
         )
 
@@ -1209,7 +1212,6 @@ class WpsRestApiJobsTest(unittest.TestCase):
         result_jobs = resp.json["jobs"]
         self.assert_equal_with_jobs_diffs(result_jobs, expect_jobs, test)
 
-    @pytest.mark.xfail(reason="Multiple statuses not supported")  # FIXME: support comma-separated list of statuses
     def test_get_jobs_by_status_multi(self):
         test = {"status": f"{Status.SUCCEEDED},{Status.RUNNING}"}
         path = get_path_kvp(sd.jobs_service.path, **test)

--- a/tests/wps_restapi/test_jobs.py
+++ b/tests/wps_restapi/test_jobs.py
@@ -16,6 +16,7 @@ import pyramid.testing
 import pytest
 from dateutil import parser as date_parser
 
+from tests.functional.utils import JobUtils
 from tests.resources import load_example
 from tests.utils import (
     get_links,
@@ -29,7 +30,6 @@ from tests.utils import (
     setup_mongodb_processstore,
     setup_mongodb_servicestore
 )
-from tests.functional.utils import JobUtils
 from weaver.datatype import Job, Service
 from weaver.execute import ExecuteMode, ExecuteResponse, ExecuteTransmissionMode
 from weaver.formats import ContentType

--- a/weaver/cli.py
+++ b/weaver/cli.py
@@ -1327,17 +1327,17 @@ class WeaverClient(object):
 
     @copy_doc(_job_info)
     def logs(self, *args, **kwargs):
-        return self._job_info(x_path="/logs", *args, **kwargs)
+        return self._job_info("/logs", *args, **kwargs)
 
     @copy_doc(_job_info)
     def exceptions(self, *args, **kwargs):
-        return self._job_info(x_path="/exceptions", *args, **kwargs)
+        return self._job_info("/exceptions", *args, **kwargs)
 
     errors = exceptions  # alias
 
     @copy_doc(_job_info)
     def statistics(self, *args, **kwargs):
-        return self._job_info(x_path="/statistics", *args, **kwargs)
+        return self._job_info("/statistics", *args, **kwargs)
 
     stats = statistics  # alias
 

--- a/weaver/cli.py
+++ b/weaver/cli.py
@@ -1326,18 +1326,18 @@ class WeaverClient(object):
         return self._parse_result(resp, with_links=with_links, with_headers=with_headers, output_format=output_format)
 
     @copy_doc(_job_info)
-    def logs(self, *args, **kwargs):
-        return self._job_info("/logs", *args, **kwargs)
+    def logs(self, **kwargs):
+        return self._job_info("/logs", **kwargs)
 
     @copy_doc(_job_info)
-    def exceptions(self, *args, **kwargs):
-        return self._job_info("/exceptions", *args, **kwargs)
+    def exceptions(self, **kwargs):
+        return self._job_info("/exceptions", **kwargs)
 
     errors = exceptions  # alias
 
     @copy_doc(_job_info)
-    def statistics(self, *args, **kwargs):
-        return self._job_info("/statistics", *args, **kwargs)
+    def statistics(self, **kwargs):
+        return self._job_info("/statistics", **kwargs)
 
     stats = statistics  # alias
 

--- a/weaver/cli.py
+++ b/weaver/cli.py
@@ -1202,12 +1202,12 @@ class WeaverClient(object):
         :param sort: Sorting field to list jobs. Name must be one of the fields supported by job objects.
         :param page: Paging index to list jobs.
         :param limit: Amount of jobs to list per page.
-        :param status: Filter job listing only to matching status.
+        :param status: Filter job listing only to matching status. If multiple are provided, must match one of them.
         :param detail: Obtain detailed job descriptions.
         :param groups: Obtain grouped representation of jobs per provider and process categories.
         :param process: Obtain jobs executed only by matching :term:`Process`.
         :param provider: Obtain jobs only matching remote :term:`Provider`.
-        :param tags: Obtain jobs filtered by matching tags.
+        :param tags: Obtain jobs filtered by matching tags. Jobs must match all tags simultaneously, not one of them.
         :returns: Retrieved status of the job.
         """
         base_url = self._get_url(url)
@@ -2398,11 +2398,23 @@ def make_parser():
     add_listing_options(op_jobs, item="job")
     op_jobs.add_argument(
         "-S", "--status", dest="status", choices=Status.values(), type=str.lower, nargs="+",
-        help="Filter job listing only to matching status."
+        help="Filter job listing only to matching status. If multiple are provided, must match one of them."
     )
     op_jobs.add_argument(
         "-G", "--groups", dest="groups", action="store_true",
         help="Obtain grouped representation of jobs per provider and process categories."
+    )
+    op_jobs.add_argument(
+        "-fP", "--process", dest="process",
+        help="Filter job listing only to matching process (local and/or remote whether combined with '-fS')."
+    )
+    op_jobs.add_argument(
+        "-fS", "--provider", "--service", dest="provider",
+        help="Filter job listing only to matching remote service provider."
+    )
+    op_jobs.add_argument(
+        "-fT", "--tags", dest="tags", type=str.lower, nargs="+",
+        help="Filter job listing only to matching tags. Jobs must match all tags simultaneously, not one of them."
     )
 
     op_dismiss = WeaverArgumentParser(

--- a/weaver/cli.py
+++ b/weaver/cli.py
@@ -2471,10 +2471,10 @@ def make_parser():
         ),
         formatter_class=ParagraphFormatter,
     )
-    set_parser_sections(op_exceptions)
-    add_url_param(op_exceptions, required=False)
-    add_job_ref_param(op_exceptions)
-    add_shared_options(op_exceptions)
+    set_parser_sections(op_statistics)
+    add_url_param(op_statistics, required=False)
+    add_job_ref_param(op_statistics)
+    add_shared_options(op_statistics)
 
     op_results = WeaverArgumentParser(
         "results",

--- a/weaver/cli.py
+++ b/weaver/cli.py
@@ -1174,7 +1174,7 @@ class WeaverClient(object):
              sort=None,             # type: Optional[Sort]
              page=None,             # type: Optional[int]
              limit=None,            # type: Optional[int]
-             status=None,           # type: Optional[StatusType]
+             status=None,           # type: Optional[Union[StatusType, List[StatusType]]]
              detail=False,          # type: bool
              groups=False,          # type: bool
              process=None,          # type: Optional[str]
@@ -1221,7 +1221,10 @@ class WeaverClient(object):
         if sort is not None:
             query["sort"] = sort
         if isinstance(status, str) and status:
-            query["status"] = map_status(status)
+            status = status.split(",")
+        if isinstance(status, list) and status:
+            status = [map_status(_status) for _status in status]
+            query["status"] = ",".join(status)
         if isinstance(detail, bool) and detail:
             query["detail"] = detail
         if isinstance(groups, bool) and groups:
@@ -2394,7 +2397,7 @@ def make_parser():
     add_shared_options(op_jobs)
     add_listing_options(op_jobs, item="job")
     op_jobs.add_argument(
-        "-S", "--status", dest="status", choices=Status.values(), type=str.lower,
+        "-S", "--status", dest="status", choices=Status.values(), type=str.lower, nargs="+",
         help="Filter job listing only to matching status."
     )
     op_jobs.add_argument(

--- a/weaver/formats.py
+++ b/weaver/formats.py
@@ -463,7 +463,7 @@ def get_content_type(extension, charset=None, default=None):
 
 
 def add_content_type_charset(content_type, charset):
-    # type: (str, Optional[str]) -> str
+    # type: (Union[str, ContentType], Optional[str]) -> str
     """
     Apply the specific charset to the content-type with some validation in case of conflicting definitions.
 

--- a/weaver/processes/execution.py
+++ b/weaver/processes/execution.py
@@ -358,7 +358,7 @@ def collect_statistics(process, settings=None, job=None, rss_start=None):
         if stats and job:
             job.statistics = stats
         return stats or None
-    except Exception as exc:
+    except Exception as exc:  # pragma: no cover
         LOGGER.warning("Ignoring error that occurred during statistics collection [%s]", str(exc), exc_info=exc)
 
 
@@ -375,7 +375,7 @@ def fetch_wps_process(job, wps_url, headers, settings):
         raise OWSNoApplicableCode(f"Failed to retrieve WPS capabilities. Error: [{ex!s}].")
     try:
         wps_process = wps.describeprocess(job.process)
-    except Exception as ex:
+    except Exception as ex:  # pragma: no cover
         raise OWSNoApplicableCode(f"Failed to retrieve WPS process description. Error: [{ex!s}].")
     return wps_process
 
@@ -575,7 +575,7 @@ def submit_job(request, reference, tags=None):
         is_workflow = False
         is_local = False
         tags += "remote"
-    else:
+    else:  # pragma: no cover
         LOGGER.error("Expected process/service, got: %s", type(reference))
         raise TypeError("Invalid process or service reference to execute job.")
     tags = request.params.get("tags", "").split(",") + tags

--- a/weaver/processes/utils.py
+++ b/weaver/processes/utils.py
@@ -1057,7 +1057,7 @@ def register_wps_processes_from_config(container, wps_processes_file_path=None):
             register_wps_processes_dynamic(svc_name, svc_url, svc_vis, container)
 
         LOGGER.info("Finished processing configuration file [%s].", wps_processes_file_path)
-    except Exception as exc:
+    except Exception as exc:  # pragma: no cover
         msg = f"Invalid WPS-1 providers configuration file caused: [{fully_qualified_name(exc)}]({exc!s})."
         LOGGER.exception(msg)
         raise RuntimeError(msg)

--- a/weaver/status.py
+++ b/weaver/status.py
@@ -87,6 +87,7 @@ JOB_STATUS_CATEGORIES = {
 # FIXME: see below detail in map_status about 'successful', partially compliant to OGC statuses
 # https://github.com/opengeospatial/ogcapi-processes/blob/ca8e90/core/openapi/schemas/statusCode.yaml
 JOB_STATUS_CODE_API = JOB_STATUS_CATEGORIES[StatusCompliant.OGC] - {Status.SUCCESSFUL}
+JOB_STATUS_SEARCH_API = set(list(JOB_STATUS_CODE_API) + [str(StatusCategory.FINISHED)])
 
 # id -> str
 STATUS_PYWPS_MAP = {s: _WPS_STATUS._fields[s].lower() for s in range(len(WPS_STATUS))}
@@ -109,7 +110,25 @@ if TYPE_CHECKING:
         Status.EXCEPTION,
         Status.UNKNOWN
     ]
-    AnyStatusType = Union[StatusType, int]
+    AnyStatusType = Union[Status, StatusType, int]
+
+    AnyStatusCategory = Union[
+        StatusCategory,
+        Literal[
+            StatusCategory.RUNNING,
+            StatusCategory.FINISHED,
+            StatusCategory.FAILED,
+        ],
+    ]
+
+    AnyStatusOrCategory = Union[AnyStatusType, AnyStatusCategory]
+
+    AnyStatusSearch = [
+        Status,  # not 'AnyStatusType' to disallow 'int'
+        StatusType,
+        StatusCategory,
+        AnyStatusCategory,
+    ]
 
 
 def map_status(wps_status, compliant=StatusCompliant.OGC):
@@ -135,7 +154,7 @@ def map_status(wps_status, compliant=StatusCompliant.OGC):
         return map_status(STATUS_PYWPS_MAP[wps_status], compliant)
 
     # remove 'Process' from OWSLib statuses and lower for every compliant
-    job_status = wps_status.lower().replace("process", "")
+    job_status = str(wps_status).lower().replace("process", "")
 
     if compliant == StatusCompliant.OGC:
         if job_status in JOB_STATUS_CATEGORIES[StatusCategory.RUNNING]:

--- a/weaver/status.py
+++ b/weaver/status.py
@@ -87,7 +87,7 @@ JOB_STATUS_CATEGORIES = {
 # FIXME: see below detail in map_status about 'successful', partially compliant to OGC statuses
 # https://github.com/opengeospatial/ogcapi-processes/blob/ca8e90/core/openapi/schemas/statusCode.yaml
 JOB_STATUS_CODE_API = JOB_STATUS_CATEGORIES[StatusCompliant.OGC] - {Status.SUCCESSFUL}
-JOB_STATUS_SEARCH_API = set(list(JOB_STATUS_CODE_API) + [str(StatusCategory.FINISHED)])
+JOB_STATUS_SEARCH_API = set(list(JOB_STATUS_CODE_API) + [StatusCategory.FINISHED.value.lower()])
 
 # id -> str
 STATUS_PYWPS_MAP = {s: _WPS_STATUS._fields[s].lower() for s in range(len(WPS_STATUS))}

--- a/weaver/store/base.py
+++ b/weaver/store/base.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
 
     from weaver.datatype import Bill, Job, Process, Quote, Service, VaultFile
     from weaver.execute import AnyExecuteResponse
+    from weaver.status import AnyStatusSearch
     from weaver.typedefs import (
         AnyUUID,
         AnyVersion,
@@ -186,7 +187,7 @@ class StoreJobs(StoreInterface):
                   tags=None,                # type: Optional[List[str]]
                   access=None,              # type: Optional[str]
                   notification_email=None,  # type: Optional[str]
-                  status=None,              # type: Optional[str]
+                  status=None,              # type: Optional[AnyStatusSearch, List[AnyStatusSearch]]
                   sort=None,                # type: Optional[str]
                   page=0,                   # type: Optional[int]
                   limit=10,                 # type: Optional[int]

--- a/weaver/store/mongodb.py
+++ b/weaver/store/mongodb.py
@@ -998,6 +998,8 @@ class MongodbJobStore(StoreJobs, MongodbStore, ListingMixin):
     @staticmethod
     def _apply_tags_filter(tags):
         # type: (Optional[Union[str, List[str]]]) -> MongodbAggregateExpression
+        if not tags:
+            return {}
         bad_tags = [vis for vis in Visibility.values() if vis in tags]
         if any(bad_tags):
             raise JobInvalidParameter(json={

--- a/weaver/store/mongodb.py
+++ b/weaver/store/mongodb.py
@@ -1081,7 +1081,7 @@ class MongodbJobStore(StoreJobs, MongodbStore, ListingMixin):
                     statuses.add(_status)
             search_filters["status"] = {"$in": list(statuses)}  # type: ignore
         elif status:
-            search_filters["status"] = status
+            search_filters["status"] = status[0]
         return search_filters
 
     @staticmethod

--- a/weaver/store/mongodb.py
+++ b/weaver/store/mongodb.py
@@ -925,7 +925,7 @@ class MongodbJobStore(StoreJobs, MongodbStore, ListingMixin):
 
         search_filters.update(self._apply_status_filter(status))
         search_filters.update(self._apply_ref_or_type_filter(job_type, process, service))
-        search_filters.update(self._apply_tags_filter(tags, request))
+        search_filters.update(self._apply_tags_filter(tags))
         search_filters.update(self._apply_access_filter(access, request))
         search_filters.update(self._apply_datetime_filter(datetime_interval))
 
@@ -997,6 +997,7 @@ class MongodbJobStore(StoreJobs, MongodbStore, ListingMixin):
 
     @staticmethod
     def _apply_tags_filter(tags):
+        # type: (Optional[Union[str, List[str]]]) -> MongodbAggregateExpression
         bad_tags = [vis for vis in Visibility.values() if vis in tags]
         if any(bad_tags):
             raise JobInvalidParameter(json={

--- a/weaver/store/mongodb.py
+++ b/weaver/store/mongodb.py
@@ -41,7 +41,7 @@ from weaver.execute import ExecuteMode
 from weaver.formats import repr_json
 from weaver.processes.types import ProcessType
 from weaver.sort import Sort, SortMethods
-from weaver.status import JOB_STATUS_CATEGORIES, Status, map_status
+from weaver.status import JOB_STATUS_CATEGORIES, Status, StatusCategory, map_status
 from weaver.store.base import StoreBills, StoreJobs, StoreProcesses, StoreQuotes, StoreServices, StoreVault
 from weaver.utils import (
     VersionFormat,
@@ -1072,11 +1072,12 @@ class MongodbJobStore(StoreJobs, MongodbStore, ListingMixin):
             return search_filters
         if not isinstance(status, list):
             status = [status]
-        if any(_status in JOB_STATUS_CATEGORIES for _status in status) or len(status) > 1:
+        if any(_status in StatusCategory for _status in status) or len(status) > 1:
             statuses = set()
             for _status in status:
-                if _status in JOB_STATUS_CATEGORIES:
-                    statuses.union(JOB_STATUS_CATEGORIES[status])
+                if _status in StatusCategory:
+                    category_status = JOB_STATUS_CATEGORIES[StatusCategory[_status]]
+                    statuses = statuses.union(category_status)
                 else:
                     statuses.add(_status)
             search_filters["status"] = {"$in": list(statuses)}  # type: ignore

--- a/weaver/store/mongodb.py
+++ b/weaver/store/mongodb.py
@@ -925,6 +925,7 @@ class MongodbJobStore(StoreJobs, MongodbStore, ListingMixin):
 
         search_filters.update(self._apply_status_filter(status))
         search_filters.update(self._apply_ref_or_type_filter(job_type, process, service))
+        search_filters.update(self._apply_tags_filter(tags, request))
         search_filters.update(self._apply_access_filter(access, request))
         search_filters.update(self._apply_datetime_filter(datetime_interval))
 

--- a/weaver/utils.py
+++ b/weaver/utils.py
@@ -2172,3 +2172,22 @@ def parse_number_with_unit(number, binary=None):
     except (AttributeError, KeyError, ValueError, TypeError):
         raise ValueError(f"Invalid number with optional unit string could not be parsed: [{number!s}]")
     return val
+
+
+def copy_doc(copy_func):
+    # type: (AnyCallableAnyArgs) -> AnyCallableAnyArgs
+    """
+    Decorator to copy the docstring from one callable to another.
+
+    .. code-block:: python
+
+        copy_doc(self.copy_func)(self.func)
+
+        @copy_doc(func)
+        def copy_func(self): pass
+    """
+    def wrapper(func):
+        # type: (AnyCallableAnyArgs) -> AnyCallableAnyArgs
+        func.__doc__ = copy_func.__doc__
+        return func
+    return wrapper

--- a/weaver/wps_restapi/colander_extras.py
+++ b/weaver/wps_restapi/colander_extras.py
@@ -198,6 +198,26 @@ class OneOfCaseInsensitive(colander.OneOf):
             return super(OneOfCaseInsensitive, self).__call__(node, value)
 
 
+class StringOneOf(colander.OneOf):
+    """
+    Validator that ensures the given value matches one of the available choices, but defined by string delimited values.
+    """
+
+    def __init__(self, choices, delimiter=",", case_sensitive=True, **kwargs):
+        # type: (Iterable[str], str, str, Any) -> None
+        self._delim = delimiter
+        if not case_sensitive:
+            choices = OneOfCaseInsensitive(choices).choices
+        super(StringOneOf, self).__init__(choices, **kwargs)
+
+    def __call__(self, node, value):
+        # type: (colander.SchemaNode, Any) -> None
+        if not isinstance(value, str):
+            super(StringOneOf, self).__call__(node, value)  # raise accordingly
+        for val in value.split(self._delim):
+            super(StringOneOf, self).__call__(node, val)  # raise accordingly
+
+
 class BoundedRange(colander.Range):
     """
     Validator of value within range with added ``exclusive`` bounds support.

--- a/weaver/wps_restapi/colander_extras.py
+++ b/weaver/wps_restapi/colander_extras.py
@@ -204,7 +204,7 @@ class StringOneOf(colander.OneOf):
     """
 
     def __init__(self, choices, delimiter=",", case_sensitive=True, **kwargs):
-        # type: (Iterable[str], str, str, Any) -> None
+        # type: (Iterable[str], str, bool, Any) -> None
         self._delim = delimiter
         if not case_sensitive:
             choices = OneOfCaseInsensitive(choices).choices

--- a/weaver/wps_restapi/jobs/jobs.py
+++ b/weaver/wps_restapi/jobs/jobs.py
@@ -75,6 +75,7 @@ def get_queried_jobs(request):
     detail = filters.pop("detail", False)
     groups = filters.pop("groups", "").split(",") if filters.get("groups", False) else filters.pop("groups", None)
 
+    filters["status"] = filters["status"].split(",") if "status" in filters else None
     filters["tags"] = list(filter(lambda s: s, filters["tags"].split(",") if filters.get("tags", False) else ""))
     filters["notification_email"] = (
         encrypt_email(filters["notification_email"], settings)

--- a/weaver/wps_restapi/swagger_definitions.py
+++ b/weaver/wps_restapi/swagger_definitions.py
@@ -1687,7 +1687,7 @@ class JobStatusSearchEnum(ExtendedSchemaNode):
     title = "JobStatusSearch"
     default = Status.ACCEPTED
     example = Status.ACCEPTED
-    validator = StringOneOf(JOB_STATUS_SEARCH_API, delimiter=",")
+    validator = StringOneOf(JOB_STATUS_SEARCH_API, delimiter=",", case_sensitive=False)
 
 
 class JobTypeEnum(ExtendedSchemaNode):

--- a/weaver/wps_restapi/swagger_definitions.py
+++ b/weaver/wps_restapi/swagger_definitions.py
@@ -47,7 +47,7 @@ from weaver.processes.constants import (
 )
 from weaver.quotation.status import QuoteStatus
 from weaver.sort import Sort, SortMethods
-from weaver.status import JOB_STATUS_CODE_API, Status
+from weaver.status import JOB_STATUS_CODE_API, JOB_STATUS_SEARCH_API, Status
 from weaver.visibility import Visibility
 from weaver.wps_restapi.colander_extras import (
     AllOfKeywordSchema,
@@ -68,6 +68,7 @@ from weaver.wps_restapi.colander_extras import (
     PermissiveSequenceSchema,
     SchemeURL,
     SemanticVersion,
+    StringOneOf,
     StringRange,
     XMLObject
 )
@@ -1679,6 +1680,14 @@ class JobStatusEnum(ExtendedSchemaNode):
     default = Status.ACCEPTED
     example = Status.ACCEPTED
     validator = OneOf(JOB_STATUS_CODE_API)
+
+
+class JobStatusSearchEnum(ExtendedSchemaNode):
+    schema_type = String
+    title = "JobStatusSearch"
+    default = Status.ACCEPTED
+    example = Status.ACCEPTED
+    validator = StringOneOf(JOB_STATUS_SEARCH_API, delimiter=",")
 
 
 class JobTypeEnum(ExtendedSchemaNode):
@@ -4610,7 +4619,8 @@ class GetJobsQueries(ExtendedMappingSchema):
         Integer(allow_string=True), name="maxDuration", missing=drop, default=null, validator=Range(min=0),
         description="Maximum duration (seconds) between started time and current/finished time of jobs to find.")
     datetime = DateTimeInterval(missing=drop, default=None)
-    status = JobStatusEnum(missing=drop, default=None)
+    status = JobStatusSearchEnum(description="One of more comma-separated statuses to filter jobs.",
+                                 missing=drop, default=None)
     processID = ProcessIdentifierTag(missing=drop, default=null,
                                      description="Alias to 'process' for OGC-API compliance.")
     process = ProcessIdentifierTag(missing=drop, default=None,
@@ -4623,7 +4633,7 @@ class GetJobsQueries(ExtendedMappingSchema):
     access = JobAccess(missing=drop, default=None)
     notification_email = ExtendedSchemaNode(String(), missing=drop, validator=Email())
     tags = ExtendedSchemaNode(String(), missing=drop, default=None,
-                              description="Comma-separated values of tags assigned to jobs")
+                              description="Comma-separated values of tags assigned to jobs.")
 
 
 class GetProcessJobsQuery(LocalProcessQuery, GetJobsQueries):


### PR DESCRIPTION
Changes:
--------
- Add `CLI` and `WeaverClient` support of ``logs``, ``exceptions`` and ``statistics`` retrieval.
- Add `CLI` and `WeaverClient` support of `Job` search filtered by ``tags``, ``process`` and ``providers`` queries.
- Add `CLI` and `WeaverClient` support of `Job` search filtered by multiple ``status`` values.

Fixes:
------
- Fix ``tags`` query parameter not applied to filter `Job` search requests.