### PR TITLE
workaround json2xml limiting deps

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,8 @@ Changes:
 Fixes:
 ------
 - Remove hard requirement ``shapely==1.8.2`` to obtain latest fixes.
+- Update ``json2xml>=3.20.0`` requirement to allow more recent ``certifi``, ``requests`` and ``urllib3`` dependencies to
+  be used by all packages (relates to `vinitkumar/json2xml#157 <https://github.com/vinitkumar/json2xml/issues/157>`_).
 - Fix resolution of `CWL` file from references that do not provide a known ``Content-Type`` that can represent `CWL`
   contents. This can occur when deploying a ``builtin`` `Process` from the local file reference, which does not generate
   a request and, therefore, no ``Content-Type``. This can occur also for servers that incorrectly or simply do not

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,8 @@ git+https://github.com/ESGF/esgf-compute-api.git@v2.3.7#egg=esgf-compute-api
 # use pserve to continue supporting config.ini with paste settings
 gunicorn>=20.0.4
 json2xml<3.19.0; python_version <= "3.6"
---install-option="--no-deps" json2xml; python_version >= "3.7"
+# reduced dependencies contrains to let packages update to latest (https://github.com/vinitkumar/json2xml/issues/157)
+json2xml>=3.20.0; python_version >= "3.7"
 jsonschema>=3.0.1
 lxml
 mako

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,8 @@ cryptography
 # (https://github.com/common-workflow-language/common-workflow-language/issues/587)
 ### git+https://github.com/crim-ca/cwltool@docker-gpu#egg=cwltool; python_version >= "3"
 cwltool==3.1.20220913185150
+# defused required for json2xml
+defusedxml
 docker
 duration
 git+https://github.com/ESGF/esgf-compute-api.git@v2.3.7#egg=esgf-compute-api
@@ -37,7 +39,7 @@ git+https://github.com/ESGF/esgf-compute-api.git@v2.3.7#egg=esgf-compute-api
 # use pserve to continue supporting config.ini with paste settings
 gunicorn>=20.0.4
 json2xml<3.19.0; python_version <= "3.6"
-json2xml; python_version >= "3.7"
+--install-option="--no-deps" json2xml; python_version >= "3.7"
 jsonschema>=3.0.1
 lxml
 mako


### PR DESCRIPTION
Workaround `json2xml` limiting deps for latest `certifi`, `requests`, `urllib3` versions.

Relates to https://github.com/vinitkumar/json2xml/issues/157 (strict dependencies enforced by package)
Relates to https://github.com/meanmail-dev/requirements/issues/95 (parsing requirements in PyCharm)
