### PR TITLE
fixes for test execution

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,7 +19,7 @@ Fixes:
 ------
 - Fix resolution of `CWL` file from references that do not provide a known ``Content-Type`` that can represent `CWL`
   contents. This can occur when deploying a ``builtin`` `Process` from the local file reference, which does not generate
-  a request, and therefore, no ``Content-Type``. This can occurs also for servers that incorrectly or simply do not
+  a request and, therefore, no ``Content-Type``. This can occur also for servers that incorrectly or simply do not
   report their response ``Content-Type`` header.
 
 .. _changes_4.25.0:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,8 @@ Fixes:
   report their response ``Content-Type`` header.
 - Fix resolution of file reference with explicit `CWL` or `YAML` extensions when ``Content-Type`` is not reported or is
   indicated as ``plain/text``.
+- Fix invalid resolution of ``builtin`` `Process` that could load the optional `JSON` or `YAML` payload file intended
+  to provide additional `Process` definition details, instead of the expected `CWL` for the package definition.
 
 .. _changes_4.25.0:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,8 @@ Fixes:
   contents. This can occur when deploying a ``builtin`` `Process` from the local file reference, which does not generate
   a request and, therefore, no ``Content-Type``. This can occur also for servers that incorrectly or simply do not
   report their response ``Content-Type`` header.
+- Fix resolution of file reference with explicit `CWL` or `YAML` extensions when ``Content-Type`` is not reported or is
+  indicated as ``plain/text``.
 
 .. _changes_4.25.0:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,11 +12,15 @@ Changes
 
 Changes:
 --------
-- No change.
+- Add more explicit ``PackageException`` error messages with contextual details when a `CWL` file reference cannot be
+  resolved correctly.
 
 Fixes:
 ------
-- No change.
+- Fix resolution of `CWL` file from references that do not provide a known ``Content-Type`` that can represent `CWL`
+  contents. This can occur when deploying a ``builtin`` `Process` from the local file reference, which does not generate
+  a request, and therefore, no ``Content-Type``. This can occurs also for servers that incorrectly or simply do not
+  report their response ``Content-Type`` header.
 
 .. _changes_4.25.0:
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -272,6 +272,7 @@ def get_test_weaver_app(config=None, settings=None):
     # type: (Optional[Configurator], Optional[SettingsType]) -> TestApp
     config = get_test_weaver_config(config=config, settings=settings)
     config.registry.settings.setdefault("weaver.ssl_verify", "false")
+    setup_config_with_mongodb(config)
     app = weaver_app({}, **config.get_settings())
     return TestApp(app)
 

--- a/weaver/processes/builtin/__init__.py
+++ b/weaver/processes/builtin/__init__.py
@@ -53,8 +53,7 @@ def _get_builtin_reference_mapping(root):
     """
     Generates a mapping of `reference` to actual ``builtin`` package file path.
     """
-    builtin_names = [_pkg for _pkg in os.listdir(root)
-                     if os.path.splitext(_pkg)[-1].replace(".", "") in PACKAGE_EXTENSIONS]
+    builtin_names = [_pkg for _pkg in os.listdir(root) if os.path.splitext(_pkg)[-1] == ".cwl"]
     refs = {
         os.path.splitext(_pkg)[0]: {"package": os.path.join(root, _pkg), "payload": {}}
         for _pkg in builtin_names
@@ -110,7 +109,7 @@ def _get_builtin_package(process_id, package):
     - Add `hints` section with :data:`CWL_REQUIREMENT_APP_BUILTIN`.
     - Replace references to environment variable :data:`WEAVER_ROOT_DIR` as needed.
 
-    The `CWL` ``hints`` are employed to avoid error from the runner that doesn't known this requirement definition.
+    The `CWL` ``hints`` are employed to avoid error from the runner that doesn't know this requirement definition.
     The ``hints`` can be directly in the package definition without triggering validation errors.
     """
     if "hints" not in package:

--- a/weaver/processes/builtin/__init__.py
+++ b/weaver/processes/builtin/__init__.py
@@ -18,7 +18,7 @@ from weaver.exceptions import PackageExecutionError, PackageNotFound, ProcessNot
 from weaver.execute import ExecuteControlOption
 from weaver.processes.constants import CWL_REQUIREMENT_APP_BUILTIN
 from weaver.processes.types import ProcessType
-from weaver.processes.wps_package import PACKAGE_EXTENSIONS, get_process_definition
+from weaver.processes.wps_package import get_process_definition
 from weaver.store.base import StoreProcesses
 from weaver.utils import clean_json_text_body, get_registry, ows_context_href
 from weaver.visibility import Visibility

--- a/weaver/processes/wps_package.py
+++ b/weaver/processes/wps_package.py
@@ -583,6 +583,14 @@ def _generate_process_with_cwl_from_reference(reference, process_hint=None):
                 LOGGER.warning("Attempting auto-resolution of invalid Content-Type [%s] to [%s] "
                                "for CWL reference [%s].", content_type, ContentType.APP_JSON, reference)
                 content_type = ContentType.APP_JSON
+            elif reference.endswith(".yml") or reference.endswith(".yaml"):
+                LOGGER.warning("Attempting auto-resolution of invalid Content-Type [%s] to [%s] "
+                               "for CWL reference [%s].", content_type, ContentType.APP_YAML, reference)
+                content_type = ContentType.APP_YAML
+            elif reference.endswith(".cwl"):
+                LOGGER.warning("Attempting auto-resolution of invalid Content-Type [%s] to [%s] "
+                               "for CWL reference [%s].", content_type, ContentType.APP_CWL, reference)
+                content_type = ContentType.APP_CWL
             elif data.startswith("<?xml") or reference.endswith(".xml"):
                 LOGGER.warning("Attempting auto-resolution of invalid Content-Type [%s] to [%s] "
                                "for WPS reference [%s].", content_type, ContentType.TEXT_XML, reference)

--- a/weaver/processes/wps_package.py
+++ b/weaver/processes/wps_package.py
@@ -567,7 +567,7 @@ def _generate_process_with_cwl_from_reference(reference, process_hint=None):
                 f"Couldn't obtain a valid response from [{ref_wps}]. "
                 f"Service response: [{response.status_code} {response.reason}]"
             )
-        content_type = get_header("Content-Type", response.headers)
+        content_type = get_header("Content-Type", response.headers, default="")
         ogc_api_ctypes = {
             ContentType.APP_JSON,
             ContentType.APP_YAML,

--- a/weaver/processes/wps_package.py
+++ b/weaver/processes/wps_package.py
@@ -577,7 +577,7 @@ def _generate_process_with_cwl_from_reference(reference, process_hint=None):
         ogc_api_json = {ctype for ctype in ogc_api_ctypes if ctype.endswith("json")}
 
         # try to detect incorrectly reported media-type using common structures
-        if ContentType.TEXT_PLAIN in content_type:
+        if ContentType.TEXT_PLAIN in content_type or not content_type:
             data = response.text
             if (data.startswith("{") and data.endswith("}")) or reference.endswith(".json"):
                 LOGGER.warning("Attempting auto-resolution of invalid Content-Type [%s] to [%s] "


### PR DESCRIPTION
## Changes

- Add more explicit ``PackageException`` error messages with contextual details when a `CWL` file reference cannot be
  resolved correctly.
- Ensure all generated test-webapps use the same test database collection.

Fixes:
------
- Fix resolution of `CWL` file from references that do not provide a known ``Content-Type`` that can represent `CWL`
  contents. This can occur when deploying a ``builtin`` `Process` from the local file reference, which does not generate
  a request and, therefore, no ``Content-Type``. This can occur also for servers that incorrectly or simply do not
  report their response ``Content-Type`` header.
- Fix resolution of file reference with explicit `CWL` or `YAML` extensions when ``Content-Type`` is not reported or is
  indicated as ``plain/text``.
- Fix invalid resolution of ``builtin`` `Process` that could load the optional `JSON` or `YAML` payload file intended
  to provide additional `Process` definition details, instead of the expected `CWL` for the package definition.
