### PR TITLE
Include additional cwl requirements

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,7 +13,7 @@ Changes
 Changes:
 --------
 - Support `CWL` definition for ``cwltool:CUDARequirement`` to request the use of a GPU, including support for using
-  Docker with a GPU.
+  Docker with a GPU (resolves `#104 <https://github.com/crim-ca/weaver/issues/104>`_).
 - Support `CWL` definition for ``NetworkAccess`` to indicate whether a process requires outgoing IPv4/IPv6 network
   access.
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@ Changes:
 --------
 - Support `CWL` definition for ``cwltool:CUDARequirement`` to request the use of a GPU, including support for using
   Docker with a GPU.
+- Support `CWL` definition for ``NetworkAccess`` to indicate whether a process requires outgoing IPv4/IPv6 network
+  access.
 
 Fixes:
 ------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,7 +12,8 @@ Changes
 
 Changes:
 --------
-- No change.
+- Support `CWL` definition for ``cwltool:CUDARequirement`` to request the use of a GPU, including support for using
+  Docker with a GPU.
 
 Fixes:
 ------

--- a/weaver/processes/constants.py
+++ b/weaver/processes/constants.py
@@ -83,12 +83,14 @@ Set of :term:`CWL` requirements that correspond to remote execution of an :term:
 """
 
 # FIXME: convert to 'Constants' class
+CWL_REQUIREMENT_CUDA = "cwltool:CUDARequirement"
 CWL_REQUIREMENT_ENV_VAR = "EnvVarRequirement"
 CWL_REQUIREMENT_INIT_WORKDIR = "InitialWorkDirRequirement"
 CWL_REQUIREMENT_RESOURCE = "ResourceRequirement"
 CWL_REQUIREMENT_SCATTER = "ScatterFeatureRequirement"
 
 CWL_REQUIREMENT_FEATURES = frozenset([
+    CWL_REQUIREMENT_CUDA,
     CWL_REQUIREMENT_ENV_VAR,
     CWL_REQUIREMENT_INIT_WORKDIR,
     CWL_REQUIREMENT_RESOURCE,   # FIXME: perform pre-check on job submit? (https://github.com/crim-ca/weaver/issues/138)

--- a/weaver/processes/constants.py
+++ b/weaver/processes/constants.py
@@ -86,6 +86,7 @@ Set of :term:`CWL` requirements that correspond to remote execution of an :term:
 CWL_REQUIREMENT_CUDA = "cwltool:CUDARequirement"
 CWL_REQUIREMENT_ENV_VAR = "EnvVarRequirement"
 CWL_REQUIREMENT_INIT_WORKDIR = "InitialWorkDirRequirement"
+CWL_REQUIREMENT_NETWORK_ACCESS = "NetworkAccess"
 CWL_REQUIREMENT_RESOURCE = "ResourceRequirement"
 CWL_REQUIREMENT_SCATTER = "ScatterFeatureRequirement"
 
@@ -93,6 +94,7 @@ CWL_REQUIREMENT_FEATURES = frozenset([
     CWL_REQUIREMENT_CUDA,
     CWL_REQUIREMENT_ENV_VAR,
     CWL_REQUIREMENT_INIT_WORKDIR,
+    CWL_REQUIREMENT_NETWORK_ACCESS,
     CWL_REQUIREMENT_RESOURCE,   # FIXME: perform pre-check on job submit? (https://github.com/crim-ca/weaver/issues/138)
     CWL_REQUIREMENT_SCATTER,
 ])

--- a/weaver/wps_restapi/swagger_definitions.py
+++ b/weaver/wps_restapi/swagger_definitions.py
@@ -30,6 +30,7 @@ from weaver.formats import AcceptLanguage, ContentType, OutputFormat
 from weaver.owsexceptions import OWSMissingParameterValue
 from weaver.processes.constants import (
     CWL_REQUIREMENT_APP_BUILTIN,
+    CWL_REQUIREMENT_CUDA,
     CWL_REQUIREMENT_APP_DOCKER,
     CWL_REQUIREMENT_APP_DOCKER_GPU,
     CWL_REQUIREMENT_APP_ESGF_CWT,
@@ -3613,6 +3614,40 @@ class RequirementClass(ExtendedSchemaNode):
     description = "CWL requirement class specification."
 
 
+class CudaRequirementSpecification(PermissiveMappingSchema):
+    cudaVersionMin = ExtendedSchemaNode(
+        String(),
+        example="11.4",
+        title="Cuda version minimum",
+        description="The minimum Cuda version required."
+    )
+    cudaComputeCapability = ExtendedSchemaNode(
+        String(),
+        example="3.0",
+        title="Cuda compute capability",
+        description="The compute capability supported by the GPU."
+    )
+    cudaDeviceCountMin = ExtendedSchemaNode(
+        Integer(),
+        example=1,
+        title="Cuda device count minimum",
+        description="The minimum amount of devices required."
+    )
+    cudaDeviceCountMax = ExtendedSchemaNode(
+        Integer(),
+        example=8,
+        title="Cuda device count maximum",
+        description="The maximum amount of devices required."
+    )
+
+
+class CudaRequirementMap(ExtendedMappingSchema):
+    CudaRequirement = CudaRequirementSpecification(
+        name=CWL_REQUIREMENT_CUDA,
+        title=CWL_REQUIREMENT_CUDA
+    )
+
+
 class DockerRequirementSpecification(PermissiveMappingSchema):
     dockerPull = ExtendedSchemaNode(
         String(),
@@ -3779,6 +3814,7 @@ class CWLRequirements(OneOfKeywordSchema):
 class CWLHintsMap(AnyOfKeywordSchema, PermissiveMappingSchema):
     _any_of = [
         BuiltinRequirementMap(missing=drop),
+        CudaRequirementMap(missing=drop),
         DockerRequirementMap(missing=drop),
         DockerGpuRequirementMap(missing=drop),
         InitialWorkDirRequirementMap(missing=drop),

--- a/weaver/wps_restapi/swagger_definitions.py
+++ b/weaver/wps_restapi/swagger_definitions.py
@@ -3620,23 +3620,29 @@ class CudaRequirementSpecification(PermissiveMappingSchema):
         String(),
         example="11.4",
         title="Cuda version minimum",
-        description="The minimum Cuda version required."
+        description="The minimum Cuda version required.",
+        validator=SemanticVersion(regex=r"^\d+\.\d+$")
     )
     cudaComputeCapability = ExtendedSchemaNode(
         String(),
         example="3.0",
         title="Cuda compute capability",
-        description="The compute capability supported by the GPU."
+        description="The compute capability supported by the GPU.",
+        validator=SemanticVersion(regex=r"^\d+\.\d+$")
     )
     cudaDeviceCountMin = ExtendedSchemaNode(
         Integer(),
         example=1,
+        default=1,
+        validator=Range(min=1),
         title="Cuda device count minimum",
         description="The minimum amount of devices required."
     )
     cudaDeviceCountMax = ExtendedSchemaNode(
         Integer(),
         example=8,
+        default=1,
+        validator=Range(min=1),
         title="Cuda device count maximum",
         description="The maximum amount of devices required."
     )
@@ -3647,6 +3653,10 @@ class CudaRequirementMap(ExtendedMappingSchema):
         name=CWL_REQUIREMENT_CUDA,
         title=CWL_REQUIREMENT_CUDA
     )
+
+
+class CudaRequirementClass(CudaRequirementSpecification):
+    _class = RequirementClass(example=CWL_REQUIREMENT_CUDA, validator=OneOf([CWL_REQUIREMENT_CUDA]))
 
 
 class NetworkAccessRequirementSpecification(PermissiveMappingSchema):
@@ -3663,6 +3673,10 @@ class NetworkAccessRequirementMap(ExtendedMappingSchema):
         name=CWL_REQUIREMENT_NETWORK_ACCESS,
         title=CWL_REQUIREMENT_NETWORK_ACCESS
     )
+
+
+class NetworkAccessRequirementClass(NetworkAccessRequirementSpecification):
+    _class = RequirementClass(example=CWL_REQUIREMENT_NETWORK_ACCESS, validator=OneOf([CWL_REQUIREMENT_NETWORK_ACCESS]))
 
 
 class DockerRequirementSpecification(PermissiveMappingSchema):
@@ -3804,6 +3818,7 @@ class CWLRequirementsMap(AnyOfKeywordSchema):
         DockerRequirementMap(missing=drop),
         DockerGpuRequirementMap(missing=drop),
         InitialWorkDirRequirementMap(missing=drop),
+        NetworkAccessRequirementMap(missing=drop),
         PermissiveMappingSchema(missing=drop),
     ]
 
@@ -3813,6 +3828,7 @@ class CWLRequirementsItem(OneOfKeywordSchema):
         DockerRequirementClass(missing=drop),
         DockerGpuRequirementClass(missing=drop),
         InitialWorkDirRequirementClass(missing=drop),
+        NetworkAccessRequirementClass(missing=drop),
         UnknownRequirementClass(missing=drop),  # allows anything, must be last
     ]
 
@@ -3848,9 +3864,11 @@ class CWLHintsItem(OneOfKeywordSchema, PermissiveMappingSchema):
     discriminator = "class"
     _one_of = [
         BuiltinRequirementClass(missing=drop),
+        CudaRequirementClass(missing=drop),
         DockerRequirementClass(missing=drop),
         DockerGpuRequirementClass(missing=drop),
         InitialWorkDirRequirementClass(missing=drop),
+        NetworkAccessRequirementClass(missing=drop),
         ESGF_CWT_RequirementClass(missing=drop),
         OGCAPIRequirementClass(missing=drop),
         WPS1RequirementClass(missing=drop),

--- a/weaver/wps_restapi/swagger_definitions.py
+++ b/weaver/wps_restapi/swagger_definitions.py
@@ -30,12 +30,12 @@ from weaver.formats import AcceptLanguage, ContentType, OutputFormat
 from weaver.owsexceptions import OWSMissingParameterValue
 from weaver.processes.constants import (
     CWL_REQUIREMENT_APP_BUILTIN,
-    CWL_REQUIREMENT_CUDA,
     CWL_REQUIREMENT_APP_DOCKER,
     CWL_REQUIREMENT_APP_DOCKER_GPU,
     CWL_REQUIREMENT_APP_ESGF_CWT,
     CWL_REQUIREMENT_APP_OGC_API,
     CWL_REQUIREMENT_APP_WPS1,
+    CWL_REQUIREMENT_CUDA,
     CWL_REQUIREMENT_INIT_WORKDIR,
     OAS_COMPLEX_TYPES,
     OAS_DATA_TYPES,

--- a/weaver/wps_restapi/swagger_definitions.py
+++ b/weaver/wps_restapi/swagger_definitions.py
@@ -37,6 +37,7 @@ from weaver.processes.constants import (
     CWL_REQUIREMENT_APP_WPS1,
     CWL_REQUIREMENT_CUDA,
     CWL_REQUIREMENT_INIT_WORKDIR,
+    CWL_REQUIREMENT_NETWORK_ACCESS,
     OAS_COMPLEX_TYPES,
     OAS_DATA_TYPES,
     PACKAGE_ARRAY_BASE,
@@ -3648,6 +3649,22 @@ class CudaRequirementMap(ExtendedMappingSchema):
     )
 
 
+class NetworkAccessRequirementSpecification(PermissiveMappingSchema):
+    networkAccess = ExtendedSchemaNode(
+        Boolean(),
+        example=True,
+        title="Network Access",
+        description="Indicate whether a process requires outgoing IPv4/IPv6 network access."
+    )
+
+
+class NetworkAccessRequirementMap(ExtendedMappingSchema):
+    NetworkAccessRequirement = NetworkAccessRequirementSpecification(
+        name=CWL_REQUIREMENT_NETWORK_ACCESS,
+        title=CWL_REQUIREMENT_NETWORK_ACCESS
+    )
+
+
 class DockerRequirementSpecification(PermissiveMappingSchema):
     dockerPull = ExtendedSchemaNode(
         String(),
@@ -3818,6 +3835,7 @@ class CWLHintsMap(AnyOfKeywordSchema, PermissiveMappingSchema):
         DockerRequirementMap(missing=drop),
         DockerGpuRequirementMap(missing=drop),
         InitialWorkDirRequirementMap(missing=drop),
+        NetworkAccessRequirementMap(missing=drop),
         ESGF_CWT_RequirementMap(missing=drop),
         OGCAPIRequirementMap(missing=drop),
         WPS1RequirementMap(missing=drop),


### PR DESCRIPTION
- Support `CWL` definition for ``cwltool:CUDARequirement`` to request the use of a GPU, including support for using
  Docker with a GPU.
- Support `CWL` definition for ``NetworkAccess`` to indicate whether a process requires outgoing IPv4/IPv6 network
  access.

Fixes #104 