### PR TITLE
remove pyproj with owslib==0.27.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -111,28 +111,6 @@ jobs:
           # note: '22' is v8, '21' is v7
           path: /tmp/proj-8.2.1/install
           key: ${{ runner.os }}-python${{ matrix.python-version }}-proj
-      - name: Install Proj Lib Prerequisite
-        if: |
-          steps.python-semver.outputs.major == 3 &&
-          steps.python-semver.outputs.minor >= 10 &&
-          steps.cache-proj.outputs.cache-hit != 'true'
-        env:
-          PROJ_CACHE_HIT: ${{ steps.cache-proj.outputs.cache-hit }}
-        # copy install instead of direct install to avoid cache permission denied
-        run: |
-          if [[ "${PROJ_CACHE_HIT}" != 'true' ]]; then
-            sudo apt-get install -y cmake libcurl4-openssl-dev libsqlite3-dev
-            cd /tmp/
-            wget https://download.osgeo.org/proj/proj-8.2.1.tar.gz
-            tar -xzf proj-8.2.1.tar.gz
-            mkdir proj-8.2.1/install
-            mkdir proj-8.2.1/build
-            cd proj-8.2.1/build
-            cmake -DCMAKE_INSTALL_PREFIX=/tmp/proj-8.2.1/install -DBUILD_TESTING=OFF ..
-            make install -j $(nproc)
-          fi
-          echo "PROJ_DIR=/usr/local" >> $GITHUB_ENV
-          sudo cp --verbose --force --recursive /tmp/proj-8.2.1/install/* /usr/local/
       - name: Install Dependencies
         # skip python setup if running with docker
         if: ${{ matrix.test-case != 'test-docker' }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,12 +48,10 @@ lxml
 mako
 # esgf-compute-api (cwt) needs oauthlib but doesn't add it in their requirements
 oauthlib
-owslib==0.27.1
+owslib==0.27.2
 psutil
 # FIXME: pymongo>=4 breaks with kombu corresponding to pinned Celery (https://github.com/crim-ca/weaver/issues/386)
 pymongo>=3.12.0,<4
-# pyproj>=2 employed by OWSLib, but make requirements stricter
-pyproj>=3
 pyramid>=1.7.3
 pyramid_beaker>=0.8
 pyramid_celery>=4.0.0   # required for celery>=5


### PR DESCRIPTION
Since the dependency is not needed anymore, we can reduce the test worker setup time as well as the resulting docker image.

Relates to #459

