### PR TITLE
add codecov secret to test workflow to avoid GitHub Action API rate-limiting failing upload

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -135,6 +135,7 @@ jobs:
         uses: codecov/codecov-action@v2
         if: ${{ success() && matrix.test-case == 'test-coverage-only' }}
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./reports/coverage.xml
           fail_ci_if_error: true
           verbose: true


### PR DESCRIPTION
Relates to https://github.com/codecov/codecov-action/issues/598