### PR TITLE
fix OpenAPI Spec generation from cornice-swagger with 3.x schema

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,11 +12,18 @@ Changes
 
 Changes:
 --------
-- No change.
+- Return ``Content-Type: application/vnd.oai.openapi+json; version=3.0`` for OpenAPI endpoint response referenced
+  by ``service-desc`` in the API conformance details, as specified by
+  `OGC API - Processes - OpenAPI 3.0 requirement class <https://docs.ogc.org/is/18-062r2/18-062r2.html#toc43>`_.
+- Support the generation of external schema references (``$ref``) using the ``schema_ref`` attribute if provided
+  in a ``colander.SchemaNode`` that does not provide an explicit object schema definition with properties.
+- Add Python typing definitions related to OpenAPI specification.
 
 Fixes:
 ------
-- No change.
+- Fix invalid generation of OpenAPI 3.0 specification for `Weaver` API using ``cornice_swagger``.
+  The generated schema structure used to return a mix of Swagger 2.0 and OpenAPI 3.0 definitions.
+  The provided contents are now defined completely with OpenAPI 3.0 specification format.
 
 .. _changes_4.25.0:
 

--- a/tests/wps_restapi/test_api.py
+++ b/tests/wps_restapi/test_api.py
@@ -36,7 +36,7 @@ class GenericApiRoutesTestCase(unittest.TestCase):
         # override media-type with alternative representations for specific rel links
         expect_ctype = {
             "service-desc": ContentType.APP_OAS_JSON,
-            "OpenAPI":  ContentType.APP_OAS_JSON,
+            "OpenAPI": ContentType.APP_OAS_JSON,
         }
         # FIXME: patch broken content-type from reference websites
         #  (see https://github.com/opengeospatial/NamingAuthority/issues/183)

--- a/tests/wps_restapi/test_api.py
+++ b/tests/wps_restapi/test_api.py
@@ -32,6 +32,18 @@ class GenericApiRoutesTestCase(unittest.TestCase):
             self.fail(f"expected valid response format as defined in schema [{ex!s}] in\n{body}")
         refs = [link["rel"] for link in body["links"]]
         assert len(body["links"]) == len(set(refs)), "Link relationships must all be unique"
+
+        # override media-type with alternative representations for specific rel links
+        expect_ctype = {
+            "service-desc": ContentType.APP_OAS_JSON,
+            "OpenAPI":  ContentType.APP_OAS_JSON,
+        }
+        # FIXME: patch broken content-type from reference websites
+        #  (see https://github.com/opengeospatial/NamingAuthority/issues/183)
+        ctype_header_links = {
+            "http://schemas.opengis.net/wps/": ContentType.APP_XML
+        }
+
         for link in body["links"]:
             path = link["href"]
             rtype = link["type"]
@@ -40,6 +52,10 @@ class GenericApiRoutesTestCase(unittest.TestCase):
             else:
                 rtype = [rtype]
             rel = link["rel"]
+            exact = False
+            if rel in expect_ctype:
+                exact = True
+                rtype = [expect_ctype[rel]]
 
             # request endpoint to validate it is accessible
             if "localhost" in path:
@@ -57,12 +73,9 @@ class GenericApiRoutesTestCase(unittest.TestCase):
             test = f"({rel}) [{path}]"
             assert code in [200, 400], f"Reference link expected to be found, got [{code}] for {test}"
 
-            # FIXME: patch broken content-type from reference websites
-            #  (see https://github.com/opengeospatial/NamingAuthority/issues/183)
-            ctype_header_links = {
-                "http://schemas.opengis.net/wps/": ContentType.APP_XML
-            }
-            ctype = resp.headers.get("Content-Type", "").split(";")[0].strip()
+            ctype = resp.headers.get("Content-Type", "")
+            if not exact:
+                ctype = ctype.split(";")[0].strip()
             if not ctype:
                 for ref_link in ctype_header_links:
                     if path.startswith(ref_link):

--- a/tests/wps_restapi/test_jobs.py
+++ b/tests/wps_restapi/test_jobs.py
@@ -887,8 +887,8 @@ class WpsRestApiJobsTest(unittest.TestCase, JobUtils):
         uri = sd.openapi_json_service.path
         resp = self.app.get(uri, headers=self.json_headers)
         schema_prefix = sd.GetProcessJobsQuery.__name__
-        assert not resp.json["parameters"][f"{schema_prefix}.page"]["required"]
-        assert not resp.json["parameters"][f"{schema_prefix}.limit"]["required"]
+        assert not resp.json["components"]["parameters"][f"{schema_prefix}.page"]["required"]
+        assert not resp.json["components"]["parameters"][f"{schema_prefix}.limit"]["required"]
 
     def test_get_jobs_filter_by_tags_single(self):
         path = get_path_kvp(sd.jobs_service.path, tags="unique", detail=False)

--- a/weaver/formats.py
+++ b/weaver/formats.py
@@ -52,6 +52,7 @@ class ContentType(Constants):
     APP_GZIP = "application/gzip"
     APP_HDF5 = "application/x-hdf5"
     APP_JSON = "application/json"
+    APP_OAS_JSON = "application/vnd.oai.openapi+json; version=3.0"
     APP_OGC_PKG_JSON = "application/ogcapppkg+json"
     APP_OGC_PKG_YAML = "application/ogcapppkg+yaml"
     APP_NETCDF = "application/x-netcdf"

--- a/weaver/typedefs.py
+++ b/weaver/typedefs.py
@@ -516,3 +516,79 @@ if TYPE_CHECKING:
         OpenAPISchemaReference,
         OpenAPISchemaMetadata,
     ]
+    OpenAPISpecLicence = TypedDict("OpenAPISpecLicence", {
+        "name": str,
+        "url": str,
+    }, total=True)
+    OpenAPISpecContact = TypedDict("OpenAPISpecContact", {
+        "name": str,
+        "email": str,
+        "url": str,
+    }, total=True)
+    OpenAPISpecInfo = TypedDict("OpenAPISpecInfo", {
+        "description": NotRequired[str],
+        "licence": OpenAPISpecLicence,
+        "contact": OpenAPISpecContact,
+        "title": str,
+        "version": str,
+    }, total=True)
+    OpenAPISpecContent = TypedDict("OpenAPISpecContent", {
+        "schema": OpenAPISchema,
+    }, total=True)
+    OpenAPISpecResponse = TypedDict("OpenAPISpecResponse", {
+        "summary": NotRequired[str],
+        "description": NotRequired[str],
+        "content": Dict[str, OpenAPISpecContent],  # Media-Type keys
+    }, total=True)
+    OpenAPISpecPath = TypedDict("OpenAPISpecPath", {
+        "responses": Dict[str, OpenAPISpecResponse],  # HTTP code keys
+        "parameters": List[OpenAPISchema],
+        "summary": str,
+        "description": str,
+        "tags": List[str],
+    }, total=True)
+    OpenAPISpecPathMethods = TypedDict("OpenAPISpecPathMethods", {
+        "head": NotRequired[OpenAPISpecPath],
+        "get": NotRequired[OpenAPISpecPath],
+        "post": NotRequired[OpenAPISpecPath],
+        "put": NotRequired[OpenAPISpecPath],
+        "patch": NotRequired[OpenAPISpecPath],
+        "delete": NotRequired[OpenAPISpecPath],
+        "options": NotRequired[OpenAPISpecPath],
+    }, total=True)
+    OpenAPISpecContent
+    OpenAPISpecParameter = TypedDict("OpenAPISpecParameter", {
+        "name": str,
+        "in": Literal["header", "cookie", "query", "path", "body"],
+        "required": bool,
+        "allowReserved": NotRequired[bool],
+        "default": NotRequired[JSON],   # Swagger 2.0, OpenAPI 3.0: nest under 'schema'
+        "summary": NotRequired[str],
+        "description": NotRequired[str],
+        "type": NotRequired[str],  # Swagger 2.0
+        "schema": OpenAPISchema,   # OpenAPI 3.0, 'content' alternative available
+        "content": NotRequired[Dict[str, OpenAPISpecContent]],  # Media-Type keys
+    }, total=True)
+    OpenAPISpecComponents = TypedDict("OpenAPISpecComponents", {
+        "schemas": NotRequired[Dict[str, OpenAPISchema]],               # $ref object name as keys
+        "parameters": NotRequired[Dict[str, OpenAPISpecParameter]],     # $ref object name as keys
+        "responses": NotRequired[Dict[str, OpenAPISpecResponse]],       # $ref object name as keys
+    }, total=True)
+    OpenAPISpecExternalDocs = TypedDict("OpenAPISpecExternalDocs", {
+        "description": str,
+        "url": str,
+    }, total=True)
+    OpenAPISpecification = TypedDict("OpenAPISpecification", {
+        "openapi": Literal["3.0.0"],
+        "info": OpenAPISpecInfo,
+        "basePath": str,
+        "host": str,
+        "schemes": List[str],
+        "tags": List[str],
+        "paths": Dict[str, OpenAPISpecPathMethods],     # API path keys nested with HTTP methods
+        "components": OpenAPISpecComponents,            # OpenAPI 3.0, nested sections with $ref object name as keys
+        "definitions": NotRequired[Dict[str, OpenAPISchema]],        # Swagger 2.0, OpenAPI 3.0: 'components/schemas'
+        "parameters": NotRequired[Dict[str, OpenAPISpecParameter]],  # Swagger 2.0, OpenAPI 3.0: 'components/parameters'
+        "responses": NotRequired[Dict[str, OpenAPISpecResponse]],    # Swagger 2.0, OpenAPI 3.0: 'components/responses'
+        "externalDocs": NotRequired[OpenAPISpecExternalDocs],
+    }, total=True)

--- a/weaver/wps_restapi/api.py
+++ b/weaver/wps_restapi/api.py
@@ -32,7 +32,7 @@ from weaver.wps_restapi.constants import ConformanceCategory
 from weaver.wps_restapi.utils import get_wps_restapi_base_url, wps_restapi_base_path
 
 if TYPE_CHECKING:
-    from typing import Callable, List, Optional
+    from typing import Any, Callable, List, Optional
 
     from weaver.typedefs import JSON, OpenAPISpecification, SettingsType, TypedDict
     from weaver.wps_restapi.constants import AnyConformanceCategory
@@ -620,13 +620,14 @@ def get_openapi_json(http_scheme="http", http_host="localhost", base_url=None,
 
 @cache_region("doc", sd.openapi_json_service.name)
 def openapi_json_cached(*args, **kwargs):
+    # type: (*Any, **Any) -> OpenAPISpecification
     return get_openapi_json(*args, **kwargs)
 
 
-@sd.openapi_json_service.get(tags=[sd.TAG_API], renderer=OutputFormat.JSON, content_type=ContentType.APP_OAS_JSON,
+@sd.openapi_json_service.get(tags=[sd.TAG_API], renderer=OutputFormat.JSON,
                              schema=sd.OpenAPIEndpoint(), response_schemas=sd.get_openapi_json_responses)
 def openapi_json(request):  # noqa: F811
-    # type: (Request) -> OpenAPISpecification
+    # type: (Request) -> HTTPException
     """
     Weaver OpenAPI schema definitions.
     """
@@ -636,7 +637,8 @@ def openapi_json(request):  # noqa: F811
     weaver_server_url = get_weaver_url(settings)
     LOGGER.debug("Request app URL:   [%s]", request.url)
     LOGGER.debug("Weaver config URL: [%s]", weaver_server_url)
-    return openapi_json_cached(base_url=weaver_server_url, use_docstring_summary=True, settings=settings)
+    spec = openapi_json_cached(base_url=weaver_server_url, use_docstring_summary=True, settings=settings)
+    return HTTPOk(json=spec, content_type=ContentType.APP_OAS_JSON)
 
 
 @cache_region("doc", sd.api_swagger_ui_service.name)

--- a/weaver/wps_restapi/colander_extras.py
+++ b/weaver/wps_restapi/colander_extras.py
@@ -62,10 +62,10 @@ from cornice_swagger.converters.exceptions import ConversionError, NoSuchConvert
 from cornice_swagger.converters.parameters import (
     BodyParameterConverter,
     HeaderParameterConverter,
-    PathParameterConverter,
-    ParameterConverter,
     ParameterConversionDispatcher,
-    QueryParameterConverter,
+    ParameterConverter,
+    PathParameterConverter,
+    QueryParameterConverter
 )
 from cornice_swagger.converters.schema import (
     STRING_FORMATTERS,

--- a/weaver/wps_restapi/colander_extras.py
+++ b/weaver/wps_restapi/colander_extras.py
@@ -59,6 +59,14 @@ from typing import TYPE_CHECKING
 
 import colander
 from cornice_swagger.converters.exceptions import ConversionError, NoSuchConverter
+from cornice_swagger.converters.parameters import (
+    BodyParameterConverter,
+    HeaderParameterConverter,
+    PathParameterConverter,
+    ParameterConverter,
+    ParameterConversionDispatcher,
+    QueryParameterConverter,
+)
 from cornice_swagger.converters.schema import (
     STRING_FORMATTERS,
     NumberTypeConverter,
@@ -69,9 +77,16 @@ from cornice_swagger.converters.schema import (
     convert_range_validator,
     convert_regex_validator
 )
+from cornice_swagger.swagger import CorniceSwagger, DefinitionHandler, ParameterHandler, ResponseHandler
 
 if TYPE_CHECKING:
     from typing import Any, Dict, Iterable, Optional, Sequence, Type, Union
+    from typing_extensions import Literal
+
+    from cornice import Service as CorniceService
+    from pyramid.registry import Registry
+
+    from weaver.typedefs import JSON, OpenAPISchema, OpenAPISpecification, OpenAPISpecInfo, OpenAPISpecParameter
 
 # pylint: disable=C0209,consider-using-f-string
 
@@ -2266,3 +2281,133 @@ class OAS3TypeConversionDispatcher(TypeConversionDispatcher):
             converted["xml"] = xml
 
         return converted
+
+
+class OAS3ParameterConverter(ParameterConverter):
+    reserved_params = [
+        "name",
+        "in",
+        "required",
+        "allowReserved",
+        "summary",
+        "description",
+        "schema",
+        "content",
+    ]
+
+    def convert(self, schema_node, definition_handler):
+        # type: (colander.SchemaNode, DefinitionHandler) -> OpenAPISpecParameter
+        param_spec = super(OAS3ParameterConverter, self).convert(schema_node, definition_handler)
+        if "schema" not in param_spec:
+            param_schema = {}
+            for param in list(param_spec):
+                if param not in self.reserved_params:
+                    param_schema[param] = param_spec.pop(param)
+            param_spec["schema"] = param_schema
+        return param_spec
+
+
+class OAS3BodyParameterConverter(BodyParameterConverter, OAS3ParameterConverter):
+    pass
+
+
+class OAS3PathParameterConverter(PathParameterConverter, OAS3ParameterConverter):
+    pass
+
+
+class OAS3QueryParameterConverter(QueryParameterConverter, OAS3ParameterConverter):
+    pass
+
+
+class OAS3HeaderParameterConverter(HeaderParameterConverter, OAS3ParameterConverter):
+    pass
+
+
+class OAS3CookieParameterConverter(OAS3ParameterConverter):
+    _in = "cookie"
+
+
+class OAS3ParameterConversionDispatcher(ParameterConversionDispatcher):
+    converters = {
+        "body": OAS3BodyParameterConverter,
+        "path": OAS3PathParameterConverter,
+        "querystring": OAS3QueryParameterConverter,
+        "GET": OAS3QueryParameterConverter,
+        "header": OAS3HeaderParameterConverter,
+        "headers": OAS3HeaderParameterConverter,
+        "cookie": OAS3CookieParameterConverter,  # Not available in Swagger 2.0
+    }
+
+
+class OAS3DefinitionHandler(DefinitionHandler):
+    json_pointer = "#/components/schemas/"
+
+    def _schema_object_to_pointer(self, schema, depth, base_name):
+        # type: (OpenAPISchema, int, str) -> OpenAPISchema
+        schema_ref = super(OAS3DefinitionHandler, self)._schema_object_to_pointer(schema, depth, base_name)
+        schema_name = schema_ref["$ref"].rsplit("/", 1)[-1]
+        schema = self.definition_registry[schema_name]
+        if "schema" not in schema:
+            self.definition_registry[schema_name] = {"schema": schema}
+        return schema_ref
+
+
+class OAS3ParameterHandler(ParameterHandler):
+    json_pointer = "#/components/parameters/"
+
+
+class OAS3ResponseHandler(ResponseHandler):
+    json_pointer = "#/components/responses/"
+
+
+class CorniceOpenAPI(CorniceSwagger):
+    openapi_spec = 3
+
+    def __init__(self,
+                 services=None,             # type: Optional[Sequence[CorniceService]]
+                 def_ref_depth=0,           # type: int
+                 param_ref=False,           # type: bool
+                 resp_ref=False,            # type: bool
+                 pyramid_registry=None,     # type: Optional[Registry]
+                 ):                         # type: (...) -> None
+        if self.openapi_spec == 3:
+            self.definitions = OAS3DefinitionHandler
+            self.parameters = OAS3ParameterHandler
+            self.responses = OAS3ResponseHandler
+            self.type_converter = OAS3TypeConversionDispatcher
+            self.parameter_converter = OAS3ParameterConversionDispatcher
+        super(CorniceOpenAPI, self).__init__(
+            services=services,
+            def_ref_depth=def_ref_depth,
+            param_ref=param_ref,
+            resp_ref=resp_ref,
+            pyramid_registry=pyramid_registry,
+        )
+
+    def generate(self,
+                 title=None,        # type: Optional[str]
+                 version=None,      # type: Optional[str]
+                 base_path=None,    # type: Optional[str]
+                 info=None,         # type: Optional[OpenAPISpecInfo]
+                 swagger=None,      # type: Optional[JSON]
+                 openapi_spec=2,    # type: Literal[2, 3]
+                 **kwargs           # type: Any
+                 ):                 # type: (...) -> OpenAPISpecification
+        spec = super(CorniceOpenAPI, self).generate(
+            title=title,
+            version=version,
+            base_path=base_path,
+            info=info,
+            swagger=swagger,
+            openapi_spec=openapi_spec,
+            **kwargs
+        )
+        if self.openapi_spec == 3:
+            definitions = spec.pop("definitions", {})
+            parameters = spec.pop("parameters", {})
+            responses = spec.pop("responses", {})
+            spec.setdefault("components", {})
+            spec["components"].setdefault("schemas", definitions)
+            spec["components"].setdefault("parameters", parameters)
+            spec["components"].setdefault("responses", responses)
+        return spec


### PR DESCRIPTION

Changes:
--------
- Return ``Content-Type: application/vnd.oai.openapi+json; version=3.0`` for OpenAPI endpoint response referenced
  by ``service-desc`` in the API conformance details, as specified by [OGC API - Processes - OpenAPI 3.0 requirement class](https://docs.ogc.org/is/18-062r2/18-062r2.html#toc43).
- Support the generation of external schema references (``$ref``) using the ``schema_ref`` attribute if provided
  in a ``colander.SchemaNode`` that does not provide an explicit object schema definition with properties.
- Add Python typing definitions related to OpenAPI specification.

Fixes:
------
- Fix invalid generation of OpenAPI 3.0 specification for `Weaver` API using ``cornice_swagger``.
  The generated schema structure used to return a mix of Swagger 2.0 and OpenAPI 3.0 definitions.
  The provided contents are now defined completely with OpenAPI 3.0 specification format.
