### PR TITLE
fix wps-output-context not used for wps xml status and job log files

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,8 @@ Fixes:
 - Fix implementation of functional ``DockerRequirement`` test cases for `Process` deployment when references are
   provided by ``href`` within the ``executionUnit`` or ``owsContext``
   (relates to `#11 <https://github.com/crim-ca/weaver/issues/11>`_).
+- Fix ``weaver.wps_output_context`` sub-directory resolved from default settings or ``X-WPS-Output-Context`` request
+  header not employed for storing the `XML` status location and `Job` log files next to the `Job` outputs directory.
 
 .. _changes_4.22.0:
 

--- a/weaver/processes/wps_package.py
+++ b/weaver/processes/wps_package.py
@@ -184,6 +184,8 @@ def retrieve_package_job_log(execution, job, progress_min=0, progress_max=100):
     try:
         # weaver package log every status update into this file (we no longer rely on the http monitoring)
         out_dir = get_wps_output_dir(get_settings())
+        if job.context:
+            out_dir = os.path.join(out_dir, job.context)
         # if the process is a weaver package this status xml should be available in the process output dir
         log_path = get_status_location_log_path(execution.statusLocation, out_dir=out_dir)
         with open(log_path, mode="r", encoding="utf-8") as log_file:
@@ -904,6 +906,7 @@ class WpsPackage(Process):
         self.request = None                  # type: Optional[WorkerRequest]
         self.response = None                 # type: Optional[ExecuteResponse]
         self._job = None                     # type: Optional[Job]
+        self._job_status_file = None         # type: Optional[str]
 
         self.payload = payload
         self.package = package
@@ -931,6 +934,23 @@ class WpsPackage(Process):
             status_supported=True,
             **kw
         )
+
+    @property
+    def status_filename(self):
+        # type: () -> str
+        """
+        Obtain the XML status location of this process when executed.
+
+        The status location applies the ``WPS-Output-Context`` if defined such that any following output
+        or log file references that derive from it will be automatically stored in the same nested context.
+        """
+        if self._job_status_file:
+            return self._job_status_file
+        status_file = super(WpsPackage, self).status_filename
+        if self.job.context:
+            status_file = os.path.join(self.job.context, status_file)
+        self._job_status_file = status_file
+        return status_file
 
     def setup_loggers(self, log_stdout_stderr=True):
         # type: (bool) -> None

--- a/weaver/processes/wps_package.py
+++ b/weaver/processes/wps_package.py
@@ -104,7 +104,7 @@ from weaver.vault.utils import (
     map_vault_location,
     parse_vault_token
 )
-from weaver.wps.service import ReferenceStatusLocationStorage
+from weaver.wps.storage import ReferenceStatusLocationStorage
 from weaver.wps.utils import get_wps_output_dir, get_wps_output_url, map_wps_output_location
 from weaver.wps_restapi import swagger_definitions as sd
 

--- a/weaver/processes/wps_package.py
+++ b/weaver/processes/wps_package.py
@@ -104,6 +104,7 @@ from weaver.vault.utils import (
     map_vault_location,
     parse_vault_token
 )
+from weaver.wps.service import ReferenceStatusLocationStorage
 from weaver.wps.utils import get_wps_output_dir, get_wps_output_url, map_wps_output_location
 from weaver.wps_restapi import swagger_definitions as sd
 
@@ -945,6 +946,11 @@ class WpsPackage(Process):
         or log file references that derive from it will be automatically stored in the same nested context.
         """
         if self._job_status_file:
+            return self._job_status_file
+        # avoid error in case process execution is a remote provider (eg: during workflow step)
+        # file is already defined in a specific location and cannot be moved
+        if isinstance(self.status_store, ReferenceStatusLocationStorage):
+            self._job_status_file = self.status_store.location()
             return self._job_status_file
         status_file = super(WpsPackage, self).status_filename
         if self.job.context:

--- a/weaver/processes/wps_package.py
+++ b/weaver/processes/wps_package.py
@@ -948,6 +948,8 @@ class WpsPackage(Process):
             return self._job_status_file
         status_file = super(WpsPackage, self).status_filename
         if self.job.context:
+            status_store_ctx_dir = os.path.join(self.status_store.target, self.job.context)
+            os.makedirs(status_store_ctx_dir, exist_ok=True)
             status_file = os.path.join(self.job.context, status_file)
         self._job_status_file = status_file
         return status_file

--- a/weaver/wps/service.py
+++ b/weaver/wps/service.py
@@ -9,7 +9,6 @@ from pyramid.httpexceptions import HTTPBadRequest, HTTPSeeOther
 from pyramid.request import Request as PyramidRequest
 from pywps.app import Process as ProcessWPS, WPSRequest
 from pywps.app.Service import Service as ServiceWPS
-from pywps.inout.storage import StorageAbstract
 from pywps.response import WPSResponse
 from pywps.response.execute import ExecuteResponse
 from requests.structures import CaseInsensitiveDict
@@ -27,6 +26,7 @@ from weaver.processes.utils import get_process
 from weaver.store.base import StoreProcesses
 from weaver.utils import extend_instance, get_header, get_registry, get_settings, get_weaver_url
 from weaver.visibility import Visibility
+from weaver.wps.storage import ReferenceStatusLocationStorage
 from weaver.wps.utils import (
     check_wps_status,
     get_wps_local_status_location,
@@ -55,42 +55,11 @@ if TYPE_CHECKING:
     )
 
 
-class ReferenceStatusLocationStorage(StorageAbstract):
-    """
-    Simple storage that simply redirects to a pre-existing status location.
-    """
-    # pylint: disable=W0222  # ignore mismatch signature of method params not employed
-
-    def __init__(self, url_location, settings):
-        # type: (str, SettingsType) -> None
-        self._url = url_location
-        # location might not exist yet based on worker execution timing
-        self._file = get_wps_local_status_location(url_location, settings, must_exist=False)
-
-    def url(self, *_, **__):
-        """
-        URL location of the XML status file.
-        """
-        return self._url
-
-    def location(self, *_, **__):
-        """
-        Directory location of the XML status file.
-        """
-        return self._file
-
-    def store(self, *_, **__):
-        pass
-
-    def write(self, *_, **__):
-        pass
-
-
 class WorkerRequest(WPSRequest):
     """
     Extended :mod:`pywps` request with additional handling provided by :mod:`weaver`.
     """
-    _auth_headers = CaseInsensitiveDict({  # take advantage of case insensitive only, value don't care
+    _auth_headers = CaseInsensitiveDict({  # take advantage of case-insensitive only, value don't care
         "Authorization": None,
         "X-Auth": None,
         sd.XAuthVaultFileHeader.name: None,

--- a/weaver/wps/storage.py
+++ b/weaver/wps/storage.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from typing import TYPE_CHECKING
+
+from pywps.inout.storage import StorageAbstract
+
+from weaver.wps.utils import get_wps_local_status_location
+
+if TYPE_CHECKING:
+    from weaver.typedefs import SettingsType
+
+
+class ReferenceStatusLocationStorage(StorageAbstract):
+    """
+    Simple storage that simply redirects to a pre-existing status location.
+    """
+    # pylint: disable=W0222  # ignore mismatch signature of method params not employed
+
+    def __init__(self, url_location, settings):
+        # type: (str, SettingsType) -> None
+        self._url = url_location
+        # location might not exist yet based on worker execution timing
+        self._file = get_wps_local_status_location(url_location, settings, must_exist=False)
+
+    def url(self, *_, **__):
+        """
+        URL location of the XML status file.
+        """
+        return self._url
+
+    def location(self, *_, **__):
+        """
+        Directory location of the XML status file.
+        """
+        return self._file
+
+    def store(self, *_, **__):
+        pass
+
+    def write(self, *_, **__):
+        pass

--- a/weaver/wps/utils.py
+++ b/weaver/wps/utils.py
@@ -125,7 +125,7 @@ def get_wps_output_context(request):
     """
     Obtains and validates allowed values for sub-directory context of WPS outputs in header ``X-WPS-Output-Context``.
 
-    :raises HTTPUnprocessableEntity: if the header was provided an contains invalid or illegal value.
+    :raises HTTPUnprocessableEntity: if the header was provided and contains invalid or illegal value.
     :returns: validated context or None if not specified.
     """
     headers = getattr(request, "headers", {})


### PR DESCRIPTION
- Fix ``weaver.wps_output_context`` sub-directory resolved from default settings or ``X-WPS-Output-Context`` request
  header not employed for storing the `XML` status location and `Job` log files next to the `Job` outputs directory.