### PR TITLE
pin sphinx_autodoc_typehints[type_comment]>=1.19

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,7 +16,9 @@ Changes:
 
 Fixes:
 ------
-- No change.
+- Fix missing ``sphinx_autodoc_typehints[type_comment]`` extras due to renamed definition without leading ``s`` by
+  pinning ``1.19`` as the minimum version
+  (relates to `tox-dev/sphinx-autodoc-typehints#263 <https://github.com/tox-dev/sphinx-autodoc-typehints/issues/263>`_).
 
 .. _changes_4.28.0:
 

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -11,5 +11,5 @@ sphinx-autoapi>=1.7.0
 sphinx-paramlinks>=0.4.1
 # adds redoc OpenAPI directly served on readthedocs
 sphinxcontrib-redoc>=1.6.0
-sphinx_autodoc_typehints[type_comments]>=1.11.1
+sphinx_autodoc_typehints[type_comment]>=1.19
 sphinx_rtd_theme>=0.5.1

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -11,5 +11,7 @@ sphinx-autoapi>=1.7.0
 sphinx-paramlinks>=0.4.1
 # adds redoc OpenAPI directly served on readthedocs
 sphinxcontrib-redoc>=1.6.0
-sphinx_autodoc_typehints[type_comment]>=1.19
+# extras renamed in 1.19 (see https://github.com/tox-dev/sphinx-autodoc-typehints/issues/263)
+sphinx_autodoc_typehints[type_comments]<1.19; python_version >= "3.6"
+sphinx_autodoc_typehints[type_comment]>=1.19; python_version >= "3.7"
 sphinx_rtd_theme>=0.5.1

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -12,6 +12,6 @@ sphinx-paramlinks>=0.4.1
 # adds redoc OpenAPI directly served on readthedocs
 sphinxcontrib-redoc>=1.6.0
 # extras renamed in 1.19 (see https://github.com/tox-dev/sphinx-autodoc-typehints/issues/263)
-sphinx_autodoc_typehints[type_comments]<1.19; python_version >= "3.6"
+sphinx_autodoc_typehints[type_comments]<1.19; python_version <= "3.6"
 sphinx_autodoc_typehints[type_comment]>=1.19; python_version >= "3.7"
 sphinx_rtd_theme>=0.5.1


### PR DESCRIPTION
## changes

- pin sphinx_autodoc_typehints[type_comment]>=1.19 to resolve missing extras requirement (relates to https://github.com/tox-dev/sphinx-autodoc-typehints/issues/263)