### PR TITLE
fix dynamic regex definitions for schema validation with `colander>=2`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1096,7 +1096,7 @@ Changes:
   (relates to `#157 <https://github.com/crim-ca/weaver/issues/157>`_)
   Only utilities are added, not all routes provide the information yet.
 - Add validation of ``schema`` field under ``Format`` schema (as per `opengeospatial/ogcapi-processes schema format.yml
-  <https://github.com/opengeospatial/ogcapi-processes/blob/master/core/openapi/schemas/format.yaml>`_) such that only
+  <https://github.com/opengeospatial/ogcapi-processes/blob/master/openapi/schemas/processes-core/format.yaml>`_) such that only
   URL formatted strings are allowed, or alternatively an explicit JSON definition. Previous definitions that would
   indicate an empty string schema are dropped since ``schema`` is optional.
 - Block unknown and ``builtin`` process types during deployment from the API

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,8 @@ Fixes:
 ------
 - Fix dynamic regex definitions for schema validation with ``colander>=2`` that modifies ``URL_REGEX`` pattern
   (relates to `Pylons/colander#352 <https://github.com/Pylons/colander/pull/352>`_).
+- Fix invalid default results from ``colander`` schemas with ``missing=drop|required`` and ``default`` parameters when
+  combined with ``cornice`` OpenAPI schemas. Pin ``colander<2`` to avoid problems with latest changes.
 
 .. _changes_4.28.0:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,7 +16,8 @@ Changes:
 
 Fixes:
 ------
-- No change.
+- Fix dynamic regex definitions for schema validation with ``colander>=2`` that modifies ``URL_REGEX`` pattern
+  (relates to `Pylons/colander#352 <https://github.com/Pylons/colander/pull/352>`_).
 
 .. _changes_4.28.0:
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,7 +9,7 @@ bump2version
 codacy-coverage
 coverage
 doc8>=0.8.1
-docformatter>=1.5.0     # add support of config file
+docformatter==1.5.0     # add support of config file
 flake8<6  # FIXME: false positive redefinition (https://github.com/PyCQA/pyflakes/issues/757)
 flynt
 isort>=4.3.21,<5

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ celery[mongodb]>=5.2.2,<6; sys_platform != "win32" and python_version >= "3.7"
 # FIXME: drop support? more recent versions not avilable for end-of-life python
 celery[mongodb]>=5.1,<5.2; sys_platform != "win32" and python_version <= "3.6"  # rq.filter: >=5.1,<5.2 # pyup: ignore
 cffi
-colander
+colander<2
 cornice
 #cornice_swagger>=0.7.0
 cornice-swagger @ git+https://github.com/fmigneault/cornice.ext.swagger.git@openapi-3

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -2017,7 +2017,6 @@ class TestWeaverClientAuthBase(TestWeaverClientBase):
 
     @classmethod
     def setup_auth_app(cls):
-
         def auth_view(request):
             # type: (AnyRequestType) -> AnyResponseType
             token = str(uuid.uuid4())
@@ -2057,7 +2056,6 @@ class TestWeaverClientAuthBase(TestWeaverClientBase):
 
 
 class TestWeaverCLIAuthHandler(TestWeaverClientAuthBase):
-
     def test_describe_auth(self):
         # prints formatted JSON ProcessDescription over many lines
         proc = self.test_process["Echo"]

--- a/tests/wps_restapi/test_api.py
+++ b/tests/wps_restapi/test_api.py
@@ -15,7 +15,6 @@ from weaver.wps_restapi import swagger_definitions as sd
 
 
 class GenericApiRoutesTestCase(unittest.TestCase):
-
     @classmethod
     def setUpClass(cls):
         cls.testapp = get_test_weaver_app(settings={"weaver.wps": True, "weaver.wps_restapi": True})

--- a/tests/wps_restapi/test_colander_extras.py
+++ b/tests/wps_restapi/test_colander_extras.py
@@ -751,54 +751,54 @@ def test_invalid_schema_mismatch_default_validator():
         pytest.fail("Erroneous schema must raise immediately if default doesn't conform to its own validator.")
 
 
-def test_schema_default_missing_validator_combinations():
+@pytest.mark.parametrize("test_case", [
+    (Mapping, {}, colander.Invalid),                    # required but missing
+    (Mapping, {"test": None}, colander.Invalid),        # wrong value schema-type
+    (Mapping, {"test": "random"}, {"test": "random"}),  # uses the value as is if provided because no validator
+    (Default, {}, {"test": "test"}),                    # default+required adds the value if omitted
+    (Default, {"test": None}, {"test": "test"}),        # default+required sets the value if null
+    (Default, {"test": "random"}, {"test": "random"}),  # default+required uses the value as is if provided
+    (Missing, {}, {}),                                  # missing only drops the value if omitted
+    (Missing, {"test": None}, {}),
+    (Missing, {"test": "random"}, {"test": "random"}),
+    (DefaultMissing, {}, {"test": "test"}),             # default+missing ignores drops and sets omitted value
+    (DefaultMissing, {"test": None}, {}),
+    (DefaultMissing, {"test": "random"}, {"test": "random"}),
+    (Validator, {}, colander.Invalid),
+    (Validator, {"test": None}, colander.Invalid),
+    (Validator, {"test": "bad"}, colander.Invalid),
+    (Validator, {"test": "test"}, {"test": "test"}),
+    (DefaultValidator, {}, {"test": "test"}),
+    (DefaultValidator, {"test": None}, {"test": "test"}),
+    (DefaultValidator, {"test": "bad"}, colander.Invalid),
+    (DefaultValidator, {"test": "test"}, {"test": "test"}),
+    (DefaultMissingValidator, {}, {"test": "test"}),    # default+missing ignores drop and sets default if omitted
+    (DefaultMissingValidator, {"test": None}, {}),
+    # (DefaultMissingValidator, {"test": "bad"}, {}),
+    (DefaultMissingValidator, {"test": "bad"}, colander.Invalid),
+    (DefaultMissingValidator, {"test": "test"}, {"test": "test"}),
+    (MissingValidator, {}, {}),
+    (MissingValidator, {"test": None}, {}),
+    # (MissingValidator, {"test": "bad"}, {}),
+    (MissingValidator, {"test": "bad"}, colander.Invalid),
+    (MissingValidator, {"test": "test"}, {"test": "test"}),
+    (DefaultDropRequired, {}, {}),
+    (DefaultDropRequired, {"test": None}, {}),
+    (DefaultDropRequired, {"test": "bad"}, {}),
+    (DefaultDropRequired, {"test": "test"}, {"test": "test"}),
+    (DefaultDropValidator, {}, {}),
+    (DefaultDropValidator, {"test": None}, {}),
+    (DefaultDropValidator, {"test": "bad"}, {}),
+    (DefaultDropValidator, {"test": "test"}, {"test": "test"}),
+])
+def test_schema_default_missing_validator_combinations(test_case):
     """
     Validate resulting deserialization of mappings according to parameter combinations and parsed data.
 
     .. seealso::
         :func:`test_schema_default_missing_validator_openapi`
     """
-    test_schemas = [
-        (Mapping, {}, colander.Invalid),                    # required but missing
-        (Mapping, {"test": None}, colander.Invalid),        # wrong value schema-type
-        (Mapping, {"test": "random"}, {"test": "random"}),  # uses the value as is if provided because no validator
-        (Default, {}, {"test": "test"}),                    # default+required adds the value if omitted
-        (Default, {"test": None}, {"test": "test"}),        # default+required sets the value if null
-        (Default, {"test": "random"}, {"test": "random"}),  # default+required uses the value as is if provided
-        (Missing, {}, {}),                                  # missing only drops the value if omitted
-        (Missing, {"test": None}, {}),
-        (Missing, {"test": "random"}, {"test": "random"}),
-        (DefaultMissing, {}, {"test": "test"}),             # default+missing ignores drops and sets omitted value
-        (DefaultMissing, {"test": None}, {}),
-        (DefaultMissing, {"test": "random"}, {"test": "random"}),
-        (Validator, {}, colander.Invalid),
-        (Validator, {"test": None}, colander.Invalid),
-        (Validator, {"test": "bad"}, colander.Invalid),
-        (Validator, {"test": "test"}, {"test": "test"}),
-        (DefaultValidator, {}, {"test": "test"}),
-        (DefaultValidator, {"test": None}, {"test": "test"}),
-        (DefaultValidator, {"test": "bad"}, colander.Invalid),
-        (DefaultValidator, {"test": "test"}, {"test": "test"}),
-        (DefaultMissingValidator, {}, {"test": "test"}),    # default+missing ignores drop and sets default if omitted
-        (DefaultMissingValidator, {"test": None}, {}),
-        # (DefaultMissingValidator, {"test": "bad"}, {}),
-        (DefaultMissingValidator, {"test": "bad"}, colander.Invalid),
-        (DefaultMissingValidator, {"test": "test"}, {"test": "test"}),
-        (MissingValidator, {}, {}),
-        (MissingValidator, {"test": None}, {}),
-        # (MissingValidator, {"test": "bad"}, {}),
-        (MissingValidator, {"test": "bad"}, colander.Invalid),
-        (MissingValidator, {"test": "test"}, {"test": "test"}),
-        (DefaultDropRequired, {}, {}),
-        (DefaultDropRequired, {"test": None}, {}),
-        (DefaultDropRequired, {"test": "bad"}, {}),
-        (DefaultDropRequired, {"test": "test"}, {"test": "test"}),
-        (DefaultDropValidator, {}, {}),
-        (DefaultDropValidator, {"test": None}, {}),
-        (DefaultDropValidator, {"test": "bad"}, {}),
-        (DefaultDropValidator, {"test": "test"}, {"test": "test"}),
-    ]
-    evaluate_test_cases(test_schemas)
+    evaluate_test_cases([test_case])
 
 
 def test_schema_default_missing_validator_openapi():

--- a/weaver/datatype.py
+++ b/weaver/datatype.py
@@ -1322,7 +1322,7 @@ class Job(Base):
             "estimatedCompletion": None,
             "percentCompleted": self.progress,
             # new name as per OGC-API, enforced integer
-            # https://github.com/opengeospatial/ogcapi-processes/blob/master/core/openapi/schemas/statusInfo.yaml
+            # https://github.com/opengeospatial/ogcapi-processes/blob/master/openapi/schemas/processes-core/statusInfo.yaml
             "progress": int(self.progress),
             "links": self.links(settings, self_link=self_link)
         }

--- a/weaver/processes/convert.py
+++ b/weaver/processes/convert.py
@@ -1091,6 +1091,7 @@ class CWLIODefinition(object):
     symbols: "Union[CWL_IO_EnumSymbols, AnyValue, Type[AnyValue]]" = AnyValue
     """
     Specifies the allowed values when the definition is marked as :attr:`enum`.
+
     When not overriden by literal values, it uses the default :class:`AnyValue`.
     """
 

--- a/weaver/processes/sources.py
+++ b/weaver/processes/sources.py
@@ -17,7 +17,8 @@ if TYPE_CHECKING:
     from weaver.typedefs import DataSourceConfig
 
 DATA_SOURCES = {}  # type: DataSourceConfig
-"""Data sources configuration.
+"""
+Data sources configuration.
 
 Unless explicitly overridden, the configuration will be loaded from file as specified by``weaver.data_sources`` setting.
 Following JSON schema format is expected (corresponding YAML also supported):

--- a/weaver/processes/wps_package.py
+++ b/weaver/processes/wps_package.py
@@ -1206,7 +1206,6 @@ class DirectoryNestedStorage(CachedStorage):
 
 
 class WpsPackage(Process):
-
     def __init__(self, package=None, payload=None, **kw):
         # type: (CWL, Optional[JSON], **Any) -> None
         """

--- a/weaver/status.py
+++ b/weaver/status.py
@@ -177,7 +177,7 @@ def map_status(wps_status, compliant=StatusCompliant.OGC):
             job_status = Status.FAILED
 
     # FIXME: new official status is 'successful', but this breaks everywhere (tests, local/remote execute, etc.)
-    #        https://github.com/opengeospatial/ogcapi-processes/blob/master/openapi/schemas/processes-core/statusCode.yaml
+    #   https://github.com/opengeospatial/ogcapi-processes/blob/master/openapi/schemas/processes-core/statusCode.yaml
     if job_status == Status.SUCCESSFUL:
         job_status = Status.SUCCEEDED
 

--- a/weaver/status.py
+++ b/weaver/status.py
@@ -36,7 +36,7 @@ JOB_STATUS_CATEGORIES = {
     #   OGC compliant (new): [accepted, running, successful, failed, dismissed]
     #   PyWPS uses:          [Accepted, Started, Succeeded, Failed, Paused, Exception]
     #   OWSLib users:        [Accepted, Running, Succeeded, Failed, Paused] (with 'Process' in front)
-    # https://github.com/opengeospatial/ogcapi-processes/blob/master/core/openapi/schemas/statusCode.yaml
+    # https://github.com/opengeospatial/ogcapi-processes/blob/master/openapi/schemas/processes-core/statusCode.yaml
     # http://docs.opengeospatial.org/is/14-065/14-065.html#17
 
     # corresponding statuses are aligned vertically for 'COMPLIANT' groups
@@ -177,7 +177,7 @@ def map_status(wps_status, compliant=StatusCompliant.OGC):
             job_status = Status.FAILED
 
     # FIXME: new official status is 'successful', but this breaks everywhere (tests, local/remote execute, etc.)
-    #        https://github.com/opengeospatial/ogcapi-processes/blob/master/core/openapi/schemas/statusCode.yaml
+    #        https://github.com/opengeospatial/ogcapi-processes/blob/master/openapi/schemas/processes-core/statusCode.yaml
     if job_status == Status.SUCCESSFUL:
         job_status = Status.SUCCEEDED
 

--- a/weaver/wps_restapi/colander_extras.py
+++ b/weaver/wps_restapi/colander_extras.py
@@ -354,7 +354,9 @@ class SchemeURL(colander.Regex):
         if path_pattern:
             if isinstance(path_pattern, RegexPattern):
                 path_pattern = path_pattern.pattern
-            regex = f"{regex[:-1] + path_pattern}$"
+            # depending colander version: $ end-of-line, \Z end-of-string (before \n if any), or \z end-of-string (\0)
+            index = -2 if regex.lower().endswith(r"\z") else -1 if regex.endswith("$") else 0
+            regex = rf"{regex[:index] + path_pattern}\Z"
         super(SchemeURL, self).__init__(regex, msg=msg, flags=flags)
 
 

--- a/weaver/wps_restapi/colander_extras.py
+++ b/weaver/wps_restapi/colander_extras.py
@@ -382,7 +382,6 @@ class SemanticVersion(colander.Regex):
 
 
 class ExtendedBoolean(colander.Boolean):
-
     def __init__(self, *args, true_choices=None, false_choices=None, allow_string=False, **kwargs):
         # type: (Any, Optional[Iterable[str]], Optional[Iterable[str]], bool, Any) -> None
         """

--- a/weaver/wps_restapi/swagger_definitions.py
+++ b/weaver/wps_restapi/swagger_definitions.py
@@ -755,7 +755,7 @@ class LandingPage(ExtendedMappingSchema):
 
 
 # sub-schema within:
-#   https://github.com/opengeospatial/ogcapi-processes/blob/master/core/openapi/schemas/format.yaml
+#   https://github.com/opengeospatial/ogcapi-processes/blob/master/openapi/schemas/processes-core/format.yaml
 class FormatSchema(OneOfKeywordSchema):
     _one_of = [
         # pointer to a file or JSON schema relative item (as in OpenAPI definitions)
@@ -1273,7 +1273,7 @@ class BoundingBoxInputType(ExtendedMappingSchema):
 
 
 # FIXME: support byte/binary type (string + format:byte) ?
-#   https://github.com/opengeospatial/ogcapi-processes/blob/master/core/openapi/schemas/binaryInputValue.yaml
+#   https://github.com/opengeospatial/ogcapi-processes/blob/master/openapi/schemas/processes-core/binaryInputValue.yaml
 class AnyLiteralType(OneOfKeywordSchema):
     """
     Submitted values that correspond to literal data.
@@ -3311,7 +3311,7 @@ class ExecuteInputListValues(ExtendedSequenceSchema):
 
 # same as 'ExecuteInputReference', but using 'OGC' schema with 'type' field
 # Defined as:
-#   https://github.com/opengeospatial/ogcapi-processes/blob/master/core/openapi/schemas/link.yaml
+#   https://github.com/opengeospatial/ogcapi-processes/blob/master/openapi/schemas/processes-core/link.yaml
 # But explicitly in the context of an execution input, rather than any other link (eg: metadata)
 class ExecuteInputFileLink(Link):  # for other metadata (title, hreflang, etc.)
     schema_ref = f"{OGC_API_SCHEMA_CORE}/link.yaml"
@@ -3337,7 +3337,7 @@ class ExecuteInputFile(AnyOfKeywordSchema):
     ]
 
 
-# https://github.com/opengeospatial/ogcapi-processes/blob/master/core/openapi/schemas/inputValueNoObject.yaml
+# https://github.com/opengeospatial/ogcapi-processes/blob/master/openapi/schemas/processes-core/inputValueNoObject.yaml
 # Any literal value directly provided inline in input mapping.
 #
 #   {"inputs": {"<id>": <literal-data>}}
@@ -3345,9 +3345,9 @@ class ExecuteInputFile(AnyOfKeywordSchema):
 # Excludes objects to avoid conflict with later object mapping and {"value": <data>} definitions.
 # Excludes array literals that will be defined separately with allowed array of any item within this schema.
 # FIXME: does not support byte/binary type (string + format:byte) - see also: 'AnyLiteralType'
-#   https://github.com/opengeospatial/ogcapi-processes/blob/master/core/openapi/schemas/binaryInputValue.yaml
+#   https://github.com/opengeospatial/ogcapi-processes/blob/master/openapi/schemas/processes-core/binaryInputValue.yaml
 # FIXME: does not support bbox
-#   https://github.com/opengeospatial/ogcapi-processes/blob/master/core/openapi/schemas/bbox.yaml
+#   https://github.com/opengeospatial/ogcapi-processes/blob/master/openapi/schemas/processes-core/bbox.yaml
 class ExecuteInputInlineValue(OneOfKeywordSchema):
     description = "Execute input value provided inline."
     _one_of = [
@@ -3358,7 +3358,7 @@ class ExecuteInputInlineValue(OneOfKeywordSchema):
     ]
 
 
-# https://github.com/opengeospatial/ogcapi-processes/blob/master/core/openapi/schemas/inputValue.yaml
+# https://github.com/opengeospatial/ogcapi-processes/blob/master/openapi/schemas/processes-core/inputValue.yaml
 #
 #   oneOf:
 #     - $ref: "inputValueNoObject.yaml"
@@ -3372,13 +3372,13 @@ class ExecuteInputObjectData(OneOfKeywordSchema):
     ]
 
 
-# https://github.com/opengeospatial/ogcapi-processes/blob/master/core/openapi/schemas/qualifiedInputValue.yaml
+# https://github.com/opengeospatial/ogcapi-processes/blob/master/openapi/schemas/processes-core/qualifiedInputValue.yaml
 class ExecuteInputQualifiedValue(Format):
     schema_ref = f"{OGC_API_SCHEMA_CORE}/qualifiedInputValue.yaml"
     value = ExecuteInputObjectData()    # can be anything, including literal value, array of them, nested object
 
 
-# https://github.com/opengeospatial/ogcapi-processes/blob/master/core/openapi/schemas/inlineOrRefData.yaml
+# https://github.com/opengeospatial/ogcapi-processes/blob/master/openapi/schemas/processes-core/inlineOrRefData.yaml
 #
 #   oneOf:
 #     - $ref: "inputValueNoObject.yaml"     # in OGC-API spec, includes a generic array
@@ -3408,7 +3408,7 @@ class ExecuteInputData(OneOfKeywordSchema):
     ]
 
 
-# https://github.com/opengeospatial/ogcapi-processes/blob/master/core/openapi/schemas/execute.yaml
+# https://github.com/opengeospatial/ogcapi-processes/blob/master/openapi/schemas/processes-core/execute.yaml
 #
 #   inputs:
 #     additionalProperties:           # this is the below 'variable=<input-id>'


### PR DESCRIPTION
## changes

- Fix dynamic regex definitions for schema validation with ``colander>=2`` that modifies ``URL_REGEX`` pattern
  (relates to https://github.com/Pylons/colander/pull/352).