### PR TITLE
updates for CWL CUDA, Resources, NetworkAccess requirements

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,7 +12,14 @@ Changes
 
 Changes:
 --------
-- No change.
+- Update documentation with examples for ``cwltool:CUDARequirement``, ``ResourceRequirement`` and ``NetworkAccess``.
+- Improve schema definition of ``ResourceRequirement``.
+- Deprecate ``DockerGpuRequirement``, with attempts to auto-convert it into corresponding ``DockerRequirement``
+  combined with  ``cwltool:CUDARequirement`` definitions. If this conversion does not work transparently for the user,
+  explicit `CWL` updates with those definitions should be made.
+- Ensure validation check that exactly one `CWL` requirement or hint is provided to represent the application type.
+  In case of missing requirement, the reported error will contain a documentation link to guide the user in adjusting
+  its `Application Package` accordingly.
 
 Fixes:
 ------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,19 @@ Changes
 
 Changes:
 --------
+- No change.
+
+Fixes:
+------
+- No change.
+
+.. _changes_4.27.0:
+
+`4.27.0 <https://github.com/crim-ca/weaver/tree/4.27.0>`_ (2022-11-22)
+========================================================================
+
+Changes:
+--------
 - Support `CWL` ``InlineJavascriptRequirement`` for `Process` deployment to allow successful schema validation.
 - Support `CWL` ``Directory`` type references (resolves `#466 <https://github.com/crim-ca/weaver/issues/466>`_).
   Those references correspond to `WPS` and `OGC API - Processes` ``href``

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,8 +18,8 @@ Changes:
   combined with  ``cwltool:CUDARequirement`` definitions. If this conversion does not work transparently for the user,
   explicit `CWL` updates with those definitions should be made.
 - Ensure that validation check finds exactly one provided `CWL` requirement or hint to represent the application type.
-  In case of missing requirement, the reported error will contain a documentation link to guide the user in adjusting
-  its `Application Package` accordingly.
+  In case of missing requirement, the `Process` deployment will fail with a reported error that contains a documentation
+  link to guide the user in adjusting its `Application Package` accordingly.
 
 Fixes:
 ------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ Changes
 
 Changes:
 --------
+- Add `Job` log message size checks to better control what gets logged during the `Application Package` execution to
+  avoid large documents causing problems when attempting save them to storage database.
 - Update documentation with examples for ``cwltool:CUDARequirement``, ``ResourceRequirement`` and ``NetworkAccess``.
 - Improve schema definition of ``ResourceRequirement``.
 - Deprecate ``DockerGpuRequirement``, with attempts to auto-convert it into corresponding ``DockerRequirement``
@@ -27,7 +29,6 @@ Fixes:
   Use ``packaging.version.Version`` substitute whenever possible, but preserve backward
   compatibility with ``distutils`` in case of older Python not supporting it.
 - Fix ``cli._update_files`` so there are no attempts to upload remote references to the `Vault`.
-- No change.
 
 .. _changes_4.27.0:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,7 +17,7 @@ Changes:
 - Deprecate ``DockerGpuRequirement``, with attempts to auto-convert it into corresponding ``DockerRequirement``
   combined with  ``cwltool:CUDARequirement`` definitions. If this conversion does not work transparently for the user,
   explicit `CWL` updates with those definitions should be made.
-- Ensure validation check that exactly one `CWL` requirement or hint is provided to represent the application type.
+- Ensure that validation check finds exactly one provided `CWL` requirement or hint to represent the application type.
   In case of missing requirement, the reported error will contain a documentation link to guide the user in adjusting
   its `Application Package` accordingly.
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ MAKEFILE_NAME := $(word $(words $(MAKEFILE_LIST)),$(MAKEFILE_LIST))
 # Application
 APP_ROOT    := $(abspath $(lastword $(MAKEFILE_NAME))/..)
 APP_NAME    := $(shell basename $(APP_ROOT))
-APP_VERSION ?= 4.26.0
+APP_VERSION ?= 4.27.0
 APP_INI     ?= $(APP_ROOT)/config/$(APP_NAME).ini
 DOCKER_REPO ?= pavics/weaver
 #DOCKER_REPO ?= docker-registry.crim.ca/ogc/weaver

--- a/README.rst
+++ b/README.rst
@@ -5,6 +5,9 @@ Weaver
 **Implementations**
 
 * |ogc-proc-long|
+* |wps|
+* |esgf| processes
+* |cwl| for |ogc-apppkg|_
 * |ems| for Workflows
 * |ades|
 
@@ -108,7 +111,7 @@ the application definition provided by |cwl| configuration. It can then directly
 a registered process |ogc-apppkg|_ with received inputs from a WPS request to expose output results for a
 following `ADES` in a `EMS` workflow execution chain.
 
-`Weaver` **extends** |ogc-proc-api|_ by providing additional functionalities such as more detailed job logs
+`Weaver` **extends** |ogc-api-proc|_ by providing additional functionalities such as more detailed job logs
 endpoints, adding more process management and search request options than required by the standard, and supporting
 *remote providers* registration for dynamic process definitions, to name a few.
 Because of this, not all features offered in `Weaver` are guaranteed to be applicable on other similarly
@@ -283,9 +286,9 @@ It is part of `PAVICS`_ and `Birdhouse`_ ecosystems and is available within the 
 .. |wps| replace:: `Web Processing Services` (WPS)
 .. |ogc| replace:: Open Geospatial Consortium
 .. _ogc: https://www.ogc.org/
-.. |ogc-proc-api| replace:: `OGC API - Processes`
-.. _ogc-proc-api: https://github.com/opengeospatial/ogcapi-processes
-.. |ogc-proc-long| replace:: |ogc-proc-api|_ (WPS-REST bindings)
+.. |ogc-api-proc| replace:: `OGC API - Processes`
+.. _ogc-api-proc: https://github.com/opengeospatial/ogcapi-processes
+.. |ogc-proc-long| replace:: |ogc-api-proc|_ (WPS-REST bindings)
 .. |ogc-tb14| replace:: OGC Testbed-14
 .. _ogc-tb14: https://www.ogc.org/projects/initiatives/testbed14
 .. |ogc-tb14-platform-er| replace:: ADES & EMS Results and Best Practices Engineering Report

--- a/README.rst
+++ b/README.rst
@@ -42,13 +42,13 @@ for each process.
     :alt: Requires Python 3.6+
     :target: https://www.python.org/getit
 
-.. |commits-since| image:: https://img.shields.io/github/commits-since/crim-ca/weaver/4.26.0.svg
+.. |commits-since| image:: https://img.shields.io/github/commits-since/crim-ca/weaver/4.27.0.svg
     :alt: Commits since latest release
-    :target: https://github.com/crim-ca/weaver/compare/4.26.0...master
+    :target: https://github.com/crim-ca/weaver/compare/4.27.0...master
 
-.. |version| image:: https://img.shields.io/badge/latest%20version-4.26.0-blue
+.. |version| image:: https://img.shields.io/badge/latest%20version-4.27.0-blue
     :alt: Latest Tagged Version
-    :target: https://github.com/crim-ca/weaver/tree/4.26.0
+    :target: https://github.com/crim-ca/weaver/tree/4.27.0
 
 .. |requires| image:: https://requires.io/github/crim-ca/weaver/requirements.svg?branch=master
     :alt: Requirements Status
@@ -62,9 +62,9 @@ for each process.
     :alt: Github Actions CI Build Status (master branch)
     :target: https://github.com/crim-ca/weaver/actions?query=workflow%3ATests+branch%3Amaster
 
-.. |github_tagged| image:: https://img.shields.io/github/workflow/status/crim-ca/weaver/Tests/4.26.0?label=4.26.0
+.. |github_tagged| image:: https://img.shields.io/github/workflow/status/crim-ca/weaver/Tests/4.27.0?label=4.27.0
     :alt: Github Actions CI Build Status (latest tag)
-    :target: https://github.com/crim-ca/weaver/actions?query=workflow%3ATests+branch%3A4.26.0
+    :target: https://github.com/crim-ca/weaver/actions?query=workflow%3ATests+branch%3A4.27.0
 
 .. |readthedocs| image:: https://img.shields.io/readthedocs/pavics-weaver
     :alt: ReadTheDocs Build Status (master branch)
@@ -76,7 +76,7 @@ for each process.
 
 .. below shield will either indicate the targeted version or 'tag not found'
 .. since docker tags are pushed following manual builds by CI, they are not automatic and no build artifact exists
-.. |docker_build_status| image:: https://img.shields.io/docker/v/pavics/weaver/4.26.0?label=tag%20status
+.. |docker_build_status| image:: https://img.shields.io/docker/v/pavics/weaver/4.27.0?label=tag%20status
     :alt: Docker Build Status (latest version)
     :target: https://hub.docker.com/r/pavics/weaver/tags
 
@@ -199,12 +199,12 @@ Docker image repositories:
 
 ::
 
-    $ docker pull pavics/weaver:4.26.0
+    $ docker pull pavics/weaver:4.27.0
 
 For convenience, following tags are also available:
 
-- ``weaver:4.26.0-manager``: `Weaver` image that will run the API for WPS process and job management.
-- ``weaver:4.26.0-worker``: `Weaver` image that will run the process job runner application.
+- ``weaver:4.27.0-manager``: `Weaver` image that will run the API for WPS process and job management.
+- ``weaver:4.27.0-worker``: `Weaver` image that will run the process job runner application.
 
 Following links correspond to existing servers with `Weaver` configured as *EMS*/*ADES* instances respectively.
 

--- a/docker/Dockerfile-base
+++ b/docker/Dockerfile-base
@@ -3,7 +3,7 @@ LABEL description.short="Weaver Base"
 LABEL description.long="Workflow Execution Management Service (EMS); Application, Deployment and Execution Service (ADES)"
 LABEL maintainer="Francis Charette-Migneault <francis.charette-migneault@crim.ca>"
 LABEL vendor="CRIM"
-LABEL version="4.26.0"
+LABEL version="4.27.0"
 
 # setup paths
 ENV APP_DIR=/opt/local/src/weaver

--- a/docs/examples/docker-python-script-report.cwl
+++ b/docs/examples/docker-python-script-report.cwl
@@ -1,3 +1,4 @@
+#!/usr/bin/env cwl-runner
 cwlVersion: v1.0
 class: CommandLineTool
 baseCommand:

--- a/docs/examples/docker-shell-script-cat.cwl
+++ b/docs/examples/docker-shell-script-cat.cwl
@@ -1,3 +1,4 @@
+#!/usr/bin/env cwl-runner
 cwlVersion: v1.0
 class: CommandLineTool
 baseCommand: cat
@@ -13,4 +14,5 @@ outputs:
   - id: output
     type: File
     outputBinding:
-      glob: stdout.log
+      glob: output.txt
+stdout: output.txt

--- a/docs/examples/requirement-cuda.cwl
+++ b/docs/examples/requirement-cuda.cwl
@@ -1,0 +1,19 @@
+#!/usr/bin/env cwl-runner
+cwlVersion: v1.2
+class: CommandLineTool
+baseCommand: nvidia-smi
+requirements:
+  cwltool:CUDARequirement:
+    cudaVersionMin: "11.2"
+    cudaComputeCapability: "7.5"
+    cudaDeviceCountMin: 1
+    cudaDeviceCountMax: 4
+$namespaces:
+  cwltool: "http://commonwl.org/cwltool#"
+inputs: {}
+outputs:
+  output:
+    type: File
+    outputBinding:
+      glob: output.txt
+stdout: output.txt

--- a/docs/examples/requirement-network.cwl
+++ b/docs/examples/requirement-network.cwl
@@ -1,0 +1,16 @@
+#!/usr/bin/env cwl-runner
+cwlVersion: v1.2
+class: CommandLineTool
+baseCommand: curl
+requirements:
+  NetworkAccess:
+    networkAccess: true
+inputs:
+  url:
+    type: string
+outputs:
+  output:
+    type: File
+    outputBinding:
+      glob: "output.txt"
+stdout: "output.txt"

--- a/docs/examples/requirement-resources.cwl
+++ b/docs/examples/requirement-resources.cwl
@@ -1,0 +1,21 @@
+#!/usr/bin/env cwl-runner
+cwlVersion: v1.2
+class: CommandLineTool
+baseCommand: "<high-compute-algorithm>"
+requirements:
+  ResourceRequirement:
+    coresMin: 8
+    coresMax: 16
+    ramMin: 1024
+    ramMax: 2048
+    tmpdirMin: 128
+    tmpdirMax: 1024
+    outdirMin: 1024
+    outdirMax: 2048
+inputs: {}
+outputs:
+  output:
+    type: File
+    outputBinding:
+      glob: output.txt
+stdout: output.txt

--- a/docs/source/appendix.rst
+++ b/docs/source/appendix.rst
@@ -180,7 +180,8 @@ Glossary
         input/output chaining between operations.
 
         .. seealso::
-            Refer to :ref:`proc_workflow`, :ref:`proc_workflow_ops` and :ref:`CWL Workflow` sections for more details.
+            Refer to :ref:`proc_workflow`, :ref:`proc_workflow_ops` and :ref:`app_pkg_workflow`
+            sections for more details.
 
     WPS
         | Web Processing Service.

--- a/docs/source/appendix.rst
+++ b/docs/source/appendix.rst
@@ -194,6 +194,10 @@ Glossary
     WPS-REST
         Alias employed to refer to :term:`OGC API - Processes` endpoints for corresponding :term:`WPS` definitions.
 
+    WPS-T
+        Alias employed to refer to older revisions of :term:`OGC API - Processes` standard.
+        The name referred to :term:`WPS` *Transactional* operations introduced by the RESTful API.
+
     XML
         | Extensible Markup Language
         | Alternative representation of some data object provided by the application. Requires appropriate ``Accept``
@@ -219,5 +223,5 @@ Useful Links
 - |iana-link|_
 - |oas|_
 - |ogc|_ (:term:`OGC`)
-- |ogc-proc-api|_
+- |ogc-api-proc|_
 - |weaver-issues|_

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -214,7 +214,7 @@ they are optional and which default value or operation is applied in each situat
   | (default: *path* ``/``)
   |
   | Endpoint that will be employed as prefix to refer to WPS-REST requests
-  | (including but not limited to |ogc-proc-api|_ schemas).
+  | (including but not limited to |ogc-api-proc|_ schemas).
   |
   | It can either be the explicit *full URL* to use or the *path* relative to ``weaver.url``.
   | Setting ``weaver.wps_restapi_path`` is ignored if its URL equivalent is defined.

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -105,7 +105,7 @@ Problem connecting workflow steps together
 
 .. seealso::
 
-    - :ref:`CWL Workflow`
+    - :ref:`app_pkg_workflow`
     - :ref:`Output File Format`
 
 

--- a/docs/source/package.rst
+++ b/docs/source/package.rst
@@ -30,8 +30,9 @@ definition available with |pkg-req|_ request.
 .. note::
 
     The package request is a `Weaver`-specific implementation, and therefore, is not necessarily available on other
-    :term:`ADES`/:term:`EMS` implementation as this feature is not part of |ogc-proc-api|_ specification.
+    :term:`ADES`/:term:`EMS` implementation as this feature is not part of |ogc-api-proc|_ specification.
 
+.. _app_pkg_types:
 
 Typical CWL Package Definition
 ===========================================
@@ -223,19 +224,63 @@ second task could be delayed until the first task is completed, therefore avoidi
 
 .. _app_pkg_remote:
 .. _app_pkg_wps1:
-.. _app_pkg_ogc-api:
-.. _app_pkg_esgf-cwt:
+.. _app_pkg_ogc_api:
+.. _app_pkg_esgf_cwt:
 
 Remote Applications
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. todo::
-    - WPS1Requirement
-    - OGCAPIRequirement
-    - ESGF-CWTRequirement
+To define an application that refers to a :ref:`proc_remote_provider`, an :ref:`proc_wps_12`, an :ref:`proc_ogc_api`
+or an :ref:`proc_esgf_cwt` endpoint, the corresponding `Weaver`-specific :term:`CWL`-like requirements must be employed
+to indicate the URL where that remote resource is accessible. Once deployed, the contained :term:`CWL`
+package and the resulting :term:`Process` will be exposed as a :ref:`proc_ogc_api` resource.
+
+Upon reception of a :ref:`Process Execution <proc_op_execute>` request, `Weaver` will take care of resolving
+the indicated process URL from the :term:`CWL` requirement and will dispatch the execution to the resource
+after applying any relevant I/O, parameter and Media-Type conversion to align with the target server standard
+for submitting the :term:`Job` requests.
+
+Below are examples of the corresponding :term:`CWL` requirements employed for each type of remote application.
+
+.. code-block:: yaml
+    :caption: WPS-1/2 Package Definition
+
+    cwlVersion: "v1.0"
+    class: CommandLineTool
+    hints:
+      WPS1Requirement:
+        provider: "https://example.com/ows/wps/catalog"
+        process: "getpoint"
+
+.. code-block:: yaml
+    :caption: OGC API Package Definition
+
+    cwlVersion: "v1.0"
+    class: CommandLineTool
+    hints:
+      OGCAPIRequirement:
+        process: "https://example.com/ogcapi/processes/getpoint"
+
+.. code-block:: json
+    :caption: ESGF-CWT Package Definition
+
+    {
+      "cwlVersion": "v1.0",
+      "class": "CommandLineTool",
+      "hints": {
+        "ESGF-CWTRequirement": {
+          "provider": "https://edas.nccs.nasa.gov/wps/cwt",
+          "process": "xarray.subset"
+        }
+      }
+    }
 
 
-
+.. seealso::
+    - :ref:`proc_remote_provider`
+    - :ref:`proc_wps_12`
+    - :ref:`proc_ogc_api`
+    - :ref:`proc_esgf_cwt`
 
 .. _app_pkg_workflow:
 

--- a/docs/source/processes.rst
+++ b/docs/source/processes.rst
@@ -238,8 +238,8 @@ Workflow
 Processes categorized as :term:`Workflow` are very similar to `WPS-REST`_ processes. From the API standpoint, they
 actually look exactly the same as an atomic process when calling :ref:`DescribeProcess <proc_op_describe>`
 or :ref:`Execute <proc_op_execute>` requests.
-The difference lies within the referenced :ref:`Application Package` which uses a :ref:`CWL Workflow` instead of
-typical :ref:`CWL CommandLineTool`, and therefore, modifies how the :term:`Process` is internally executed.
+The difference lies within the referenced :ref:`Application Package` which uses a :ref:`app_pkg_workflow` instead of
+typical :ref:`app_pkg_cmd`, and therefore, modifies how the :term:`Process` is internally executed.
 
 For :term:`Workflow` processes to be deploy-able and executable, it is **mandatory** that `Weaver` is configured as
 :term:`EMS` or :term:`HYBRID` (see: :ref:`Configuration Settings`). This requirement is due to the nature
@@ -1035,7 +1035,7 @@ combinations.
 .. [#wf]
     Workflows are only available on :term:`EMS` and :term:`HYBRID` instances. Since they chain processes,
     no fetch is needed as the sub-step process will do it instead as needed. See :ref:`Workflow` process as well
-    as :ref:`CWL Workflow` for more details.
+    as :ref:`app_pkg_workflow` for more details.
 
 .. todo::
     method to indicate explicit fetch to override these? (https://github.com/crim-ca/weaver/issues/183)
@@ -1684,6 +1684,6 @@ Workflow (Chaining Step Processes)
 
 .. seealso::
 
-    - :ref:`CWL Workflow`
+    - :ref:`app_pkg_workflow`
     - :ref:`proc_workflow_ops`
     - :ref:`Workflow` process type

--- a/docs/source/processes.rst
+++ b/docs/source/processes.rst
@@ -17,18 +17,16 @@ Type of Processes
 `Weaver` supports multiple type of processes, as listed below.
 Each one of them are accessible through the same API interface, but they have different implications.
 
-- `Builtin`_
-- `WPS-1/2`_
-- `WPS-REST`_ (a.k.a.: WPS-3, |ogc-proc-api|_)
-- `ESGF-CWT`_
-- `Workflow`_
-- `Remote Provider`_
-
+- :ref:`proc_builtin`
+- :ref:`proc_wps_12`
+- :ref:`OGC API - Processes <proc_ogc_api>` (formerly known as :term:`WPS-REST`, :term:`WPS-T` or `WPS-3`)
+- :ref:`proc_esgf_cwt`
+- :ref:`proc_workflow`
+- :ref:`proc_remote_provider`
 
 .. seealso::
     Section |examples|_ provides multiple concrete use cases of :ref:`Deploy <proc_op_deploy>`
     and :ref:`Execute <proc_op_execute>` request payloads for diverse set of applications.
-
 
 .. _proc_builtin:
 
@@ -63,10 +61,11 @@ WPS-1/2
 -------
 
 This kind of process corresponds to a *traditional* :term:`WPS` :term:`XML` or :term:`JSON` endpoint
-(depending of supported version) prior to `WPS-REST`_ specification. When the `WPS-REST`_ process is deployed
-in `Weaver` using an URL reference to an WPS-1/2 process, `Weaver` parses and converts the :term:`XML` or :term:`JSON`
-body of the response and registers the process locally using this definition. This allows a remote server offering
-limited functionalities (e.g.: no REST bindings supported) to provide them through `Weaver`.
+(depending of supported version) prior to :ref:`proc_wps_rest` specification. When an |ogc-api-proc|_ description is
+deployed in `Weaver` using an URL reference to an WPS-1/2 process through the use of a :ref:`app_pkg_wps` requirement,
+`Weaver` parses and converts the :term:`XML` or :term:`JSON` body of the :term:`WPS` response and registers the process
+locally. This allows a remote server offering limited functionalities (e.g.: no REST bindings supported)
+to provide them through `Weaver`.
 
 A minimal :ref:`Deploy <proc_op_deploy>` request body for this kind of process could be as follows:
 
@@ -103,18 +102,22 @@ Please refer to :ref:`Configuration of WPS Processes` section for more details o
 .. seealso::
     - `Remote Provider`_
 
+.. _proc_ogc_api:
 .. _proc_wps_rest:
 
-WPS-REST
---------
+OGC API - Processes (WPS-REST, WPS-T, WPS-3)
+--------------------------------------------
 
 This :term:`Process` type is the main component of `Weaver`. All other types are converted to this one either
-through some parsing (e.g.: `WPS-1/2`_) or with some requirement indicators (e.g.: `Builtin`_, `Workflow`_) for
-special handling.
+through some parsing (e.g.: :ref:`proc_wps_12`) or with some requirement indicators
+(e.g.: :ref:`proc_builtin`, :ref:`proc_workflow`) for
+special handling. The represented :term:`Process` is aligned with |ogc-api-proc|_ specifications.
 
 When deploying one such :term:`Process` directly, it is expected to have a definition specified
-with a :term:`CWL` `Application Package`_.
-This is most of the time employed to wrap an operations packaged in a reference :term:`Docker` image.
+with a :term:`CWL` `Application Package`_, which provides resources about one of the described :ref:`app_pkg_types`.
+
+This is most of the time employed to wrap operations packaged in a reference :term:`Docker` image, but it can also
+wrap :ref:`app_pkg_remote` to be executed on another server (i.e.: :term:`ADES`).
 The reference package can be provided in multiple ways as presented below.
 
 .. note::
@@ -198,45 +201,21 @@ Where the referenced file hosted at ``"https://remote-file-server.com/my-package
 ESGF-CWT
 ----------
 
-For *traditional* WPS-1 process type, Weaver adds default values to :term:`CWL` definition. As we can see in
-:mod:`weaver/processes/wps_package.py`, the following default values for the :term:`CWL` package are:
+For :term:`ESGF-CWT` processes, the ``ESGF-CWTRequirement`` hint must be used.
+For an example :term:`CWL` using this definition, see :ref:`app_pkg_esgf_cwt` section.
 
-.. code-block:: python
-
-    cwl_package = OrderedDict([
-        ("cwlVersion", "v1.0"),
-        ("class", "CommandLineTool"),
-        ("hints", {
-            CWL_REQUIREMENT_APP_WPS1: {
-                "provider": get_url_without_query(wps_service_url),
-                "process": process_id,
-            }}),
-    ])
-
-In :term:`ESGF-CWT` processes, ``ESGF-CWTRequirement`` hint must be used instead of usual ``WPS1Requirement``, contained
-in the :py:data:`weaver.processes.constants.CWL_REQUIREMENT_APP_WPS1` variable. The handling of this technicality is
-handled in :mod:`weaver/processes/wps_package.py`. We can define :term:`ESGF-CWT` processes using this syntax:
-
-.. code-block:: json
-
-    {
-      "cwlVersion": "v1.0",
-      "class": "CommandLineTool",
-      "hints": {
-        "ESGF-CWTRequirement": {
-          "provider": "https://edas.nccs.nasa.gov/wps/cwt",
-          "process": "xarray.subset"
-        }
-      }
-    }
+This kind of :term:`Process` allows for remote :ref:`Execution <proc_op_execute>` and
+:ref:`Monitoring <proc_op_monitor>` of a :term:`Job` dispatched to an instance that
+implements |esgf-cwt-git|_ part of the |esgf|_.
+Using `Weaver`, this :term:`Process` automatically obtains an :ref:`proc_ogc_api` representation.
 
 .. _proc_workflow:
 
 Workflow
 ----------
 
-Processes categorized as :term:`Workflow` are very similar to `WPS-REST`_ processes. From the API standpoint, they
-actually look exactly the same as an atomic process when calling :ref:`DescribeProcess <proc_op_describe>`
+Processes categorized as :term:`Workflow` are very similar to :ref:`proc_wps_rest` processes. From the API standpoint,
+they actually look exactly the same as an atomic process when calling :ref:`DescribeProcess <proc_op_describe>`
 or :ref:`Execute <proc_op_execute>` requests.
 The difference lies within the referenced :ref:`Application Package` which uses a :ref:`app_pkg_workflow` instead of
 typical :ref:`app_pkg_cmd`, and therefore, modifies how the :term:`Process` is internally executed.
@@ -292,21 +271,21 @@ responses, the parsing operation accomplished by `Weaver` makes theses services 
 allows the user to use it as a central hub to keep references to all his remotely accessible services and dispatch
 :term:`Job` executions from a common location.
 
-A *remote provider* differs from previously presented `WPS-1/2`_ processes such that the underlying processes of the
-service are not registered locally. For example, if a remote service has two WPS processes, only top-level service URL
-will be registered locally (in `Weaver`'s database) and the application will have no explicit knowledge of these remote
-processes until requested. When calling :term:`Process`-specific requests
+A *remote provider* differs from previously presented :ref:`proc_wps_12` processes such that the underlying processes
+of the service are not registered locally. For example, if a remote service has two WPS processes, only top-level
+service URL will be registered locally (in `Weaver`'s database) and the application will have no explicit knowledge
+of these remote processes until requested. When calling :term:`Process`-specific requests
 (e.g.: :ref:`DescribeProcess <proc_op_describe>` or :ref:`Execute <proc_op_execute>`), `Weaver` will re-send the
 corresponding request (with appropriate interface conversion) directly to the remote :term:`Provider` each time and
-return the result accordingly. On the other hand, a `WPS-1/2`_ reference would be parsed and saved locally with the
-response *at the time of deployment*. This means that a deployed `WPS-1/2`_ reference would act as a *snapshot* of the
-reference :term:`Process` (which could become out-of-sync), while `Remote Provider`_ will dynamically update according
-to the re-fetched response from the remote service each time, always keeping the obtained description in sync with the
-remote :term:`Provider`. If our example remote service was extended to have a third :term:`WPS` process, it would
-immediately and transparently be reflected in :ref:`GetCapabilities <proc_op_getcap>`
+return the result accordingly. On the other hand, a :ref:`proc_wps_12` reference would be parsed and saved locally with
+the response *at the time of deployment*. This means that a deployed :ref:`proc_wps_12` reference would act as
+a *snapshot* of the reference :term:`Process` (which could become out-of-sync), while :ref:`proc_remote_provider` will
+dynamically update according to the re-fetched response from the remote service each time, always keeping the obtained
+description in sync with the remote :term:`Provider`. If our example remote service was extended to have a third
+:term:`WPS` process, it would immediately and transparently be reflected in :ref:`GetCapabilities <proc_op_getcap>`
 and :ref:`DescribeProcess <proc_op_describe>` retrieved by `Weaver` on `Providers`_-scoped requests without any change
-to the registered :term:`Provider` definition. This would not be the case for the `WPS-1/2`_ reference that would need
-a manual update (i.e.: deploy the third :term:`Process` to register it in `Weaver`).
+to the registered :term:`Provider` definition. This would not be the case for the :ref:`proc_wps_12` reference that
+would need a manual update (i.e.: deploy the third :term:`Process` to register it in `Weaver`).
 
 
 .. _`Providers`: https://pavics-weaver.readthedocs.io/en/latest/api.html#tag/Providers
@@ -340,7 +319,7 @@ following request (`DescribeProviderProcess`_):
 
 .. warning::
 
-    API requests scoped under `Providers`_ are `Weaver`-specific implementation. These are not part of |ogc-proc-api|_
+    API requests scoped under `Providers`_ are `Weaver`-specific implementation. These are not part of |ogc-api-proc|_
     specification.
 
 
@@ -382,11 +361,12 @@ result in this process to become available for following steps.
 After deployment and visibility preconditions have been met, the corresponding process should become available
 through :ref:`DescribeProcess <proc_op_describe>` requests and other routes that depend on an existing process.
 
-Note that when a process is deployed using the `WPS-REST`_ interface, it also becomes available through the `WPS-1/2`_
-interface with the same identifier and definition. Because of compatibility limitations, some parameters in the
-`WPS-1/2`_ side might not be perfectly mapped to the equivalent or adjusted `WPS-REST`_ interface, although this
-concerns mostly only new features such as :term:`Job` status monitoring. For most traditional use cases, properties
-are mapped between the two interfaces, but it is recommended to use the `WPS-REST`_ one because of the added features.
+Note that when a process is deployed using the :ref:`proc_wps_rest` interface, it also becomes available through the
+:ref:`proc_wps_12` interface with the same identifier and definition. Because of compatibility limitations, some
+parameters in the :ref:`proc_wps_12` side might not be perfectly mapped to the equivalent or adjusted
+:ref:`proc_wps_rest` interface, although this concerns mostly only new features such as :term:`Job` status monitoring.
+For most traditional use cases, properties are mapped between the two interfaces, but it is recommended to use the
+:ref:`proc_wps_rest` one because of the added features.
 
 .. seealso::
     Please refer to :ref:`application-package` chapter for any additional parameters that can be
@@ -877,8 +857,9 @@ In this case, it becomes the responsibility of this remote instance to handle th
 avoids potential problems such as if `Weaver` as :term:`EMS` doesn't have authorized access to a link that only the
 target :term:`ADES` would have access to.
 
-When :term:`CWL` package defines ``WPS1Requirement`` under ``hints`` for corresponding `WPS-1/2`_ remote processes
-being monitored by `Weaver`, it will skip fetching of |http_scheme|-based references since that would otherwise lead
+When :term:`CWL` package defines ``WPS1Requirement`` under ``hints`` for corresponding :ref:`proc_wps_12` remote
+processes being monitored by `Weaver` (see also :ref:`app_pkg_wps1`),
+it will skip fetching of |http_scheme|-based references since that would otherwise lead
 to useless double downloads (one on `Weaver` and the other on the :term:`WPS` side). It is the same in situation for
 ``ESGF-CWTRequirement`` employed for `ESGF-CWT`_ processes. Because these processes do not always support :term:`S3`
 buckets, and because `Weaver` supports many variants of :term:`S3` reference formats, it will first fetch the :term:`S3`
@@ -927,57 +908,57 @@ combinations.
     :name: table-file-type-handling
     :align: center
 
-    +-----------+-----------------------------------------+---------------+-------------------------------------------+
-    | |cfg|     | Process Type                            | File Scheme   | Applied Operation                         |
-    +===========+=========================================+===============+===========================================+
-    | |any|     | |any|                                   | |os_scheme|   | Query and re-process [#openseach]_        |
-    +-----------+-----------------------------------------+---------------+-------------------------------------------+
-    | |ADES|    | - `WPS-1/2`_                            | |file_scheme| | Convert to |http_scheme| [#file2http]_    |
-    |           | - `ESGF-CWT`_                           +---------------+-------------------------------------------+
-    |           | - `WPS-REST`_ (remote) [#wps3]_         | |http_scheme| | Nothing (unmodified)                      |
-    |           | - :ref:`proc_remote_provider`           +---------------+-------------------------------------------+
-    |           |                                         | |s3_scheme|   | Fetch and convert to |http_scheme| [#s3]_ |
-    |           |                                         +---------------+-------------------------------------------+
-    |           |                                         | |vault_ref|   | Convert to |http_scheme| [#vault2http]_   |
-    |           +-----------------------------------------+---------------+-------------------------------------------+
-    |           | - `WPS-REST`_ (`CWL`) [#wps3]_          | |file_scheme| | Nothing (file already local)              |
-    |           |                                         +---------------+-------------------------------------------+
-    |           |                                         | |http_scheme| | Fetch and convert to |file_scheme|        |
-    |           |                                         +---------------+                                           |
-    |           |                                         | |s3_scheme|   |                                           |
-    |           |                                         +---------------+-------------------------------------------+
-    |           |                                         | |vault_ref|   | Convert to |file_scheme|                  |
-    +-----------+-----------------------------------------+---------------+-------------------------------------------+
-    | |EMS|     | - |any| (types listed above for |ADES|) | |file_scheme| | Convert to |http_scheme| [#file2http]_    |
-    |           | - `Workflow`_ (`CWL`) [#wf]_            +---------------+-------------------------------------------+
-    |           |                                         | |http_scheme| | Nothing (unmodified, step will handle it) |
-    |           |                                         +---------------+                                           |
-    |           |                                         | |s3_scheme|   |                                           |
-    |           |                                         +---------------+                                           |
-    |           |                                         | |vault_ref|   |                                           |
-    +-----------+-----------------------------------------+---------------+-------------------------------------------+
-    | |HYBRID|  | - `WPS-1/2`_                            | |file_scheme| | Convert to |http_scheme| [#file2http]_    |
-    |           | - `ESGF-CWT`_                           +---------------+-------------------------------------------+
-    |           | - `WPS-REST`_ (remote) [#wps3]_         | |http_scheme| | Nothing (unmodified)                      |
-    |           | - :ref:`proc_remote_provider`           +---------------+-------------------------------------------+
-    |           |                                         | |s3_scheme|   | Fetch and convert to |http_scheme| [#s3]_ |
-    |           | *Note*: |HYBRID| assumes |ADES| role    +---------------+-------------------------------------------+
-    |           | (remote processes)                      | |vault_ref|   | Convert to |http_scheme| [#vault2http]_   |
-    |           +-----------------------------------------+---------------+-------------------------------------------+
-    |           | - `WPS-REST`_ (`CWL`) [#wps3]_          | |file_scheme| | Nothing (unmodified)                      |
-    |           |                                         +---------------+-------------------------------------------+
-    |           |                                         | |http_scheme| | Fetch and convert to |file_scheme|        |
-    |           | *Note*: |HYBRID| assumes |ADES| role    +---------------+-------------------------------------------+
-    |           | (local processes)                       | |vault_ref|   | Convert to |file_scheme| [#vault2file]_   |
-    |           +-----------------------------------------+---------------+-------------------------------------------+
-    |           | - `Workflow`_ (`CWL`) [#wf]_            | |file_scheme| | Convert to |http_scheme| [#file2http]_    |
-    |           |                                         +---------------+-------------------------------------------+
-    |           |                                         | |http_scheme| | Nothing (unmodified, step will handle it) |
-    |           |                                         +---------------+                                           |
-    |           |                                         | |s3_scheme|   |                                           |
-    |           |                                         +---------------+                                           |
-    |           | *Note*: |HYBRID| assumes |EMS| role     | |vault_ref|   |                                           |
-    +-----------+-----------------------------------------+---------------+-------------------------------------------+
+    +-----------+------------------------------------------+---------------+-------------------------------------------+
+    | |cfg|     | Process Type                             | File Scheme   | Applied Operation                         |
+    +===========+==========================================+===============+===========================================+
+    | |any|     | |any|                                    | |os_scheme|   | Query and re-process [#openseach]_        |
+    +-----------+------------------------------------------+---------------+-------------------------------------------+
+    | |ADES|    | - :ref:`proc_wps_12`                     | |file_scheme| | Convert to |http_scheme| [#file2http]_    |
+    |           | - :ref:`proc_esgf_cwt`                   +---------------+-------------------------------------------+
+    |           | - :ref:`proc_wps_rest` (remote) [#wps3]_ | |http_scheme| | Nothing (unmodified)                      |
+    |           | - :ref:`proc_remote_provider`            +---------------+-------------------------------------------+
+    |           |                                          | |s3_scheme|   | Fetch and convert to |http_scheme| [#s3]_ |
+    |           |                                          +---------------+-------------------------------------------+
+    |           |                                          | |vault_ref|   | Convert to |http_scheme| [#vault2http]_   |
+    |           +------------------------------------------+---------------+-------------------------------------------+
+    |           | - :ref:`proc_wps_rest` (`CWL`) [#wps3]_  | |file_scheme| | Nothing (file already local)              |
+    |           |                                          +---------------+-------------------------------------------+
+    |           |                                          | |http_scheme| | Fetch and convert to |file_scheme|        |
+    |           |                                          +---------------+                                           |
+    |           |                                          | |s3_scheme|   |                                           |
+    |           |                                          +---------------+-------------------------------------------+
+    |           |                                          | |vault_ref|   | Convert to |file_scheme|                  |
+    +-----------+------------------------------------------+---------------+-------------------------------------------+
+    | |EMS|     | - |any| (types listed above for |ADES|)  | |file_scheme| | Convert to |http_scheme| [#file2http]_    |
+    |           | - :ref:`proc_workflow` (`CWL`) [#wf]_    +---------------+-------------------------------------------+
+    |           |                                          | |http_scheme| | Nothing (unmodified, step will handle it) |
+    |           |                                          +---------------+                                           |
+    |           |                                          | |s3_scheme|   |                                           |
+    |           |                                          +---------------+                                           |
+    |           |                                          | |vault_ref|   |                                           |
+    +-----------+------------------------------------------+---------------+-------------------------------------------+
+    | |HYBRID|  | - :ref:`proc_wps_12`                     | |file_scheme| | Convert to |http_scheme| [#file2http]_    |
+    |           | - :ref:`proc_esgf_cwt`                   +---------------+-------------------------------------------+
+    |           | - :ref:`proc_wps_rest` (remote) [#wps3]_ | |http_scheme| | Nothing (unmodified)                      |
+    |           | - :ref:`proc_remote_provider`            +---------------+-------------------------------------------+
+    |           |                                          | |s3_scheme|   | Fetch and convert to |http_scheme| [#s3]_ |
+    |           | *Note*: |HYBRID| assumes |ADES| role     +---------------+-------------------------------------------+
+    |           | (remote processes)                       | |vault_ref|   | Convert to |http_scheme| [#vault2http]_   |
+    |           +------------------------------------------+---------------+-------------------------------------------+
+    |           | - :ref:`proc_wps_rest` (`CWL`) [#wps3]_  | |file_scheme| | Nothing (unmodified)                      |
+    |           |                                          +---------------+-------------------------------------------+
+    |           |                                          | |http_scheme| | Fetch and convert to |file_scheme|        |
+    |           | *Note*: |HYBRID| assumes |ADES| role     +---------------+-------------------------------------------+
+    |           | (local processes)                        | |vault_ref|   | Convert to |file_scheme| [#vault2file]_   |
+    |           +------------------------------------------+---------------+-------------------------------------------+
+    |           | - :ref:`proc_workflow` (`CWL`) [#wf]_    | |file_scheme| | Convert to |http_scheme| [#file2http]_    |
+    |           |                                          +---------------+-------------------------------------------+
+    |           |                                          | |http_scheme| | Nothing (unmodified, step will handle it) |
+    |           |                                          +---------------+                                           |
+    |           |                                          | |s3_scheme|   |                                           |
+    |           |                                          +---------------+                                           |
+    |           | *Note*: |HYBRID| assumes |EMS| role      | |vault_ref|   |                                           |
+    +-----------+------------------------------------------+---------------+-------------------------------------------+
 
 .. |any| replace:: *<any>*
 .. |cfg| replace:: Configuration
@@ -1009,12 +990,12 @@ combinations.
     where `Weaver` is hosted or another service takes care of this task.
 
 .. [#wps3]
-    When the process refers to a remote :ref:`WPS-REST` process (i.e.: remote :term:`WPS` instance that supports
+    When the process refers to a remote :ref:`proc_wps_rest` process (i.e.: remote :term:`WPS` instance that supports
     REST bindings but that is not necessarily an :term:`ADES`), `Weaver` simply *wraps* and monitors its remote
     execution, therefore files are handled just as for any other type of remote :term:`WPS`-like servers. When the
     process contains an actual :term:`CWL` :ref:`Application Package` that defines a ``CommandLineTool`` class
     (including applications with :term:`Docker` image requirement), files are fetched as it will be executed locally.
-    See :ref:`CWL CommandLineTool`, :ref:`WPS-REST` and :ref:`Remote Provider` for further details.
+    See :ref:`CWL CommandLineTool`, :ref:`proc_wps_rest` and :ref:`Remote Provider` for further details.
 
 .. [#s3]
     When an |s3_scheme| file is fetched, is gets downloaded to a temporary |file_scheme| location, which is **NOT**
@@ -1022,9 +1003,9 @@ combinations.
     support :term:`S3` references, only then the file gets converted as in [#file2http]_.
 
 .. [#vault2file]
-    When a |vault_ref| file is specified, the local :ref:`WPS-REST` process can make use of it directly. The file is
-    therefore retrieved from the :term:`Vault` using the provided UUID and access token to be passed to the application.
-    See :ref:`file_vault_inputs` and :ref:`vault_upload` for more details.
+    When a |vault_ref| file is specified, the local :ref:`proc_wps_rest` process can make use of it directly.
+    The file is therefore retrieved from the :term:`Vault` using the provided UUID and access token to be passed
+    to the application. See :ref:`file_vault_inputs` and :ref:`vault_upload` for more details.
 
 .. [#vault2http]
     When a |vault_ref| file is specified, the remote process needs to access it using the hosted :term:`Vault` endpoint.
@@ -1521,7 +1502,7 @@ and/or ``logging`` operation for scripts or :term:`Docker` images executed throu
 
 .. note::
     :term:`Job` logs and exceptions are a `Weaver`-specific implementation.
-    They are not part of traditional |ogc-proc-api|_.
+    They are not part of traditional |ogc-api-proc|_.
 
 A minimalistic example of logging output is presented below. This can be retrieved using |log-req|_ request, at any
 moment during :term:`Job` execution (with logs up to that point in time) or after its completion (for full output).

--- a/docs/source/references.rst
+++ b/docs/source/references.rst
@@ -36,6 +36,14 @@
 .. _cwl-workdir-ex: https://www.commonwl.org/user_guide/15-staging/
 .. |cwl-docker-req| replace:: DockerRequirement
 .. _cwl-docker-req: https://www.commonwl.org/v1.1/CommandLineTool.html#DockerRequirement
+.. FIXME apply official CWL specification location
+.. https://github.com/common-workflow-language/cwl-v1.2/issues/212
+.. |cwl-cuda-req| replace:: cwltool:CUDARequirement
+.. _cwl-cuda-req: https://doc.arvados.org/v2.4/user/cwl/cwl-extensions.html#CUDARequirement
+.. |cwl-resource-req| replace:: ResourceRequirement
+.. _cwl-resource-req: https://www.commonwl.org/v1.2/CommandLineTool.html#ResourceRequirement
+.. |cwl-network-req| replace:: NetworkAccess
+.. _cwl-network-req: https://www.commonwl.org/v1.2/CommandLineTool.html#NetworkAccess
 .. |cwl-io-map| replace:: CWL Mapping
 .. _cwl-io-map: https://www.commonwl.org/v1.1/CommandLineTool.html#map
 .. |cwl-io-type| replace:: CWLType Symbols

--- a/docs/source/references.rst
+++ b/docs/source/references.rst
@@ -68,8 +68,8 @@
 .. _ogc: https://www.ogc.org/
 .. |ogc-home| replace:: |ogc| Homepage
 .. _ogc-home: `ogc`_
-.. |ogc-proc-api| replace:: OGC API - Processes
-.. _ogc-proc-api: https://github.com/opengeospatial/ogcapi-processes
+.. |ogc-api-proc| replace:: OGC API - Processes
+.. _ogc-api-proc: https://github.com/opengeospatial/ogcapi-processes
 .. |ogc-exec-sync-responses| replace:: OGC API - Processes, Responses (sync)
 .. _ogc-exec-sync-responses: https://docs.ogc.org/is/18-062r2/18-062r2.html#sc_execute_response
 .. |ogc-exec-async-responses| replace:: OGC API - Processes, Responses (async)

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,23 +5,23 @@ tag = True
 tag_name = {new_version}
 
 [bumpversion:file:CHANGES.rst]
-search = 
+search =
 	`Unreleased <https://github.com/crim-ca/weaver/tree/master>`_ (latest)
 	========================================================================
-replace = 
+replace =
 	`Unreleased <https://github.com/crim-ca/weaver/tree/master>`_ (latest)
 	========================================================================
-	
+
 	Changes:
 	--------
 	- No change.
-	
+
 	Fixes:
 	------
 	- No change.
-	
+
 	.. _changes_{new_version}:
-	
+
 	`{new_version} <https://github.com/crim-ca/weaver/tree/{new_version}>`_ ({now:%%Y-%%m-%%d})
 	========================================================================
 
@@ -42,14 +42,14 @@ search = LABEL version="{current_version}"
 replace = LABEL version="{new_version}"
 
 [tool:pytest]
-addopts = 
+addopts =
 	--strict-markers
 	--tb=native
 	weaver/
 log_cli = false
 log_level = DEBUG
 python_files = test_*.py
-markers = 
+markers =
 	cli: mark test as related to CLI operations
 	testbed14: mark test as 'testbed14' validation
 	functional: mark test as functionality validation
@@ -80,7 +80,7 @@ targets = .
 [flake8]
 ignore = E126,E226,E402,F401,W503,W504
 max-line-length = 120
-exclude = 
+exclude =
 	src,
 	.git,
 	__pycache__,
@@ -112,14 +112,14 @@ add_select = D201,D213
 branch = true
 source = ./
 include = weaver/*
-omit = 
+omit =
 	setup.py
 	docs/*
 	tests/*
 	*_mako
 
 [coverage:report]
-exclude_lines = 
+exclude_lines =
 	pragma: no cover
 	raise OSError
 	raise AssertionError
@@ -143,5 +143,6 @@ exclude_lines =
 	raise PackageAuthenticationError
 	raise PackageExecutionError
 	raise PackageNotFound
+	raise PackageParsingError
 	raise PackageRegistrationError
 	raise PackageTypeError

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,27 +1,27 @@
 [bumpversion]
-current_version = 4.26.0
+current_version = 4.27.0
 commit = True
 tag = True
 tag_name = {new_version}
 
 [bumpversion:file:CHANGES.rst]
-search =
+search = 
 	`Unreleased <https://github.com/crim-ca/weaver/tree/master>`_ (latest)
 	========================================================================
-replace =
+replace = 
 	`Unreleased <https://github.com/crim-ca/weaver/tree/master>`_ (latest)
 	========================================================================
-
+	
 	Changes:
 	--------
 	- No change.
-
+	
 	Fixes:
 	------
 	- No change.
-
+	
 	.. _changes_{new_version}:
-
+	
 	`{new_version} <https://github.com/crim-ca/weaver/tree/{new_version}>`_ ({now:%%Y-%%m-%%d})
 	========================================================================
 
@@ -42,14 +42,14 @@ search = LABEL version="{current_version}"
 replace = LABEL version="{new_version}"
 
 [tool:pytest]
-addopts =
+addopts = 
 	--strict-markers
 	--tb=native
 	weaver/
 log_cli = false
 log_level = DEBUG
 python_files = test_*.py
-markers =
+markers = 
 	cli: mark test as related to CLI operations
 	testbed14: mark test as 'testbed14' validation
 	functional: mark test as functionality validation
@@ -80,7 +80,7 @@ targets = .
 [flake8]
 ignore = E126,E226,E402,F401,W503,W504
 max-line-length = 120
-exclude =
+exclude = 
 	src,
 	.git,
 	__pycache__,
@@ -112,14 +112,14 @@ add_select = D201,D213
 branch = true
 source = ./
 include = weaver/*
-omit =
+omit = 
 	setup.py
 	docs/*
 	tests/*
 	*_mako
 
 [coverage:report]
-exclude_lines =
+exclude_lines = 
 	pragma: no cover
 	raise OSError
 	raise AssertionError

--- a/tests/functional/application-packages/ReadFile/deploy.yml
+++ b/tests/functional/application-packages/ReadFile/deploy.yml
@@ -19,5 +19,5 @@ outputTransmission:
   - reference
 executionUnit:
   # note: This does not work by itself! The test suite injects the file dynamically.
-  - href: "tests/functional/application-packages/CatValue/cat.cwl"
+  - href: "tests/functional/application-packages/ReadValue/package.cwl"
 deploymentProfileName: "http://www.opengis.net/profiles/eoc/dockerizedApplication"

--- a/tests/functional/application-packages/SimulateResourceUsage/deploy.yml
+++ b/tests/functional/application-packages/SimulateResourceUsage/deploy.yml
@@ -1,0 +1,15 @@
+# YAML representation supported by WeaverClient
+processDescription:
+  id: SimulateResourceUsage
+  title: Gradually allocate RAM to simulate a process load.
+  version: "1.0"
+  keywords:
+    - test
+jobControlOptions:
+  - async-execute
+outputTransmission:
+  - reference
+executionUnit:
+  # note: This does not work by itself! The test suite injects the file dynamically.
+  - href: "tests/functional/application-packages/SimulateResourceUsage/package.cwl"
+deploymentProfileName: "http://www.opengis.net/profiles/eoc/dockerizedApplication"

--- a/tests/functional/application-packages/SimulateResourceUsage/job.yml
+++ b/tests/functional/application-packages/SimulateResourceUsage/job.yml
@@ -1,0 +1,4 @@
+ram_amount: 4
+ram_chunks: 16
+time_duration: 1
+time_interval: 0.25

--- a/tests/functional/application-packages/SimulateResourceUsage/package.cwl
+++ b/tests/functional/application-packages/SimulateResourceUsage/package.cwl
@@ -1,0 +1,45 @@
+#!/usr/bin/env cwl-runner
+# WARNING:
+#   This process can generate a large memory load and a very large output file that captures the generated data.
+#   Even with default ResourceRequirement values, the output can become substantial rapidly.
+cwlVersion: "v1.0"
+class: CommandLineTool
+baseCommand:
+  - bash
+  - script.sh
+requirements:
+  DockerRequirement:
+    dockerPull: debian:stretch-slim
+  InitialWorkDirRequirement:
+    listing:
+      # below script is generated dynamically in the working directory, and then called by the base command
+      # reference: https://unix.stackexchange.com/a/254976/288952
+      - entryname: script.sh
+        entry: |
+          echo "Will allocate RAM chunks of $(inputs.ram_chunks) MiB."
+          echo "Will allocate RAM chunks in increments up to $(inputs.ram_amount) times."
+          echo "Will maintain allocated RAM load for $(inputs.time_duration)s for each increment."
+          echo "Will wait $(inputs.time_interval)s between each allocation."
+          echo "Begin allocating memory..."
+          for index in \$(seq $(inputs.ram_amount)); do
+              echo "Allocating \$index x $(inputs.ram_chunks) MiB for $(inputs.time_duration)s..."
+              cat <( </dev/zero head -c \$((\$index * $(inputs.ram_chunks)))m) <(sleep $(inputs.time_duration)) | tail
+              echo "Waiting for $(inputs.time_interval)s..."
+              sleep $(inputs.time_interval)
+          done
+          echo "Finished allocating memory..."
+inputs:
+  ram_chunks:
+    type: int
+  ram_amount:
+    type: int
+  time_duration:
+    type: float
+  time_interval:
+    type: float
+outputs:
+  output:
+    type: File
+    outputBinding:
+      glob: "stdout.log"
+stdout: stdout.log

--- a/tests/functional/test_workflow.py
+++ b/tests/functional/test_workflow.py
@@ -525,7 +525,7 @@ class WorkflowTestRunnerBase(ResourcesUtil, TestCase):
         test_process_id = f"{cls.__name__}_{deploy_id}"
         execute_payload = cls.retrieve_payload(pid, "execute")
 
-        # replace derived reference (local only, remote must used full 'href' references)
+        # replace derived reference (local only, remote must be used full 'href' references)
         test_app_pkg = deploy_payload.get("executionUnit", [{}])[0].pop("test", None)
         if test_app_pkg:
             unit_app_pkg = cls.retrieve_payload(pid, "package")
@@ -889,7 +889,7 @@ class WorkflowTestRunnerBase(ResourcesUtil, TestCase):
                     if resp.status_code == 200 and isinstance(resp.json, list):
                         step_logs = tab_n.join(resp.json)
                         msg += f"\nStep process logs [JobID: {job_id}]" + tab_n + step_logs
-        except Exception:
+        except Exception:  # noqa
             return "Could not retrieve job logs."
         return msg
 

--- a/tests/functional/test_workflow.py
+++ b/tests/functional/test_workflow.py
@@ -530,7 +530,7 @@ class WorkflowTestRunnerBase(ResourcesUtil, TestCase):
         test_process_id = f"{cls.__name__}_{deploy_id}"
         execute_payload = cls.retrieve_payload(pid, "execute")
 
-        # replace derived reference (local only, remote must be used full 'href' references)
+        # replace derived reference (local only, remote must use the full 'href' references)
         test_app_pkg = deploy_payload.get("executionUnit", [{}])[0].pop("test", None)
         if test_app_pkg:
             unit_app_pkg = cls.retrieve_payload(pid, "package")

--- a/tests/functional/test_workflow.py
+++ b/tests/functional/test_workflow.py
@@ -362,6 +362,11 @@ class WorkflowTestRunnerBase(ResourcesUtil, TestCase):
                     level = cls.logger_level
                 cls.logger.log(level, message, *args, stack_info=traceback)
         if exception:
+            if "%" in message and args:
+                try:
+                    message = message % args
+                except TypeError:  # error on insufficient/over-specified format string arguments
+                    message += f"\nArguments could not be formatted into message: {args}"
             raise RuntimeError(message)
 
     @classmethod

--- a/tests/functional/test_wps_package.py
+++ b/tests/functional/test_wps_package.py
@@ -2509,7 +2509,7 @@ class WpsPackageAppTest(WpsConfigBase, ResourcesUtil):
         # FIXME: ensure ResourceRequirements are effective (https://github.com/crim-ca/weaver/issues/138)
         # (True, 48, 96, 4, 2, 0.25, 0.25, {CWL_REQUIREMENT_RESOURCE: {"ramMax": 2}}),      # FIXME: hangs forever
         # (True, 48, 96, 4, 2, 0.25, 0.25, {CWL_REQUIREMENT_RESOURCE: {"outdirMax": 2}}),   # FIXME: not failing
-        (True, 48, 96, 4, 2, 0.25, 0.25, {CWL_REQUIREMENT_RESOURCE: {"outdirMax": 16}}),
+        (False, 48, 96, 4, 2, 0.25, 0.25, {CWL_REQUIREMENT_RESOURCE: {"outdirMax": 16}}),
     ])
     def test_execute_with_resource_requirement(self,
                                                expect_fail,             # type: bool

--- a/tests/functional/test_wps_package.py
+++ b/tests/functional/test_wps_package.py
@@ -12,6 +12,7 @@ import copy
 import json
 import logging
 import os
+import shutil
 import tempfile
 from copy import deepcopy
 from inspect import cleandoc
@@ -56,6 +57,7 @@ from weaver.processes.constants import (
     CWL_REQUIREMENT_APP_DOCKER,
     CWL_REQUIREMENT_INIT_WORKDIR,
     CWL_REQUIREMENT_INLINE_JAVASCRIPT,
+    CWL_REQUIREMENT_RESOURCE,
     ProcessSchema
 )
 from weaver.processes.types import ProcessType
@@ -66,7 +68,7 @@ from weaver.wps.utils import get_wps_output_dir, get_wps_output_url, map_wps_out
 if TYPE_CHECKING:
     from typing import List
 
-    from weaver.typedefs import JSON, CWL_AnyRequirements
+    from weaver.typedefs import JSON, CWL_AnyRequirements, CWL_RequirementsDict, Number
 
 EDAM_PLAIN = EDAM_NAMESPACE + ":" + EDAM_MAPPING[ContentType.TEXT_PLAIN]
 OGC_NETCDF = OGC_NAMESPACE + ":" + OGC_MAPPING[ContentType.APP_NETCDF]
@@ -2499,6 +2501,106 @@ class WpsPackageAppTest(WpsConfigBase, ResourcesUtil):
             assert all(os.path.isfile(file) for file in expect_out_files)
             output_dir_files = {os.path.join(root, file) for root, _, files in os.walk(out_dir) for file in files}
             assert output_dir_files == expect_out_files
+
+    @parameterized.expand([
+        # all values in MiB / seconds accordingly
+        (False, 48, 96, 16, 3, 0.25, 0.25, {}),
+        (False, 48, 36, 4, 4, 0.25, 0.25, {CWL_REQUIREMENT_RESOURCE: {"ramMax": 52}}),
+        # FIXME: ensure ResourceRequirements are effective (https://github.com/crim-ca/weaver/issues/138)
+        # (True, 48, 96, 4, 2, 0.25, 0.25, {CWL_REQUIREMENT_RESOURCE: {"ramMax": 2}}),      # FIXME: hangs forever
+        # (True, 48, 96, 4, 2, 0.25, 0.25, {CWL_REQUIREMENT_RESOURCE: {"outdirMax": 2}}),   # FIXME: not failing
+        (True, 48, 96, 4, 2, 0.25, 0.25, {CWL_REQUIREMENT_RESOURCE: {"outdirMax": 16}}),
+    ])
+    def test_execute_with_resource_requirement(self,
+                                               expect_fail,             # type: bool
+                                               expect_ram_min_mb,       # type: int
+                                               expect_size_min_mb,      # type: int
+                                               ram_chunks_mb,           # type: int
+                                               ram_amount_mb,           # type: int
+                                               time_duration_s,         # type: Number
+                                               time_interval_s,         # type: Number
+                                               resource_requirement,    # type: CWL_RequirementsDict
+                                               ):                       # type: (...) -> None
+        """
+        Test that :data:`CWL_REQUIREMENT_RESOURCE` are considered for :term:`Process` execution.
+
+        .. note::
+            This test also conveniently serves for testing how large :term:`Job` logs are handled by the storage.
+            Because of the large output produced and captured in the logs, saving them directly to the database
+            is not supported. The :term:`Job` should therefore filter problematic entries to the log.
+        """
+        proc = "SimulateResourceUsage"
+        body = self.retrieve_payload(proc, "deploy", local=True)
+        pkg = self.retrieve_payload(proc, "package", local=True)
+        pkg["requirements"].update(resource_requirement)
+        body["executionUnit"] = [{"unit": pkg}]
+        self.deploy_process(body, describe_schema=ProcessSchema.OGC)
+
+        exec_body = {
+            "mode": ExecuteMode.ASYNC,
+            "response": ExecuteResponse.DOCUMENT,
+            "inputs": {
+                "ram_chunks": ram_chunks_mb,
+                "ram_amount": ram_amount_mb,
+                "time_duration": time_duration_s,
+                "time_interval": time_interval_s,
+            },
+            "outputs": [{"id": "output", "transmissionMode": ExecuteTransmissionMode.REFERENCE}]
+        }
+        out_dir = None
+        try:
+            with contextlib.ExitStack() as stack:
+                for mock_exec in mocked_execute_celery():
+                    stack.enter_context(mock_exec)
+                proc_url = f"/processes/{proc}/jobs"
+                resp = mocked_sub_requests(self.app, "post_json", proc_url, timeout=5,
+                                           data=exec_body, headers=self.json_headers, only_local=True)
+                assert resp.status_code in [200, 201], f"Failed with: [{resp.status_code}]\nReason:\n{resp.json}"
+                status_url = resp.json["location"]
+                job_id = resp.json["jobID"]
+                wps_dir = get_wps_output_dir(self.settings)
+                out_dir = os.path.join(wps_dir, job_id, "output")
+
+                results = self.monitor_job(status_url, expect_failed=expect_fail)
+                assert "output" in results
+                out_log = os.path.join(out_dir, "stdout.log")
+                assert os.path.isfile(out_log)
+                assert os.stat(out_log).st_size >= expect_size_min_mb * 2**20
+                with open(out_log, mode="r", encoding="utf-8") as out_file:
+                    output = (line for line in out_file.readlines() if line[0] != "\0")
+                output = list(output)
+                assert all(
+                    any(f"Allocating {i} x {ram_chunks_mb} MiB" in line for line in output)
+                    for i in range(1, ram_amount_mb + 1)
+                )
+
+                log_url = f"{status_url}/logs"
+                log_resp = mocked_sub_requests(self.app, "get", log_url, timeout=5,
+                                               headers=self.json_headers, only_local=True)
+                job_logs = log_resp.json
+                assert all(
+                    any(f"Allocating {i} x {ram_chunks_mb} MiB" in line for line in job_logs)
+                    for i in range(1, ram_amount_mb + 1)
+                )
+                assert all(
+                    any(
+                        f"<message clipped due to large dimension ({i * ram_chunks_mb:.2f} MiB)>"
+                        in line for line in job_logs
+                    )
+                    for i in range(1, ram_amount_mb + 1)
+                )
+
+                stat_url = f"{status_url}/statistics"
+                stat_resp = mocked_sub_requests(self.app, "get", stat_url, timeout=5,
+                                                headers=self.json_headers, only_local=True)
+                job_stats = stat_resp.json
+                assert all(
+                    job_stats["process"][mem] > expect_ram_min_mb
+                    for mem in ["rssBytes", "ussBytes", "vmsBytes"]
+                )
+        finally:
+            if out_dir:
+                shutil.rmtree(out_dir, ignore_errors=True)
 
     # FIXME: create a real async test (threading/multiprocess) to evaluate this correctly
     def test_dismiss_job(self):

--- a/tests/functional/test_wps_package.py
+++ b/tests/functional/test_wps_package.py
@@ -1075,6 +1075,7 @@ class WpsPackageAppTest(WpsConfigBase, ResourcesUtil):
         # not allowed even if combined with another known and valid definition
         ({"UnknownRequirement": {}, CWL_REQUIREMENT_APP_DOCKER: {"dockerPull": "python:3.7-alpine"}}, ),
         ({"UnknownRequirement": {}}, ),
+        ({}, ),  # no requirement (i.e.: simple shell script) also invalid
     ])
     def test_deploy_block_unknown_processes(self, requirements):
         # type: (CWL_AnyRequirements) -> None

--- a/tests/functional/test_wps_package.py
+++ b/tests/functional/test_wps_package.py
@@ -2031,7 +2031,7 @@ class WpsPackageAppTest(WpsConfigBase, ResourcesUtil):
                                 except Exception as exc:
                                     print(exc)
                                     raise
-                                """)
+                            """)
                         }
                     ]
                 }

--- a/tests/functional/test_wps_package.py
+++ b/tests/functional/test_wps_package.py
@@ -2509,7 +2509,7 @@ class WpsPackageAppTest(WpsConfigBase, ResourcesUtil):
         # FIXME: ensure ResourceRequirements are effective (https://github.com/crim-ca/weaver/issues/138)
         # (True, 48, 96, 4, 2, 0.25, 0.25, {CWL_REQUIREMENT_RESOURCE: {"ramMax": 2}}),      # FIXME: hangs forever
         # (True, 48, 96, 4, 2, 0.25, 0.25, {CWL_REQUIREMENT_RESOURCE: {"outdirMax": 2}}),   # FIXME: not failing
-        (False, 48, 96, 4, 2, 0.25, 0.25, {CWL_REQUIREMENT_RESOURCE: {"outdirMax": 16}}),
+        (False, 48, 12, 4, 2, 0.25, 0.25, {CWL_REQUIREMENT_RESOURCE: {"outdirMax": 16}}),
     ])
     def test_execute_with_resource_requirement(self,
                                                expect_fail,             # type: bool

--- a/tests/processes/test_constants.py
+++ b/tests/processes/test_constants.py
@@ -1,0 +1,33 @@
+import pytest
+
+from weaver.processes.constants import CWL_REQUIREMENT_CUDA_DEFAULT_PARAMETERS
+
+
+def test_cuda_default_parameters_immutable():
+    with pytest.raises(TypeError):
+        CWL_REQUIREMENT_CUDA_DEFAULT_PARAMETERS["value"] = 1
+    assert "value" not in CWL_REQUIREMENT_CUDA_DEFAULT_PARAMETERS
+
+    key = list(CWL_REQUIREMENT_CUDA_DEFAULT_PARAMETERS)[0]
+    before = CWL_REQUIREMENT_CUDA_DEFAULT_PARAMETERS[key]
+    with pytest.raises(TypeError):
+        CWL_REQUIREMENT_CUDA_DEFAULT_PARAMETERS[key] = "test"
+    assert CWL_REQUIREMENT_CUDA_DEFAULT_PARAMETERS[key] == before
+
+
+@pytest.mark.parametrize("parameters_copy", [
+    dict(CWL_REQUIREMENT_CUDA_DEFAULT_PARAMETERS),
+    CWL_REQUIREMENT_CUDA_DEFAULT_PARAMETERS.copy(),
+])
+def test_cuda_default_parameters_copy_mutable(parameters_copy):
+    assert parameters_copy is not CWL_REQUIREMENT_CUDA_DEFAULT_PARAMETERS
+    key = list(parameters_copy)[0]
+    try:
+        parameters_copy["value"] = "test"
+        parameters_copy.pop(key)
+    except TypeError:
+        pytest.fail("Only original mapping should be immutable, copy should be permitted updates.")
+    assert "value" not in CWL_REQUIREMENT_CUDA_DEFAULT_PARAMETERS
+    assert parameters_copy["value"] == "test"
+    assert key in CWL_REQUIREMENT_CUDA_DEFAULT_PARAMETERS
+    assert key not in parameters_copy

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1425,10 +1425,10 @@ def assert_equal_any_order(result,          # type: Iterable[Any]
                            formatter=str,   # type: Optional[Callable[[CompareType], str]]
                            ):               # type: (...) -> None
     if not callable(comparer):
-        def comparer(_res, _exp):
+        def comparer(_res, _exp):  # pylint: disable=E0102
             return _res == _exp
 
-    assert type(result) == type(expect), "Expected types mismatch between iterable containers."
+    assert type(result) == type(expect), "Expected types mismatch between iterable containers."  # pylint: disable=C0123
     # in case of exhaustible iterators, compute them to get a copy once
     # also use the copy to remove items such that all must be matched
     result = list(result)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1150,8 +1150,17 @@ def mocked_process_package():
     """
     Provides mocks that bypasses execution when calling :module:`weaver.processes.wps_package` functions.
     """
+    from weaver.processes.wps_package import get_application_requirement as real_get_application_requirement
+
+    def mock_get_app_req(package, **kwargs):
+        if package.get("class") == "test":
+            kwargs["required"] = False
+            kwargs["validate"] = False
+        return real_get_application_requirement(package, **kwargs)
+
     return (
         mock.patch("weaver.processes.utils.load_package_file", return_value={"class": "test"}),
+        mock.patch("weaver.processes.wps_package.get_application_requirement", side_effect=mock_get_app_req),
         mock.patch("weaver.processes.wps_package.load_package_file", return_value={"class": "test"}),
         mock.patch("weaver.processes.wps_package._load_package_content", return_value=(None, "test", None)),
         mock.patch("weaver.processes.wps_package._get_package_inputs_outputs", return_value=(None, None)),

--- a/tests/wps_restapi/test_processes.py
+++ b/tests/wps_restapi/test_processes.py
@@ -753,7 +753,7 @@ class WpsRestApiProcessesTest(unittest.TestCase):
         process = self.process_store.fetch_by_id(proc_id)
         assert process.auth is not None
         assert process.auth.type == AuthenticationTypes.DOCKER
-        assert process.auth.token == token
+        assert process.auth.token == token  # noqa
         assert process.auth.docker == docker
 
     def test_deploy_process_CWL_direct_raised_missing_id(self):
@@ -884,7 +884,7 @@ class WpsRestApiProcessesTest(unittest.TestCase):
             stack.enter_context(mocked_wps_output(self.settings))
             out_dir = self.settings["weaver.wps_output_dir"]
             out_url = self.settings["weaver.wps_output_url"]
-            assert out_url.startswith("http"), "test can run only if reference is a HTTP reference"  # sanity check
+            assert out_url.startswith("http"), "test can run only if reference is an HTTP reference"  # sanity check
             tmp_dir = stack.enter_context(tempfile.TemporaryDirectory(dir=out_dir))
             tmp_file = os.path.join(tmp_dir, "docker-python.cwl")
             tmp_href = tmp_file.replace(out_dir, out_url, 1)
@@ -926,7 +926,7 @@ class WpsRestApiProcessesTest(unittest.TestCase):
             stack.enter_context(mocked_wps_output(self.settings))
             out_dir = self.settings["weaver.wps_output_dir"]
             out_url = self.settings["weaver.wps_output_url"]
-            assert out_url.startswith("http"), "test can run only if reference is a HTTP reference"  # sanity check
+            assert out_url.startswith("http"), "test can run only if reference is an HTTP reference"  # sanity check
             tmp_dir = stack.enter_context(tempfile.TemporaryDirectory(dir=out_dir))
             tmp_file = os.path.join(tmp_dir, "docker-python.cwl")
             tmp_href = tmp_file.replace(out_dir, out_url, 1)
@@ -1086,7 +1086,7 @@ class WpsRestApiProcessesTest(unittest.TestCase):
             stack.enter_context(mocked_wps_output(self.settings))
             out_dir = self.settings["weaver.wps_output_dir"]
             out_url = self.settings["weaver.wps_output_url"]
-            assert out_url.startswith("http"), "test can run only if reference is a HTTP reference"  # sanity check
+            assert out_url.startswith("http"), "test can run only if reference is an HTTP reference"  # sanity check
             tmp_dir = stack.enter_context(tempfile.TemporaryDirectory(dir=out_dir))
             tmp_file = os.path.join(tmp_dir, "wps1.cwl")
             tmp_href = tmp_file.replace(out_dir, out_url, 1)
@@ -1174,7 +1174,7 @@ class WpsRestApiProcessesTest(unittest.TestCase):
             stack.enter_context(mocked_wps_output(self.settings))
             wps_dir = self.settings["weaver.wps_output_dir"]
             wps_url = self.settings["weaver.wps_output_url"]
-            assert wps_url.startswith("http"), "test can run only if reference is a HTTP reference"  # sanity check
+            assert wps_url.startswith("http"), "test can run only if reference is an HTTP reference"  # sanity check
             tmp_file = stack.enter_context(tempfile.NamedTemporaryFile(dir=wps_dir, mode="w", suffix=".cwl"))
             tmp_http = tmp_file.name.replace(wps_dir, wps_url, 1)
             json.dump(cwl, tmp_file)
@@ -1761,7 +1761,7 @@ class WpsRestApiProcessesTest(unittest.TestCase):
         body = resp.json
         assert body["processSummary"]["title"] == data["processDescription"]["process"]["title"], (
             "Even though MAJOR update for CWL is accomplished, other fields that usually correspond to MINOR changes "
-            "should also applied at the same time since the operation replaces the new process definition (PUT)."
+            "should also be applied at the same time since the operation replaces the new process definition (PUT)."
         )
         assert (
             "description" not in body["processSummary"] or  # if undefined, dropped from body
@@ -2037,7 +2037,7 @@ class WpsRestApiProcessesTest(unittest.TestCase):
             execute_mock_data_tests.append((mock_execute, data_execute))
 
         # apply modifications for testing
-        execute_mock_data_tests[0][1].pop("inputs")  # no inputs is valid (although can be required for WPS process)
+        execute_mock_data_tests[0][1].pop("inputs")  # no inputs valid (although it can be required for WPS process)
         execute_mock_data_tests[0][1]["outputs"][0].pop("transmissionMode")  # should resolve to default value
 
         for mock_execute, data_execute in execute_mock_data_tests:

--- a/tests/wps_restapi/test_processes.py
+++ b/tests/wps_restapi/test_processes.py
@@ -783,21 +783,8 @@ class WpsRestApiProcessesTest(unittest.TestCase):
                                   process_id="test-direct-cwl-json",    # type: str
                                   version=None,                         # type: Optional[AnyVersion]
                                   ):                                    # type: (...) -> Tuple[CWL, JSON]
-        cwl_core = {
-            "id": process_id,
-            "class": "CommandLineTool",
-            "baseCommand": ["python3", "-V"],
-            "inputs": {},
-            "outputs": {
-                "output": {
-                    "type": "File",
-                    "outputBinding": {
-                        "glob": "stdout.log"
-                    },
-                }
-            },
-        }
         cwl = {}
+        cwl_core = self.get_cwl_docker_python_version(cwl_version=None, process_id=process_id)
         cwl_base = {"cwlVersion": "v1.0"}
         cwl.update(cwl_base)
         if version:
@@ -857,10 +844,14 @@ class WpsRestApiProcessesTest(unittest.TestCase):
         assert "Longer than maximum length 1" in error
 
     @staticmethod
-    def get_cwl_docker_python_version():
-        # type: () -> CWL
-        return {
-            "cwlVersion": "v1.0",
+    def get_cwl_docker_python_version(cwl_version="v1.0", process_id=None):
+        # type: (Optional[str], Optional[str]) -> CWL
+        cwl = {}
+        if cwl_version:
+            cwl["cwlVersion"] = cwl_version
+        if process_id:
+            cwl["id"] = process_id
+        cwl.update({
             "class": "CommandLineTool",
             "requirements": {
                 CWL_REQUIREMENT_APP_DOCKER: {
@@ -877,7 +868,8 @@ class WpsRestApiProcessesTest(unittest.TestCase):
                     },
                 }
             },
-        }
+        })
+        return cwl
 
     def test_deploy_process_CWL_DockerRequirement_href(self):
         with contextlib.ExitStack() as stack:

--- a/tests/wps_restapi/test_processes.py
+++ b/tests/wps_restapi/test_processes.py
@@ -1044,11 +1044,11 @@ class WpsRestApiProcessesTest(unittest.TestCase):
             stack.enter_context(mocked_wps_output(self.settings))
             network_access_requirement = {"networkAccess": True}
             docker_requirement = {"dockerPull": "python:3.7-alpine"}
-            for type in ["hints", "requirements"]:
+            for req_type in ["hints", "requirements"]:
                 cwl = {
                     "class": "CommandLineTool",
                     "cwlVersion": "v1.2",
-                    type: {
+                    req_type: {
                         "NetworkAccess": network_access_requirement,
                         "DockerRequirement": docker_requirement
                     },
@@ -1063,7 +1063,7 @@ class WpsRestApiProcessesTest(unittest.TestCase):
                     }
                 }
 
-                p_id = "test-network-access-" + type
+                p_id = "test-network-access-" + req_type
                 body = {
                     "processDescription": {"process": {"id": p_id}},
                     "executionUnit": [{"unit": cwl}],
@@ -1073,8 +1073,8 @@ class WpsRestApiProcessesTest(unittest.TestCase):
                 pkg = self.get_application_package(p_id)
                 assert desc["deploymentProfile"] == "http://www.opengis.net/profiles/eoc/dockerizedApplication"
                 assert desc["process"]["id"] == p_id
-                assert pkg[type]["NetworkAccess"] == network_access_requirement
-                assert pkg[type]["DockerRequirement"] == docker_requirement
+                assert pkg[req_type]["NetworkAccess"] == network_access_requirement
+                assert pkg[req_type]["DockerRequirement"] == docker_requirement
 
     @mocked_remote_server_requests_wps1([
         resources.TEST_REMOTE_SERVER_URL,

--- a/weaver/__meta__.py
+++ b/weaver/__meta__.py
@@ -1,6 +1,6 @@
 __name__ = "weaver"
 __title__ = "Weaver"
-__version__ = "4.26.0"
+__version__ = "4.27.0"
 __description__ = "Workflow Execution Management Service (EMS); Application, Deployment and Execution Service (ADES)."
 __source_repository__ = "https://github.com/crim-ca/weaver"
 __docker_repository__ = "https://hub.docker.com/r/pavics/weaver"

--- a/weaver/datatype.py
+++ b/weaver/datatype.py
@@ -2088,7 +2088,7 @@ class Process(Base):
         base = "http://www.opengis.net/profiles/eoc/"
         pkg = self.package or {}
         cls = str(pkg.get("class", "")).lower()
-        req = get_application_requirement(pkg).get("class")
+        req = get_application_requirement(pkg, required=False).get("class")
         typ = self.type
 
         if cls == ProcessType.WORKFLOW:

--- a/weaver/datatype.py
+++ b/weaver/datatype.py
@@ -44,6 +44,7 @@ from weaver.store.base import StoreProcesses
 from weaver.utils import localize_datetime  # for backward compatibility of previously saved jobs not time-locale-aware
 from weaver.utils import (
     VersionFormat,
+    apply_number_with_unit,
     as_version_major_minor_patch,
     extend_instance,
     fully_qualified_name,
@@ -378,7 +379,7 @@ class Service(Base):
         try:
             _wps = self.get("_wps")
             if _wps is None:
-                # client retrieval could also be cached if recently fetched an not yet invalidated
+                # client retrieval could also be cached if recently fetched and not yet invalidated
                 self["_wps"] = _wps = get_wps_client(self.url, container=container, **kwargs)
             return _wps
         except (OWSServiceException, xml_util.ParseError) as exc:
@@ -579,7 +580,7 @@ class Service(Base):
                 meth = "HEAD"
                 url = self.url
             # - allow 500 for services that incorrectly handle invalid request params, but at least respond
-            #   (should be acceptable in this case because the 'ping' request is not necessarily well formed)
+            #   (should be acceptable in this case because the 'ping' request is not necessarily well-formed)
             # - allow 400/405 for bad request/method directly reported by the service for the same reasons
             # - enforce quick timeout (but don't allow 408 code) to avoid long pending connexions that never resolve
             allowed_codes = [200, 400, 405, 500]
@@ -620,27 +621,38 @@ class Job(Base):
         if not isinstance(self.id, (str, uuid.UUID)):
             raise TypeError(f"Type 'str' or 'UUID' is required for '{self.__name__}.id'")
 
-    def _get_log_msg(self, msg=None, status=None, progress=None):
-        # type: (Optional[str], Optional[AnyStatusType], Optional[Number]) -> str
-        if not msg:
-            msg = self.status_message
+    @staticmethod
+    def _get_message(message, size_limit=None):
+        # type: (str, Optional[int]) -> str
+        msg_len = len(message)
+        size_limit = size_limit if isinstance(size_limit, int) and size_limit > 0 else 1024**2
+        if len(message) > size_limit:
+            msg_size = apply_number_with_unit(msg_len, binary=True, decimals=2)
+            return f"<message clipped due to large dimension ({msg_size})>"
+        return message
+
+    def _get_log_msg(self, msg=None, status=None, progress=None, size_limit=None):
+        # type: (Optional[str], Optional[AnyStatusType], Optional[Number], Optional[int]) -> str
+        msg = self._get_message(msg or self.status_message, size_limit=size_limit)
         status = map_status(status or self.status)
         progress = max(0, min(100, progress or self.progress))
         return get_job_log_msg(duration=self.duration_str, progress=progress, status=status, message=msg)
 
     @staticmethod
-    def _get_err_msg(error):
-        # type: (WPSException) -> str
-        return f"{error.text} - code={error.code} - locator={error.locator}"
+    def _get_err_msg(error, size_limit=None):
+        # type: (WPSException, Optional[int]) -> str
+        error_msg = Job._get_message(error.text, size_limit=size_limit)
+        return f"{error_msg} - code={error.code} - locator={error.locator}"
 
     def save_log(self,
-                 errors=None,       # type: Optional[Union[str, Exception, WPSException, List[WPSException]]]
-                 logger=None,       # type: Optional[Logger]
-                 message=None,      # type: Optional[str]
-                 level=INFO,        # type: AnyLogLevel
-                 status=None,       # type: Optional[AnyStatusType]
-                 progress=None,     # type: Optional[Number]
-                 ):                 # type: (...) -> None
+                 errors=None,           # type: Optional[Union[str, Exception, WPSException, List[WPSException]]]
+                 logger=None,           # type: Optional[Logger]
+                 message=None,          # type: Optional[str]
+                 level=INFO,            # type: AnyLogLevel
+                 status=None,           # type: Optional[AnyStatusType]
+                 progress=None,         # type: Optional[Number]
+                 size_limit=None,       # type: Optional[int]
+                 ):                     # type: (...) -> None
         """
         Logs the specified error and/or message, and adds the log entry to the complete job log.
 
@@ -661,6 +673,10 @@ class Job(Base):
         :param progress:
             Override progress applied in the logged message entry, but does not set it to the job object.
             Uses the current :attr:`Job.progress` value if not specified.
+        :param size_limit:
+            Log message entries that individually exceed the limit will be clipped with a generic message.
+            The parameter is provided for convenience, but take note that setting a too large value could cause the
+            complete :term:`Job` to fail saving to the database if its total size exceeds the document limit.
 
         .. note::
             The job object is updated with the log but still requires to be pushed to database to actually persist it.
@@ -668,22 +684,30 @@ class Job(Base):
         if isinstance(errors, WPSException):
             errors = [errors]
         elif isinstance(errors, Exception):
-            errors = str(errors)
+            errors = self._get_message(str(errors), size_limit=size_limit)
         if isinstance(errors, str):
-            log_msg = [(ERROR, self._get_log_msg(message, status=status, progress=progress))]
+            log_msg = [(ERROR, self._get_log_msg(message, status=status, progress=progress, size_limit=size_limit))]
             self.exceptions.append(errors)
         elif isinstance(errors, list):
             log_msg = [
-                (ERROR, self._get_log_msg(self._get_err_msg(error), status=status, progress=progress))
+                (
+                    ERROR,
+                    self._get_log_msg(
+                        self._get_err_msg(error, size_limit=size_limit),
+                        status=status,
+                        progress=progress,
+                        size_limit=size_limit,
+                    )
+                )
                 for error in errors
             ]
             self.exceptions.extend([{
                 "Code": error.code,
                 "Locator": error.locator,
-                "Text": error.text
+                "Text": self._get_message(error.text, size_limit=size_limit),
             } for error in errors])
         else:
-            log_msg = [(level, self._get_log_msg(message, status=status, progress=progress))]
+            log_msg = [(level, self._get_log_msg(message, status=status, progress=progress, size_limit=size_limit))]
         for lvl, msg in log_msg:
             fmt_msg = get_log_fmt() % dict(asctime=now().strftime(get_log_date_fmt()),
                                            levelname=getLevelName(lvl),
@@ -1574,7 +1598,7 @@ class DockerAuthentication(Authentication):
     def registry(self):
         # type: () -> str
         """
-        Obtains the registry entry that must used for ``docker login {registry}``.
+        Obtains the registry entry that must be used for ``docker login {registry}``.
         """
         return dict.__getitem__(self, "registry")
 
@@ -1847,7 +1871,7 @@ class Process(Base):
     def tag(self):
         # type: () -> str
         """
-        Full identifier including the version for an unique reference.
+        Full identifier including the version for a unique reference.
         """
         proc_id = self.split_version(self.id)[0]
         # bw-compat, if no version available, no update was applied (single deploy)
@@ -2648,7 +2672,7 @@ class Quote(Base):
             (value == QuoteStatus.SUBMITTED and prev != QuoteStatus.SUBMITTED) or
             (value == QuoteStatus.PROCESSING and prev == QuoteStatus.COMPLETED)
         ):
-            LOGGER.error("Cannot revert back to previous quote status (%s => %s)", value, self.status)
+            LOGGER.error("Cannot revert to previous quote status (%s => %s)", value, self.status)
             LOGGER.debug(traceback.extract_stack())
             return
         self["status"] = value

--- a/weaver/exceptions.py
+++ b/weaver/exceptions.py
@@ -235,6 +235,15 @@ class PackageTypeError(HTTPUnprocessableEntity, PackageException):
     """
 
 
+class PackageParsingError(HTTPUnprocessableEntity, PackageException):
+    """
+    Error related to parsing of a package definition.
+
+    Error indicating that a :term:`CWL` package could not be properly parsed
+    according to expected structures or unresolved definitions.
+    """
+
+
 class PackageRegistrationError(HTTPInternalServerError, OWSNoApplicableCode, PackageException):
     """
     Error related to a registration issue for a package.

--- a/weaver/processes/builtin/__init__.py
+++ b/weaver/processes/builtin/__init__.py
@@ -135,7 +135,7 @@ def register_builtin_processes(container):
     for process_id, process_data in builtin_apps_mapping.items():
         process_path = process_data["package"]
         process_desc = process_data["payload"]
-        process_info = get_process_definition(process_desc, package=None, reference=process_path)
+        process_info = get_process_definition(process_desc, package=None, reference=process_path, builtin=True)
         process_url = "/".join([restapi_url, "processes", process_id])
         process_package = _get_builtin_package(process_id, process_info["package"])
         process_abstract = _get_builtin_metadata(process_id, process_path, "__doc__", clean=True)

--- a/weaver/processes/constants.py
+++ b/weaver/processes/constants.py
@@ -1,4 +1,5 @@
 import sys
+from types import MappingProxyType
 from typing import TYPE_CHECKING
 
 from weaver.base import Constants
@@ -44,7 +45,7 @@ class OpenSearchField(Constants):
 # CWL package (requirements/hints) corresponding to `ProcessType.APPLICATION`
 CWL_REQUIREMENT_APP_BUILTIN = "BuiltinRequirement"
 CWL_REQUIREMENT_APP_DOCKER = "DockerRequirement"
-CWL_REQUIREMENT_APP_DOCKER_GPU = "DockerGpuRequirement"
+CWL_REQUIREMENT_APP_DOCKER_GPU = "DockerGpuRequirement"  # backward compatibility
 CWL_REQUIREMENT_APP_ESGF_CWT = "ESGF-CWTRequirement"
 CWL_REQUIREMENT_APP_OGC_API = "OGCAPIRequirement"
 CWL_REQUIREMENT_APP_WPS1 = "WPS1Requirement"
@@ -78,6 +79,19 @@ CWL_REQUIREMENT_APP_REMOTE = frozenset([
 ])
 """
 Set of :term:`CWL` requirements that correspond to remote execution of an :term:`Application Package`.
+"""
+
+CWL_REQUIREMENT_CUDA_DEFAULT_PARAMETERS = MappingProxyType({
+    # use older minimal version/capability to allow more chances to match any available GPU
+    # if this causes an issue for an actual application, it must provide it explicitly anyway
+    "cudaVersionMin": "10.0",
+    "cudaComputeCapability": "3.0",
+    # use minimum defaults, single GPU
+    "cudaDeviceCountMin": 1,
+    "cudaDeviceCountMax": 1,
+})
+"""
+Parameters employed by default for updating :data:`CWL_REQUIREMENT_APP_DOCKER_GPU` into :data:`CWL_REQUIREMENT_CUDA`.
 """
 
 # FIXME: convert to 'Constants' class

--- a/weaver/processes/constants.py
+++ b/weaver/processes/constants.py
@@ -52,10 +52,7 @@ CWL_REQUIREMENT_APP_WPS1 = "WPS1Requirement"
 CWL_REQUIREMENT_APP_TYPES = frozenset([
     CWL_REQUIREMENT_APP_BUILTIN,
     CWL_REQUIREMENT_APP_DOCKER,
-    # FIXME: properly support GPU execution
-    #   - https://github.com/crim-ca/weaver/issues/104
-    #   - https://github.com/crim-ca/weaver/issues/138
-    # CWL_REQUIREMENT_APP_DOCKER_GPU,
+    CWL_REQUIREMENT_APP_DOCKER_GPU,  # backward compatibility, use 'DockerRequirement+cwltool:CUDARequirement' instead
     CWL_REQUIREMENT_APP_ESGF_CWT,
     CWL_REQUIREMENT_APP_OGC_API,
     CWL_REQUIREMENT_APP_WPS1,
@@ -67,6 +64,7 @@ Set of :term:`CWL` requirements consisting of known :term:`Application Package` 
 CWL_REQUIREMENT_APP_LOCAL = frozenset([
     CWL_REQUIREMENT_APP_BUILTIN,
     CWL_REQUIREMENT_APP_DOCKER,
+    CWL_REQUIREMENT_APP_DOCKER_GPU,
 ])
 """
 Set of :term:`CWL` requirements that correspond to local execution of an :term:`Application Package`.
@@ -184,8 +182,11 @@ if TYPE_CHECKING:
         CWL_REQUIREMENT_APP_ESGF_CWT,
         CWL_REQUIREMENT_APP_OGC_API,
         CWL_REQUIREMENT_APP_WPS1,
+        CWL_REQUIREMENT_CUDA,
         CWL_REQUIREMENT_ENV_VAR,
         CWL_REQUIREMENT_INIT_WORKDIR,
+        CWL_REQUIREMENT_INLINE_JAVASCRIPT,
+        CWL_REQUIREMENT_NETWORK_ACCESS,
         CWL_REQUIREMENT_RESOURCE,
         CWL_REQUIREMENT_SCATTER,
     ]

--- a/weaver/processes/convert.py
+++ b/weaver/processes/convert.py
@@ -398,8 +398,8 @@ def ows2json_output_data(output, process_description, container=None):
     if output.reference:
         json_output["reference"] = output.reference
 
-        # Handle special case where we have a reference to a json array containing dataset reference
-        # Avoid reference to reference by fetching directly the dataset references
+        # Handle special case where we have a reference to a json array containing dataset reference.
+        # Avoid reference to reference by fetching directly the dataset references.
         json_array = _get_multi_json_references(output, container)
         if json_array and all(str(ref).startswith("http") for ref in json_array):
             json_output["data"] = json_array
@@ -2262,7 +2262,7 @@ def oas2json_io_file(io_info, io_href=null):
 def oas2json_io_measure(io_info):
     # type: (OpenAPISchemaObject) -> Union[JSON_IO_TypedInfo, Type[null]]
     """
-    Convert an unit of measure (``UoM``) I/O definition by :term:`OpenAPI` schema into :term:`JSON` representation.
+    Convert a unit of measure (``UoM``) I/O definition by :term:`OpenAPI` schema into :term:`JSON` representation.
 
     This conversion projects an object (normally complex type) into a literal type, considering that other provided
     parameters are all metadata information.
@@ -2739,8 +2739,8 @@ def wps2json_io(io_wps, forced_fields=False):
         for io_format in io_wps_json["formats"]:
             transform_json(io_format, rename=rename, replace_values=replace_values, replace_func=replace_func)
 
-        # set 'default' format if it matches perfectly, or if only mime-type matches and it is the only available one
-        # (this avoid 'encoding' possibly not matching due to CWL not providing this information)
+        # set 'default' format if it matches perfectly, or if only mime-type matches, and it is the only available one
+        # (this avoids 'encoding' possibly not matching due to CWL not providing this information)
         io_default = get_field(io_wps_json, "default", search_variations=True)
         for io_format in io_wps_json["formats"]:
             io_format["default"] = (io_default != null and is_equal_formats(io_format, io_default))
@@ -2890,7 +2890,7 @@ def _are_different_and_set(item1, item2):
     Compares two value representations and returns ``True`` only if both are not ``null``, are of same ``type`` and
     of different representative value. By "representative", we consider here the visual representation of byte/unicode
     strings rather than literal values to support XML/JSON and Python 2/3 implementations.
-    Other non string-like types are verified with literal (usual) equality method.
+    Other non-string-like types are verified with literal (usual) equality method.
     """
     if item1 is null or item2 is null:
         return False
@@ -2946,7 +2946,7 @@ def normalize_ordered_io(io_section, order_hints=None):
     of parsers. This is merely *cosmetic* adjustments to ease readability of I/O to avoid always shuffling their order
     across multiple :term:`Application Package` and :term:`Process` reporting formats.
 
-    The important result of this function is to provide the I/O as a consistent list of objects so it is less
+    The important result of this function is to provide the I/O as a consistent list of objects, so it is less
     cumbersome to compare/merge/iterate over the elements with all functions that will follow.
 
     .. note::
@@ -2956,7 +2956,7 @@ def normalize_ordered_io(io_section, order_hints=None):
 
     :param io_section: Definition contained under the ``inputs`` or ``outputs`` fields.
     :param order_hints: Optional/partial I/O definitions hinting an order to sort unsorted-dict I/O.
-    :returns: I/O specified as list of dictionary definitions with preserved order (as best as possible).
+    :returns: I/O specified as list of dictionary definitions with preserved order (as good as possible).
     """
     if isinstance(io_section, list):
         return io_section

--- a/weaver/processes/wps_package.py
+++ b/weaver/processes/wps_package.py
@@ -318,7 +318,7 @@ def _get_process_payload(process_url):
 
 def _get_package_type(package_dict):
     # type: (CWL) -> Literal[ProcessType.APPLICATION, ProcessType.WORKFLOW]
-    return ProcessType.WORKFLOW if package_dict.get("class").lower() == "workflow" else ProcessType.APPLICATION
+    return ProcessType.WORKFLOW if package_dict.get("class", "").lower() == "workflow" else ProcessType.APPLICATION
 
 
 def _get_package_requirements_normalized(requirements, as_dict=False):

--- a/weaver/processes/wps_package.py
+++ b/weaver/processes/wps_package.py
@@ -757,7 +757,8 @@ def get_application_requirement(package,        # type: CWL
     If no :paramref:`search` filter is specified (default), retrieve the *principal* requirement that allows
     mapping to the appropriate :term:`Process` implementation. The *principal* requirement can be extracted
     for an :term:`Application Package` of type :data:`ProcessType.APPLICATION` because only one is permitted
-    simultaneously amongst :data:`CWL_REQUIREMENT_APP_TYPES`.
+    simultaneously amongst :data:`CWL_REQUIREMENT_APP_TYPES`. If the :term:`CWL` is not of type
+    :data:`ProcessType.APPLICATION`, the requirement check is skipped regardless of :paramref:`required`.
 
     If a :paramref:`search` filter is provided, this specific requirement or hint is looked for instead.
     Regardless of the applied filter, only a unique item can be matched across ``requirements``/``hints`` mapping
@@ -796,7 +797,8 @@ def get_application_requirement(package,        # type: CWL
 
     if validate:
         all_classes = sorted(list(set(item.get("class") for item in all_hints)))
-        if required:
+        app_required = _get_package_type(package) == ProcessType.APPLICATION
+        if required and app_required:
             cwl_impl_type_reqs = sorted(list(CWL_REQUIREMENT_APP_TYPES))
             if not all_classes or not any(cls in cwl_impl_type_reqs for cls in all_classes):
                 raise PackageTypeError(

--- a/weaver/processes/wps_package.py
+++ b/weaver/processes/wps_package.py
@@ -21,7 +21,7 @@ import sys
 import tempfile
 import time
 import uuid
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, overload
 from urllib.parse import parse_qsl, urlparse
 
 import colander
@@ -49,6 +49,7 @@ from weaver.exceptions import (
     PackageException,
     PackageExecutionError,
     PackageNotFound,
+    PackageParsingError,
     PackageRegistrationError,
     PackageTypeError,
     PayloadNotFound
@@ -58,12 +59,14 @@ from weaver.processes import opensearch
 from weaver.processes.constants import (
     CWL_REQUIREMENT_APP_BUILTIN,
     CWL_REQUIREMENT_APP_DOCKER,
+    CWL_REQUIREMENT_APP_DOCKER_GPU,
     CWL_REQUIREMENT_APP_ESGF_CWT,
     CWL_REQUIREMENT_APP_LOCAL,
     CWL_REQUIREMENT_APP_OGC_API,
     CWL_REQUIREMENT_APP_REMOTE,
     CWL_REQUIREMENT_APP_TYPES,
     CWL_REQUIREMENT_APP_WPS1,
+    CWL_REQUIREMENT_CUDA,
     CWL_REQUIREMENT_ENV_VAR,
     CWL_REQUIREMENT_RESOURCE,
     CWL_REQUIREMENTS_SUPPORTED,
@@ -100,6 +103,7 @@ from weaver.utils import (
     fetch_directory,
     fetch_file,
     fully_qualified_name,
+    generate_diff,
     get_any_id,
     get_header,
     get_job_log_msg,
@@ -108,6 +112,7 @@ from weaver.utils import (
     get_sane_name,
     get_settings,
     list_directory_recursive,
+    null,
     request_extra,
     setup_loggers
 )
@@ -150,12 +155,12 @@ if TYPE_CHECKING:
         CWL_Requirement,
         CWL_RequirementsDict,
         CWL_RequirementNames,
-        CWL_RequirementsList,
         CWL_Results,
         CWL_ToolPathObject,
         CWL_WorkflowStepPackage,
         CWL_WorkflowStepPackageMap,
         CWL_WorkflowStepReference,
+        Default,
         JSON,
         Literal,
         Number,
@@ -315,22 +320,110 @@ def _get_package_type(package_dict):
     return ProcessType.WORKFLOW if package_dict.get("class").lower() == "workflow" else ProcessType.APPLICATION
 
 
-def _get_package_requirements_as_class_list(requirements):
-    # type: (CWL_AnyRequirements) -> CWL_RequirementsList
+def _get_package_requirements_normalized(requirements, as_dict=False):
+    # type: (CWL_AnyRequirements, bool) -> CWL_AnyRequirements
     """
-    Converts `CWL` package ``requirements`` or ``hints`` into list representation.
+    Converts :term:`CWL` package ``requirements`` or ``hints`` into :class:`list` or :class:`dict` representation.
 
-    Uniformization `CWL` requirements into the list representation, whether the input definitions where
-    provided using the dictionary definition as ``{"<req-class>": {<params>}}`` or
-    the list of dictionary requirements ``[{<req-class+params>}]`` each with a ``class`` key.
+    Uniformization of :term:`CWL` ``requirements`` or ``hints`` into the :class:`list` representation (default)
+    or as :class:`dict` if requested, whether the input definitions where provided using the dictionary definition
+    as ``{"<req-class>": {<params>}}`` or  the list of dictionary requirements ``[{<req-class + params>}]``
+    each with a ``class`` key.
     """
     if isinstance(requirements, dict):
+        if as_dict:
+            return {req: dict(params) for req, params in requirements.items()}  # ensure literals instead of dict-like
         reqs = []
         for req in requirements:
             reqs.append({"class": req})
             reqs[-1].update(requirements[req] or {})
         return reqs
     return [dict(req) for req in requirements]  # ensure list-of-dict instead of sequence of dict-like
+
+
+def _update_package_compatibility(package):
+    # type: (CWL) -> CWL
+    """
+    Update a :term:`CWL` package with backward compatibility changes if applicable.
+    """
+    package_original = copy.deepcopy(package)
+    package_type = _get_package_type(package)
+    if package_type == ProcessType.APPLICATION:
+        docker_req = get_application_requirement(package)
+        if docker_req["class"].endwith(CWL_REQUIREMENT_APP_DOCKER_GPU):
+            # backup original for later compare and find requirements of interest
+            # requirements unrelated to update must be preserved in same locations and formats to preserve behavior
+            r_original = package.get("requirements", {})
+            h_original = package.get("hints", {})
+            r_list = _get_package_requirements_normalized(r_original)
+            h_list = _get_package_requirements_normalized(h_original)
+            r_no_docker = list(filter(lambda _req: not _req["class"].endswith(CWL_REQUIREMENT_APP_DOCKER_GPU), r_list))
+            h_no_docker = list(filter(lambda _req: not _req["class"].endswith(CWL_REQUIREMENT_APP_DOCKER_GPU), h_list))
+            r_cuda = list(filter(lambda _req: _req["class"].endswith(CWL_REQUIREMENT_CUDA), r_list))
+            h_cuda = list(filter(lambda _req: _req["class"].endswith(CWL_REQUIREMENT_CUDA), h_list))
+            docker_req["class"] = CWL_REQUIREMENT_APP_DOCKER  # GPU to official Docker requirement
+            cuda_req = r_cuda or h_cuda
+            cuda_found = bool(cuda_req)
+            if not cuda_req:  # if CUDA no explicitly provided along the older GPU requirement, define default
+                cuda_req = {
+                    "class": CWL_REQUIREMENT_CUDA,
+                    # use older minimal version/capability to allow more chances to match any available GPU
+                    # if this causes an issue for an actual application, it must provide it explicitly anyway
+                    "cudaVersionMin": "10.0",
+                    "cudaComputeCapability": "3.0",
+                    # use minimum defaults
+                    "cudaDeviceCountMin": 1,
+                    "cudaDeviceCountMax": 1,
+                }
+            # apply the change to the relevant list where it was originally found
+            if r_list == r_no_docker and h_list != h_no_docker:
+                h_list = h_no_docker + ([docker_req] if cuda_found else [docker_req, cuda_req])
+            elif r_list != r_no_docker and h_list == h_no_docker:
+                r_list = r_no_docker + ([docker_req] if cuda_found else [docker_req, cuda_req])
+            else:
+                raise PackageParsingError(
+                    f"Expected to find a unique '{CWL_REQUIREMENT_APP_DOCKER_GPU}' definition in CWL "
+                    "requirements or hints, but could not resolve it between mapping and listing representations."
+                )
+            # revert list conversion if necessary
+            r_list = _get_package_requirements_normalized(r_list, as_dict=isinstance(r_original, dict))
+            h_list = _get_package_requirements_normalized(h_list, as_dict=isinstance(h_original, dict))
+            if r_list:
+                package["requirements"] = r_list
+            if h_list:
+                package["hints"] = h_list
+            LOGGER.warning(
+                "CWL package definition updated using '%s' backward-compatibility definition.\n%s",
+                CWL_REQUIREMENT_APP_DOCKER_GPU,
+                generate_diff(package_original, package, val_name="Original CWL", ref_name="Updated CWL")
+            )
+    return package
+
+
+@overload
+def _load_package_content(package_dict,                             # type: CWL
+                          package_name=PACKAGE_DEFAULT_FILE_NAME,   # type: str
+                          data_source=None,                         # type: Optional[str]
+                          only_dump_file=False,                     # type: Literal[True]
+                          tmp_dir=None,                             # type: Optional[str]
+                          loading_context=None,                     # type: Optional[LoadingContext]
+                          runtime_context=None,                     # type: Optional[RuntimeContext]
+                          process_offering=None,                    # type: Optional[JSON]
+                          ):                                        # type: (...) -> None
+    ...
+
+
+@overload
+def _load_package_content(package_dict,                             # type: CWL
+                          package_name=PACKAGE_DEFAULT_FILE_NAME,   # type: str
+                          data_source=None,                         # type: Optional[str]
+                          only_dump_file=False,                     # type: Literal[False]
+                          tmp_dir=None,                             # type: Optional[str]
+                          loading_context=None,                     # type: Optional[LoadingContext]
+                          runtime_context=None,                     # type: Optional[RuntimeContext]
+                          process_offering=None,                    # type: Optional[JSON]
+                          ):  # type: (...) -> Tuple[CWLFactoryCallable, str, CWL_WorkflowStepPackageMap]
+    ...
 
 
 def _load_package_content(package_dict,                             # type: CWL
@@ -343,34 +436,37 @@ def _load_package_content(package_dict,                             # type: CWL
                           process_offering=None,                    # type: Optional[JSON]
                           ):  # type: (...) -> Optional[Tuple[CWLFactoryCallable, str, CWL_WorkflowStepPackageMap]]
     """
-    Loads `CWL` package definition using various contextual resources.
+    Loads :term:`CWL` package definition using various contextual resources.
 
     Following operations are accomplished to validate the package:
 
-    - Starts by resolving any intermediate sub-packages steps if the parent package is a `Workflow` (CWL class),
+    - Starts by resolving any intermediate sub-packages steps if the parent package is a :term:`Workflow`
       in order to recursively generate and validate their process and package, potentially using remote reference.
-      Each of those operations are applied to every step.
+      Each of the following operations are applied to every step individually.
     - Package I/O are reordered using any reference process offering hints if provided to generate consistent results.
+    - Perform backward compatibility checks and conversions to the package if applicable.
     - The resulting package definition is dumped to a temporary JSON file, to validate the content can be serialized.
-    - Optionally, the `CWL` factory is employed to create the application runner, validating any provided loading and
-      runtime contexts, and considering all Workflow steps if applicable, or the single application otherwise.
+    - Optionally, the :term:`CWL` factory is employed to create the application runner, validating any provided loading
+      and runtime contexts, and considering all resolved :term:`Workflow` steps if applicable, or the atomic application
+      otherwise.
 
-    :param package_dict: package content representation as a json dictionary.
-    :param package_name: name to use to create the package file.
-    :param data_source: identifier of the data source to map to specific ADES, or map to localhost if ``None``.
-    :param only_dump_file: specify if the :class:`CWLFactoryCallable` should be validated and returned.
-    :param tmp_dir: location of the temporary directory to dump files (deleted on exit).
-    :param loading_context: cwltool context used to create the cwl package (required if ``only_dump_file=False``)
-    :param runtime_context: cwltool context used to execute the cwl package (required if ``only_dump_file=False``)
-    :param process_offering: JSON body of the process description payload (used as I/O hint ordering)
+    :param package_dict: Package content representation as a dictionary.
+    :param package_name: Name to use to create the package file and :term:`CWL` identifiers.
+    :param data_source:
+        Identifier of the :term:`Data Source` to map to specific :term:`ADES`, or map to ``localhost`` if ``None``.
+    :param only_dump_file: Specify if the :class:`CWLFactoryCallable` should be validated and returned.
+    :param tmp_dir: Location of the temporary directory to dump files (deleted on exit).
+    :param loading_context: :mod:`cwltool` context used to create the :term:`CWL` package.
+    :param runtime_context: :mod:`cwltool` context used to execute the :term:`CWL` package.
+    :param process_offering: :term:`JSON` body of the process description payload (used as I/O hint ordering).
     :returns:
         If :paramref:`only_dump_file` is ``True``, returns ``None``.
-        Otherwise, tuple of:
+        Otherwise, :class:`tuple` of:
 
         - Instance of :class:`CWLFactoryCallable`
         - Package type (:attr:`ProcessType.WORKFLOW` or :attr:`ProcessType.APPLICATION`)
-        - Package sub-steps definitions if package is of type :attr:`ProcessType.WORKFLOW`. Otherwise, empty mapping.
-          Mapping of each step name contains their respective package ID and definition that must be run.
+        - Package sub-steps definitions if package represents a :attr:`ProcessType.WORKFLOW`. Otherwise, empty mapping.
+          Mapping of each step name contains their respective package ID and :term:`CWL` definition that must be run.
 
     .. warning::
         Specified :paramref:`tmp_dir` will be deleted on exit.
@@ -380,6 +476,7 @@ def _load_package_content(package_dict,                             # type: CWL
     tmp_json_cwl = os.path.join(tmp_dir, package_name)
 
     # for workflows, retrieve each 'sub-package' file
+    package_dict = _update_package_compatibility(package_dict)
     package_type = _get_package_type(package_dict)
     workflow_steps = get_package_workflow_steps(package_dict)
     step_packages = {}
@@ -648,19 +745,28 @@ def _generate_process_with_cwl_from_reference(reference, process_hint=None):
     return cwl_package, process_info
 
 
-def get_application_requirement(package, search=None, default=None, validate=True):
-    # type: (CWL, Optional[CWL_RequirementNames], Optional[Any], bool) -> Union[CWL_Requirement, Any]
+def get_application_requirement(package,        # type: CWL
+                                search=None,    # type: Optional[CWL_RequirementNames]
+                                default=null,   # type: Optional[Union[CWL_Requirement, Default]]
+                                validate=True,  # type: bool
+                                ):              # type: (...) -> Union[CWL_Requirement, Default]
     """
     Retrieves a requirement or hint from the :term:`CWL` package definition.
 
-    If no filter is specified (default), retrieve the *principal* requirement that allows mapping to the appropriate
-    :term:`Process` implementation. Obtains the first item in :term:`CWL` package ``requirements`` or ``hints``
-    that corresponds to a `Weaver`-specific application type as defined in :py:data:`CWL_REQUIREMENT_APP_TYPES`.
-    If a filter is provided, this specific requirement or hint is looked for instead.
-    Regardless of the applied filter, only a unique item can be matched across requirements/hints containers, and
-    within a same container in case of listing representation to avoid ambiguity. When requirements/hints validation
-    is enabled, all requirements must also be defined amongst :data:`CWL_REQUIREMENTS_SUPPORTED` for the :term:`CWL`
-    package to be considered valid.
+    If no :paramref:`search` filter is specified (default), retrieve the *principal* requirement that allows
+    mapping to the appropriate :term:`Process` implementation. The *principal* requirement can be extracted
+    for an :term:`Application Package` of type :data:`ProcessType.APPLICATION` because only one is permitted
+    simultaneously amongst :data:`CWL_REQUIREMENT_APP_TYPES`.
+
+    If a :paramref:`search` filter is provided, this specific requirement or hint is looked for instead.
+    Regardless of the applied filter, only a unique item can be matched across ``requirements``/``hints`` mapping
+    and/or listing representations.
+
+    When :paramref:`validate` is enabled, all ``requirements`` and ``hints`` must also be defined
+    within :data:`CWL_REQUIREMENTS_SUPPORTED` for the :term:`CWL` package to be considered valid.
+
+    When :paramref:`convert` is enabled, any backward compatibility definitions will be converted to their
+    corresponding definition.
 
     :param package: CWL definition to parse.
     :param search: Specific requirement/hint name to search and retrieve the definition if available.
@@ -673,7 +779,7 @@ def get_application_requirement(package, search=None, default=None, validate=Tru
     # workflow can have multiple, but they are not explicitly handled
     reqs = package.get("requirements", {})
     hints = package.get("hints", {})
-    all_hints = _get_package_requirements_as_class_list(reqs) + _get_package_requirements_as_class_list(hints)
+    all_hints = _get_package_requirements_normalized(reqs) + _get_package_requirements_normalized(hints)
     if search:
         app_hints = list(filter(lambda h: h["class"] == search, all_hints))
     else:
@@ -681,15 +787,20 @@ def get_application_requirement(package, search=None, default=None, validate=Tru
     if len(app_hints) > 1:
         raise PackageTypeError(
             f"Package 'requirements' and/or 'hints' define too many conflicting values: {list(app_hints)}, "
-            f"only one permitted amongst {list(CWL_REQUIREMENT_APP_TYPES)}."
+            f"only one requirement is permitted amongst {list(CWL_REQUIREMENT_APP_TYPES)}."
         )
-    req_default = default if default is not None else {"class": ""}
+    req_default = default if default is not null else {"class": ""}
     requirement = app_hints[0] if app_hints else req_default
 
     if validate:
         cwl_supported_reqs = list(CWL_REQUIREMENTS_SUPPORTED)
         if not all(item.get("class") in cwl_supported_reqs for item in all_hints):
-            raise PackageTypeError(f"Invalid requirement, the requirements supported are {cwl_supported_reqs}")
+            raise PackageTypeError(
+                f"Invalid package requirement. One supported requirement within {cwl_supported_reqs} is needed."
+                f"If a script execution is required for this application, the '{CWL_REQUIREMENT_APP_DOCKER}' "
+                f"definition can be used to provide a suitable environment. "
+                f"Refer to {sd.DOC_URL}/package.html#script-application for examples."
+            )
 
     return requirement
 
@@ -825,7 +936,8 @@ def get_process_definition(process_offering, reference=None, package=None, data_
     if reference:
         package, process_info = try_or_raise_package_error(
             lambda: _generate_process_with_cwl_from_reference(reference, process_info),
-            reason="Loading package from reference")
+            reason="Loading package from reference",
+        )
         process_info.update(process_offering)   # override upstream details
     if not isinstance(package, dict):
         raise PackageRegistrationError("Cannot decode process package contents.")
@@ -835,29 +947,34 @@ def get_process_definition(process_offering, reference=None, package=None, data_
     LOGGER.debug("Using data source: '%s'", data_source)
     package_factory, process_type, _ = try_or_raise_package_error(
         lambda: _load_package_content(package, data_source=data_source, process_offering=process_info),
-        reason="Loading package content")
+        reason="Loading package content",
+    )
 
     package_inputs, package_outputs = try_or_raise_package_error(
         lambda: _get_package_inputs_outputs(package_factory),
-        reason="Definition of package/process inputs/outputs")
+        reason="Definition of package/process inputs/outputs",
+    )
     process_inputs = process_info.get("inputs", [])
     process_outputs = process_info.get("outputs", [])
 
     try_or_raise_package_error(
         lambda: _update_package_metadata(process_info, package),
-        reason="Metadata update")
+        reason="Metadata update",
+    )
 
     process_inputs, process_outputs = try_or_raise_package_error(
         lambda: _merge_package_inputs_outputs(process_inputs, package_inputs, process_outputs, package_outputs),
-        reason="Merging of inputs/outputs")
+        reason="Merging of inputs/outputs",
+    )
 
     app_requirement = try_or_raise_package_error(
         lambda: get_application_requirement(package),
-        reason="Validate requirements and hints")
+        reason="Validate requirements and hints",
+    )
 
     auth_requirements = try_or_raise_package_error(
         lambda: get_auth_requirements(app_requirement, headers),
-        reason="Obtaining authentication requirements"
+        reason="Obtaining authentication requirements",
     )
 
     # obtain any retrieved process id if not already provided from upstream process offering, and clean it
@@ -874,7 +991,7 @@ def get_process_definition(process_offering, reference=None, package=None, data_
         "type": process_type,
         "inputs": process_inputs,
         "outputs": process_outputs,
-        "auth": auth_requirements
+        "auth": auth_requirements,
     })
     return process_offering
 
@@ -1328,7 +1445,7 @@ class WpsPackage(Process):
                 if req_cls != CWL_REQUIREMENT_APP_DOCKER:
                     continue
                 # remove build-related parameters because we forbid this in our case
-                # remove output directory since we must explicitly defined it to match with WPS
+                # remove output directory since we must explicitly define it to match with WPS
                 for req_rm in ["dockerFile", "dockerOutputDirectory"]:
                     is_rm = req_def.pop(req_rm, None)
                     if is_rm:
@@ -2056,7 +2173,7 @@ class WpsPackage(Process):
                           input_value is one of `input_object` or `array [input_object]`
                           input_object is one of `string` or `dict {class: File, location: string}`
                           in our case input are expected to be File object
-        :param tool: Whole `CWL` config including hints requirement
+        :param tool: Whole :term:`CWL` config including hints and requirements
                      (see: :py:data:`weaver.processes.constants.CWL_REQUIREMENT_APP_TYPES`)
         """
 

--- a/weaver/processes/wps_package.py
+++ b/weaver/processes/wps_package.py
@@ -1440,9 +1440,10 @@ class WpsPackage(Process):
             # when process is a docker image, memory monitoring information is obtained with CID file
             # this file is only generated when the below command is explicitly None (not even when '')
             "user_space_docker_cmd": None,
-            # if 'ResourceRequirement' is specified to limit RAM usage, below must be added to ensure it is applied
+            # if 'ResourceRequirement' is specified to limit RAM/CPU usage, below must be added to ensure it is applied
             # but don't enable it otherwise, since some defaults are applied which could break existing processes
             "strict_memory_limit": bool(res_req),
+            "strict_cpu_limit": bool(res_req),
         }
         return runtime_params
 

--- a/weaver/store/mongodb.py
+++ b/weaver/store/mongodb.py
@@ -1144,7 +1144,7 @@ class MongodbJobStore(StoreJobs, MongodbStore, ListingMixin):
             # duration is not directly stored in the database (as it can change), it must be computed inplace
             duration_field = {
                 "$addFields": {
-                    "duration": {  # becomes 'null' if cannot be computed (e.g.: not started)
+                    "duration": {  # becomes 'null' if it cannot be computed (e.g.: not started)
                         "$dateDiff": {
                             # compute the same way as Job.duration
                             "startDate": "$started",

--- a/weaver/typedefs.py
+++ b/weaver/typedefs.py
@@ -71,6 +71,7 @@ if TYPE_CHECKING:
 
     Path = Union[os.PathLike, str, bytes]
 
+    Default = TypeVar("Default")  # used for return value that is employed from a provided default value
     Params = ParamSpec("Params")  # use with 'Callable[Params, Return]', 'Params.args' and 'Params.kwargs'
     Return = TypeVar("Return")    # alias to identify the same return value as a decorated/wrapped function
     AnyCallable = TypeVar("AnyCallable", bound=Callable[..., Any])  # callable used for decorated/wrapped functions
@@ -166,11 +167,11 @@ if TYPE_CHECKING:
 
     # 'requirements' includes 'hints'
     CWL_Requirement = TypedDict("CWL_Requirement", {
-        "class": CWL_RequirementNames,  # type: ignore
+        "class": Required[CWL_RequirementNames],
         "provider": NotRequired[str],
         "process": NotRequired[str],
     }, total=False)
-    CWL_RequirementsDict = Dict[CWL_RequirementNames, Dict[str, str]]   # {'<req>': {<param>: <val>}}
+    CWL_RequirementsDict = Dict[CWL_RequirementNames, Dict[str, ValueType]]   # {'<req>': {<param>: <val>}}
     CWL_RequirementsList = List[CWL_Requirement]       # [{'class': <req>, <param>: <val>}]
     CWL_AnyRequirements = Union[CWL_RequirementsDict, CWL_RequirementsList]
     CWL_Class = Literal["CommandLineTool", "ExpressionTool", "Workflow"]

--- a/weaver/wps_restapi/swagger_definitions.py
+++ b/weaver/wps_restapi/swagger_definitions.py
@@ -3759,7 +3759,7 @@ class ResourceRequirementSpecification(PermissiveMappingSchema):
             to multiple jobs. For example, a value of 0.25 indicates that up to 4 jobs may run in parallel
             on 1 core. A value of 1.25 means that up to 3 jobs can run on a 4 core system (4/1.25 ≈ 3).
 
-            Processes can only share a core allocation if the sum of each of their 'ramMax', 'tmpdirMax', 
+            Processes can only share a core allocation if the sum of each of their 'ramMax', 'tmpdirMax',
             and 'outdirMax' requests also do not exceed the capacity of the node.
 
             Processes sharing a core must have the same level of isolation (typically a container or VM)

--- a/weaver/wps_restapi/swagger_definitions.py
+++ b/weaver/wps_restapi/swagger_definitions.py
@@ -3763,7 +3763,7 @@ class ResourceRequirementSpecification(PermissiveMappingSchema):
             and 'outdirMax' requests also do not exceed the capacity of the node.
 
             Processes sharing a core must have the same level of isolation (typically a container or VM)
-            that they would normally.
+            that they would normally have.
 
             The reported number of CPU cores reserved for the process, which is available to expressions on the
             'CommandLineTool' as 'runtime.cores', must be a non-zero integer, and may be calculated by rounding up

--- a/weaver/wps_restapi/swagger_definitions.py
+++ b/weaver/wps_restapi/swagger_definitions.py
@@ -3656,13 +3656,13 @@ class CUDAComputeCapabilitySchema(OneOfKeywordSchema):
     title = CUDAComputeCapability.title
     description = inspect.cleandoc("""
         The compute capability supported by the GPU hardware.
-        
+
         * If this is a single value, it defines only the minimum
           compute capability.  GPUs with higher capability are also
           accepted.
         * If it is an array value, then only select GPUs with compute
           capabilities that explicitly appear in the array.
-          
+
         See https://docs.nvidia.com/deploy/cuda-compatibility/#faq and
         https://docs.nvidia.com/cuda/cuda-c-best-practices-guide/index.html#cuda-compute-capability for details.
     """)
@@ -3680,11 +3680,11 @@ class CUDARequirementSpecification(PermissiveMappingSchema):
         title="CUDA version minimum",
         description=inspect.cleandoc("""
             The minimum CUDA version required to run the software. This corresponds to a CUDA SDK release.
-            
+
             When run in a container, the container image should provide the CUDA runtime, and the host
             driver is injected into the container.  In this case, because CUDA drivers are backwards compatible,
             it is possible to use an older SDK with a newer driver across major versions.
-            
+
             See https://docs.nvidia.com/deploy/cuda-compatibility/ for details.
         """),
         validator=SemanticVersion(regex=r"^\d+\.\d+$"),
@@ -3755,21 +3755,21 @@ class ResourceRequirementSpecification(PermissiveMappingSchema):
         title="Minimum reserved number of CPU cores.",
         description=inspect.cleandoc("""
             Minimum reserved number of CPU cores.
-            
+
             May be a fractional value to indicate to a scheduling algorithm that one core can be allocated
             to multiple jobs. For example, a value of 0.25 indicates that up to 4 jobs may run in parallel
             on 1 core. A value of 1.25 means that up to 3 jobs can run on a 4 core system (4/1.25 ≈ 3).
-            
+
             Processes can only share a core allocation if the sum of each of their 'ramMax', 'tmpdirMax', 
             and 'outdirMax' requests also do not exceed the capacity of the node.
-            
+
             Processes sharing a core must have the same level of isolation (typically a container or VM)
             that they would normally.
-            
+
             The reported number of CPU cores reserved for the process, which is available to expressions on the
             'CommandLineTool' as 'runtime.cores', must be a non-zero integer, and may be calculated by rounding up
             the cores request to the next whole number.
-            
+
             Scheduling systems may allocate fractional CPU resources by setting quotas or scheduling weights.
             Scheduling systems that do not support fractional CPUs may round up the request to the next whole number.
         """),
@@ -3788,7 +3788,7 @@ class ResourceRequirementSpecification(PermissiveMappingSchema):
         title="Minimum reserved RAM in mebibytes.",
         description=inspect.cleandoc("""
             Minimum reserved RAM in mebibytes (2**20).
-            
+
             May be a fractional value. If so, the actual RAM request must be rounded up to the next whole number.
             The reported amount of RAM reserved for the process, which is available to expressions on the
             'CommandLineTool' as 'runtime.ram', must be a non-zero integer.
@@ -3808,7 +3808,7 @@ class ResourceRequirementSpecification(PermissiveMappingSchema):
         title="Minimum reserved filesystem based storage for the designated temporary directory in mebibytes.",
         description=inspect.cleandoc("""
             Minimum reserved filesystem based storage for the designated temporary directory in mebibytes (2**20).
-            
+
             May be a fractional value. If so, the actual storage request must be rounded up to the next whole number.
             The reported amount of storage reserved for the process, which is available to expressions on the
             'CommandLineTool' as 'runtime.tmpdirSize', must be a non-zero integer.

--- a/weaver/wps_restapi/swagger_definitions.py
+++ b/weaver/wps_restapi/swagger_definitions.py
@@ -4658,6 +4658,7 @@ class ExecutionUnitList(ExtendedSequenceSchema):
         title="ExecutionUnit",
         description="Definition of the Application Package to execute."
     )
+    validator = Length(min=1, max=1)
 
 
 class ProcessDeploymentWithContext(ProcessDeployment):


### PR DESCRIPTION
# Changes

- Update documentation with examples for ``cwltool:CUDARequirement``, ``ResourceRequirement`` and ``NetworkAccess``.
- Improve schema definition of ``ResourceRequirement``.
- Deprecate ``DockerGpuRequirement``, with attempts to auto-convert it into corresponding ``DockerRequirement``
  combined with  ``cwltool:CUDARequirement`` definitions. If this conversion does not work transparently for the user,
  explicit `CWL` updates with those definitions should be made.
- Ensure that validation check finds exactly one provided `CWL` requirement or hint to represent the application type.
  In case of missing requirement, the reported error will contain a documentation link to guide the user in adjusting
  its `Application Package` accordingly.

# Refernces

- Temporary documentation link used due to https://github.com/common-workflow-language/cwl-v1.2/issues/212 
- Relates to #138 
- Fixes https://crim-ca.atlassian.net/browse/DAC-437

# TODO

- [x] tests for new `_update_package_compatibility` operation
- [x] tests for result `ResourceRequirement` schema validation
- [x] documentation of CWL-like hint/requirement for remote process