### PR TITLE
pin moto>=4.0.8.dev17 to fix werkzeug>=2.2.2 dependency

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,7 +14,8 @@ flynt
 isort>=4.3.21,<5
 mock<4
 # AWS mock tests (against boto3)
-moto>3
+# (fix werkzeug>=2.2.2 dependency, see https://github.com/spulec/moto/issues/5341)
+moto>=4.0.8.dev17
 pluggy>=0.7
 # FIXME: bad interpolation of 'setup.cfg' for pytest 'log_format' (https://github.com/pytest-dev/pytest/issues/10019)
 pytest<7


### PR DESCRIPTION
relates to https://github.com/spulec/moto/issues/5341