### PR TITLE
Update Python versions - security updates

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
         allow-failure: [false]
         test-case: [test-unit-only, test-func-only]
         include:
@@ -57,11 +57,11 @@ jobs:
             test-case: test-func-only
           # experimental python
           - os: ubuntu-latest
-            python-version: "3.12a"
+            python-version: "3.11"
             allow-failure: true
             test-case: test-unit-only
           - os: ubuntu-latest
-            python-version: "3.12a"
+            python-version: "3.11"
             allow-failure: true
             test-case: test-func-only
           # linter tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,8 +33,6 @@ jobs:
     env:
       # override make command to install directly in active python
       CONDA_CMD: ""
-      PYTHON_VERSION_DEFAULT: "3.10"
-      PYTHON_VERSION_EXPERIMENTAL: "3.12a"
     services:
       # Label used to access the service container
       mongodb:
@@ -59,37 +57,37 @@ jobs:
             test-case: test-func-only
           # experimental python
           - os: ubuntu-latest
-            python-version: "${{ env.PYTHON_VERSION_EXPERIMENTAL }}"
+            python-version: "3.12a"
             allow-failure: true
             test-case: test-unit-only
           - os: ubuntu-latest
-            python-version: "${{ env.PYTHON_VERSION_EXPERIMENTAL }}"
+            python-version: "3.12a"
             allow-failure: true
             test-case: test-func-only
           # linter tests
           - os: ubuntu-latest
-            python-version: "${{ env.PYTHON_VERSION_DEFAULT }}"
+            python-version: "3.10"
             allow-failure: false
             test-case: check-only
           # documentation build
           - os: ubuntu-latest
-            python-version: "${{ env.PYTHON_VERSION_DEFAULT }}"
+            python-version: "3.10"
             allow-failure: false
             test-case: docs
           # coverage test
           - os: ubuntu-latest
-            python-version: "${{ env.PYTHON_VERSION_DEFAULT }}"
+            python-version: "3.10"
             allow-failure: false
             test-case: test-coverage-only
           # smoke test of Docker image
           - os: ubuntu-latest
             # doesn't matter which version (Docker), but match default of repository
-            python-version: "${{ env.PYTHON_VERSION_DEFAULT }}"
+            python-version: "3.10"
             allow-failure: false
             test-case: test-docker
           # EMS end-2-end Workflow tests
           - os: ubuntu-latest
-            python-version: "${{ env.PYTHON_VERSION_DEFAULT }}"
+            python-version: "3.10"
             allow-failure: true
             test-case: test-workflow-only
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,7 +88,7 @@ jobs:
           # EMS end-2-end Workflow tests
           - os: ubuntu-latest
             python-version: "3.10"
-            allow-failure: true
+            allow-failure: false
             test-case: test-workflow-only
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,6 +33,8 @@ jobs:
     env:
       # override make command to install directly in active python
       CONDA_CMD: ""
+      PYTHON_VERSION_DEFAULT: "3.10"
+      PYTHON_VERSION_EXPERIMENTAL: "3.12a"
     services:
       # Label used to access the service container
       mongodb:
@@ -42,51 +44,52 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         allow-failure: [false]
         test-case: [test-unit-only, test-func-only]
         include:
           # end-of-life python
           - os: ubuntu-latest
-            python-version: 3.6
+            python-version: "3.6"
             allow-failure: true
             test-case: test-unit-only
           - os: ubuntu-latest
-            python-version: 3.6
+            python-version: "3.6"
             allow-failure: true
             test-case: test-func-only
           # experimental python
           - os: ubuntu-latest
-            python-version: "3.10"
+            python-version: "${{ env.PYTHON_VERSION_EXPERIMENTAL }}"
             allow-failure: true
             test-case: test-unit-only
           - os: ubuntu-latest
-            python-version: "3.10"
+            python-version: "${{ env.PYTHON_VERSION_EXPERIMENTAL }}"
             allow-failure: true
             test-case: test-func-only
           # linter tests
           - os: ubuntu-latest
-            python-version: 3.7
+            python-version: "${{ env.PYTHON_VERSION_DEFAULT }}"
             allow-failure: false
             test-case: check-only
           # documentation build
           - os: ubuntu-latest
-            python-version: 3.7
+            python-version: "${{ env.PYTHON_VERSION_DEFAULT }}"
             allow-failure: false
             test-case: docs
           # coverage test
           - os: ubuntu-latest
-            python-version: 3.7
+            python-version: "${{ env.PYTHON_VERSION_DEFAULT }}"
             allow-failure: false
             test-case: test-coverage-only
           # smoke test of Docker image
           - os: ubuntu-latest
-            python-version: 3.7  # doesn't matter which one (in docker), but match default of repo
+            # doesn't matter which version (Docker), but match default of repository
+            python-version: "${{ env.PYTHON_VERSION_DEFAULT }}"
             allow-failure: false
             test-case: test-docker
           # EMS end-2-end Workflow tests
           - os: ubuntu-latest
-            python-version: 3.7
+            python-version: "${{ env.PYTHON_VERSION_DEFAULT }}"
             allow-failure: true
             test-case: test-workflow-only
     steps:

--- a/docker/Dockerfile-base
+++ b/docker/Dockerfile-base
@@ -1,4 +1,4 @@
-FROM python:3.7-slim
+FROM python:3.10-slim
 LABEL description.short="Weaver Base"
 LABEL description.long="Workflow Execution Management Service (EMS); Application, Deployment and Execution Service (ADES)"
 LABEL maintainer="Francis Charette-Migneault <francis.charette-migneault@crim.ca>"

--- a/setup.py
+++ b/setup.py
@@ -91,6 +91,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Framework :: Pyramid",
         "Topic :: Internet :: WWW/HTTP",
         "Topic :: Internet :: WWW/HTTP :: WSGI :: Application",

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,6 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11",
         "Framework :: Pyramid",
         "Topic :: Internet :: WWW/HTTP",
         "Topic :: Internet :: WWW/HTTP :: WSGI :: Application",


### PR DESCRIPTION
## Changes

- update default Docker image version Python 3.10 
- add Python 3.10/3.11 to GitHub CI

## Dependencies

- #489 - Includes multiple linting fixes already applied.