### PR TITLE
mark all explicitly raised PackageException as ignored by coverage

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,23 +5,23 @@ tag = True
 tag_name = {new_version}
 
 [bumpversion:file:CHANGES.rst]
-search = 
+search =
 	`Unreleased <https://github.com/crim-ca/weaver/tree/master>`_ (latest)
 	========================================================================
-replace = 
+replace =
 	`Unreleased <https://github.com/crim-ca/weaver/tree/master>`_ (latest)
 	========================================================================
-	
+
 	Changes:
 	--------
 	- No change.
-	
+
 	Fixes:
 	------
 	- No change.
-	
+
 	.. _changes_{new_version}:
-	
+
 	`{new_version} <https://github.com/crim-ca/weaver/tree/{new_version}>`_ ({now:%%Y-%%m-%%d})
 	========================================================================
 
@@ -42,14 +42,14 @@ search = LABEL version="{current_version}"
 replace = LABEL version="{new_version}"
 
 [tool:pytest]
-addopts = 
+addopts =
 	--strict-markers
 	--tb=native
 	weaver/
 log_cli = false
 log_level = DEBUG
 python_files = test_*.py
-markers = 
+markers =
 	cli: mark test as related to CLI operations
 	testbed14: mark test as 'testbed14' validation
 	functional: mark test as functionality validation
@@ -80,7 +80,7 @@ targets = .
 [flake8]
 ignore = E126,E226,E402,F401,W503,W504
 max-line-length = 120
-exclude = 
+exclude =
 	src,
 	.git,
 	__pycache__,
@@ -112,14 +112,14 @@ add_select = D201,D213
 branch = true
 source = ./
 include = weaver/*
-omit = 
+omit =
 	setup.py
 	docs/*
 	tests/*
 	*_mako
 
 [coverage:report]
-exclude_lines = 
+exclude_lines =
 	pragma: no cover
 	raise AssertionError
 	raise NotImplementedError
@@ -139,3 +139,8 @@ exclude_lines =
 	self.logger.log
 	@overload
 	if not result.success:
+	raise PackageAuthenticationError
+	raise PackageExecutionError
+	raise PackageNotFound
+	raise PackageRegistrationError
+	raise PackageTypeError

--- a/weaver/processes/wps_package.py
+++ b/weaver/processes/wps_package.py
@@ -199,7 +199,7 @@ def retrieve_package_job_log(execution, job, progress_min=0, progress_max=100):
         for i, line in enumerate(log_lines):
             progress = map_progress(i / total * 100, progress_min, progress_max)
             job.save_log(message=line.rstrip("\n"), progress=progress, status=Status.RUNNING)
-    except (KeyError, IOError):
+    except (KeyError, IOError):  # pragma: no cover
         LOGGER.warning("Failed retrieving package log for %s", job)
 
 
@@ -664,7 +664,7 @@ def get_application_requirement(package, search=None, default=None, validate=Tru
     else:
         app_hints = list(filter(lambda h: any(h["class"].endswith(t) for t in CWL_REQUIREMENT_APP_TYPES), all_hints))
     if len(app_hints) > 1:
-        raise ValueError(
+        raise PackageTypeError(
             f"Package 'requirements' and/or 'hints' define too many conflicting values: {list(app_hints)}, "
             f"only one permitted amongst {list(CWL_REQUIREMENT_APP_TYPES)}."
         )
@@ -1061,8 +1061,7 @@ class WpsPackage(Process):
             merged_log = pkg_log[:cwl_end_index] + captured_log + pkg_log[cwl_end_index:]
             with open(self.log_file, mode="w", encoding="utf-8") as pkg_log_fd:
                 pkg_log_fd.writelines(merged_log)
-        except Exception as exc:
-            # log exception, but non-failing
+        except Exception as exc:  # pragma: no cover  # log exception, but non-failing
             self.exception_message(PackageExecutionError, exception=exc, level=logging.WARNING, status=status,
                                    message="Error occurred when retrieving internal application log.")
         return captured_log


### PR DESCRIPTION
There are many instances of `PackageException`-derived errors that are explicitly raised in the code for preemptively handling the detection of invalid conditions. The purpose of those errors raised explicitly is to provide better messages or contextual information than generic/uncaught builtin errors that would occur somewhere later in the code. All of those instances are intended to generally stop the execution at that point, and then be gracefully handled by the API. 

Given this context, raised `PackageException` are not all explicitly unit-tested, since evaluating each edge case error is tedious to set up and can easily change over time. In order to focus more on the "important code", we ignore those explicitly raised errors and assume the error they flag are simply to avoid further unnecessary processing which could otherwise yield harder errors to understand.
