### PR TITLE
Fix `convert_input_values_schema` for multiple values

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,6 +34,8 @@ Fixes:
   multiple directories for the same input source.
 - Fix deprecation warnings from :mod:`webob` and :mod:`owslib`.
 - Fix filtered warnings for expected cases during tests.
+- Fix a problem with ``convert_input_values_schema`` under the `OGC` schema, that caused the conversion to malfunction
+  when the function built lists for repeated input IDs of more than two elements.
 
 .. _changes_4.28.0:
 

--- a/tests/processes/test_convert.py
+++ b/tests/processes/test_convert.py
@@ -1033,6 +1033,17 @@ def test_convert_input_values_schema_from_old():
         {"id": "test12", "href": "/data/file1.txt", "format": {"mediaType": "text/plain"}},
         {"id": "test12", "href": "/data/file2.txt", "format": {"mediaType": "text/plain"}},
         {"id": "test12", "href": "/data/file3.txt", "format": {"mediaType": "text/plain"}},
+        {"id": "test13", "value": "short"},
+        {"id": "test13", "value": "long"},
+        {"id": "test13", "value": "more"},
+        {"id": "test14", "value": ["val1", "val2", "val3"]},
+        {"id": "test15", "href": "https://www.somewebsite.com/dir1/", "type": "application/directory"},
+        {"id": "test15", "href": "https://www.somewebsite.com/dir2/", "type": "application/directory"},
+        {"id": "test15", "href": "https://www.somewebsite.com/dir3/", "type": "application/directory"},
+        {"id": "test16", "value": 1},
+        {"id": "test16", "value": ["val1", "val2", "val3"]},
+        {"id": "test16", "value": "short"},
+        {"id": "test16", "href": "https://www.somewebsite.com/dir1/", "type": "application/directory"}
     ]
     inputs_ogc = {
         "test1": "data",
@@ -1053,8 +1064,31 @@ def test_convert_input_values_schema_from_old():
             {"href": "/data/file1.txt", "format": {"mediaType": "text/plain"}},
             {"href": "/data/file2.txt", "format": {"mediaType": "text/plain"}},
             {"href": "/data/file3.txt", "format": {"mediaType": "text/plain"}}
+        ],
+        "test13": [
+            "short",
+            "long",
+            "more"
+        ],
+        "test14": [
+            "val1",
+            "val2",
+            "val3",
+        ],
+        "test15": [
+            {"href": "https://www.somewebsite.com/dir1/", "type": "application/directory"},
+            {"href": "https://www.somewebsite.com/dir2/", "type": "application/directory"},
+            {"href": "https://www.somewebsite.com/dir3/", "type": "application/directory"}
+        ],
+        "test16": [
+            1,
+            ["val1", "val2", "val3"],
+            "short",
+            {"href": "https://www.somewebsite.com/dir1/",
+             "type": "application/directory"}
         ]
     }
+
     assert convert_input_values_schema(inputs_old, ProcessSchema.OLD) == inputs_old
     assert convert_input_values_schema(inputs_old, ProcessSchema.OGC) == inputs_ogc
 
@@ -1079,6 +1113,23 @@ def test_convert_input_values_schema_from_ogc():
             {"href": "/data/file1.txt", "format": {"mediaType": "text/plain"}},
             {"href": "/data/file2.txt", "format": {"mediaType": "text/plain"}},
             {"href": "/data/file3.txt", "format": {"mediaType": "text/plain"}}
+        ],
+        "test13": [
+            "short",
+            "long",
+            "more"
+        ],
+        "test15": [
+            {"href": "https://www.somewebsite.com/dir1/", "type": "application/directory"},
+            {"href": "https://www.somewebsite.com/dir2/", "type": "application/directory"},
+            {"href": "https://www.somewebsite.com/dir3/", "type": "application/directory"}
+        ],
+        "test16": [
+            1,
+            ["val1", "val2", "val3"],
+            "short",
+            {"href": "https://www.somewebsite.com/dir1/",
+             "type": "application/directory"}
         ]
     }
     inputs_old = [
@@ -1101,7 +1152,63 @@ def test_convert_input_values_schema_from_ogc():
         {"id": "test12", "href": "/data/file1.txt", "format": {"mediaType": "text/plain"}},
         {"id": "test12", "href": "/data/file2.txt", "format": {"mediaType": "text/plain"}},
         {"id": "test12", "href": "/data/file3.txt", "format": {"mediaType": "text/plain"}},
+        {"id": "test13", "value": "short"},
+        {"id": "test13", "value": "long"},
+        {"id": "test13", "value": "more"},
+        {"id": "test15", "href": "https://www.somewebsite.com/dir1/", "type": "application/directory"},
+        {"id": "test15", "href": "https://www.somewebsite.com/dir2/", "type": "application/directory"},
+        {"id": "test15", "href": "https://www.somewebsite.com/dir3/", "type": "application/directory"},
+        {"id": "test16", "value": 1},
+        {"id": "test16", "value": ["val1", "val2", "val3"]},
+        {"id": "test16", "value": "short"},
+        {"id": "test16", "href": "https://www.somewebsite.com/dir1/", "type": "application/directory"}
     ]
+    assert convert_input_values_schema(inputs_ogc, ProcessSchema.OGC) == inputs_ogc
+    assert convert_input_values_schema(inputs_ogc, ProcessSchema.OLD) == inputs_old
+
+
+@pytest.mark.xfail(reason="Expected to fail as conversion is probably not standard compliant")
+def test_convert_input_values_schema_from_old_xfail():
+    inputs_old = [
+        {
+            "id": "test1",
+            "href": ["https://www.somewebsite.com/dir1/",
+                     "https://www.somewebsite.com/dir2/",
+                     "https://www.somewebsite.com/dir3/"],
+            "type": "application/directory"
+        }
+    ]
+
+    inputs_ogc = {
+        "test1": {"href": ["https://www.somewebsite.com/dir1/",
+                           "https://www.somewebsite.com/dir2/",
+                           "https://www.somewebsite.com/dir3/"],
+                  "type": "application/directory"}
+    }
+
+    assert convert_input_values_schema(inputs_old, ProcessSchema.OLD) == inputs_old
+    assert convert_input_values_schema(inputs_old, ProcessSchema.OGC) == inputs_ogc
+
+
+@pytest.mark.xfail(reason="Expected to fail as conversion is probably not standard compliant")
+def test_convert_input_values_schema_from_ogc_xfail():
+    inputs_ogc = {
+        "test1": {"href": ["https://www.somewebsite.com/dir1/",
+                           "https://www.somewebsite.com/dir2/",
+                           "https://www.somewebsite.com/dir3/"],
+                  "type": "application/directory"}
+    }
+
+    inputs_old = [
+        {
+            "id": "test1",
+            "href": ["https://www.somewebsite.com/dir1/",
+                     "https://www.somewebsite.com/dir2/",
+                     "https://www.somewebsite.com/dir3/"],
+            "type": "application/directory"
+        }
+    ]
+
     assert convert_input_values_schema(inputs_ogc, ProcessSchema.OGC) == inputs_ogc
     assert convert_input_values_schema(inputs_ogc, ProcessSchema.OLD) == inputs_old
 

--- a/tests/processes/test_convert.py
+++ b/tests/processes/test_convert.py
@@ -1119,12 +1119,12 @@ def test_convert_input_values_schema_from_ogc():
             "long",
             "more"
         ],
-        "test15": [
+        "test14": [
             {"href": "https://www.somewebsite.com/dir1/", "type": "application/directory"},
             {"href": "https://www.somewebsite.com/dir2/", "type": "application/directory"},
             {"href": "https://www.somewebsite.com/dir3/", "type": "application/directory"}
         ],
-        "test16": [
+        "test15": [
             1,
             ["val1", "val2", "val3"],
             "short",
@@ -1155,13 +1155,13 @@ def test_convert_input_values_schema_from_ogc():
         {"id": "test13", "value": "short"},
         {"id": "test13", "value": "long"},
         {"id": "test13", "value": "more"},
-        {"id": "test15", "href": "https://www.somewebsite.com/dir1/", "type": "application/directory"},
-        {"id": "test15", "href": "https://www.somewebsite.com/dir2/", "type": "application/directory"},
-        {"id": "test15", "href": "https://www.somewebsite.com/dir3/", "type": "application/directory"},
-        {"id": "test16", "value": 1},
-        {"id": "test16", "value": ["val1", "val2", "val3"]},
-        {"id": "test16", "value": "short"},
-        {"id": "test16", "href": "https://www.somewebsite.com/dir1/", "type": "application/directory"}
+        {"id": "test14", "href": "https://www.somewebsite.com/dir1/", "type": "application/directory"},
+        {"id": "test14", "href": "https://www.somewebsite.com/dir2/", "type": "application/directory"},
+        {"id": "test14", "href": "https://www.somewebsite.com/dir3/", "type": "application/directory"},
+        {"id": "test15", "value": 1},
+        {"id": "test15", "value": ["val1", "val2", "val3"]},
+        {"id": "test15", "value": "short"},
+        {"id": "test15", "href": "https://www.somewebsite.com/dir1/", "type": "application/directory"}
     ]
     assert convert_input_values_schema(inputs_ogc, ProcessSchema.OGC) == inputs_ogc
     assert convert_input_values_schema(inputs_ogc, ProcessSchema.OLD) == inputs_old

--- a/tests/processes/test_convert.py
+++ b/tests/processes/test_convert.py
@@ -1030,6 +1030,9 @@ def test_convert_input_values_schema_from_old():
         {"id": "test10", "value": "more"},
         {"id": "test11", "href": "/data/file1.txt", "format": {"mediaType": "text/plain"}},
         {"id": "test11", "href": "/data/file2.txt", "format": {"mediaType": "text/plain"}},
+        {"id": "test12", "href": "/data/file1.txt", "format": {"mediaType": "text/plain"}},
+        {"id": "test12", "href": "/data/file2.txt", "format": {"mediaType": "text/plain"}},
+        {"id": "test12", "href": "/data/file3.txt", "format": {"mediaType": "text/plain"}},
     ]
     inputs_ogc = {
         "test1": "data",
@@ -1045,6 +1048,11 @@ def test_convert_input_values_schema_from_old():
         "test11": [
             {"href": "/data/file1.txt", "format": {"mediaType": "text/plain"}},
             {"href": "/data/file2.txt", "format": {"mediaType": "text/plain"}}
+        ],
+        "test12": [
+            {"href": "/data/file1.txt", "format": {"mediaType": "text/plain"}},
+            {"href": "/data/file2.txt", "format": {"mediaType": "text/plain"}},
+            {"href": "/data/file3.txt", "format": {"mediaType": "text/plain"}}
         ]
     }
     assert convert_input_values_schema(inputs_old, ProcessSchema.OLD) == inputs_old
@@ -1066,6 +1074,11 @@ def test_convert_input_values_schema_from_ogc():
         "test11": [
             {"href": "/data/file1.txt", "format": {"mediaType": "text/plain"}},
             {"href": "/data/file2.txt", "format": {"mediaType": "text/plain"}}
+        ],
+        "test12": [
+            {"href": "/data/file1.txt", "format": {"mediaType": "text/plain"}},
+            {"href": "/data/file2.txt", "format": {"mediaType": "text/plain"}},
+            {"href": "/data/file3.txt", "format": {"mediaType": "text/plain"}}
         ]
     }
     inputs_old = [
@@ -1085,6 +1098,9 @@ def test_convert_input_values_schema_from_ogc():
         {"id": "test10", "value": "more"},
         {"id": "test11", "href": "/data/file1.txt", "format": {"mediaType": "text/plain"}},
         {"id": "test11", "href": "/data/file2.txt", "format": {"mediaType": "text/plain"}},
+        {"id": "test12", "href": "/data/file1.txt", "format": {"mediaType": "text/plain"}},
+        {"id": "test12", "href": "/data/file2.txt", "format": {"mediaType": "text/plain"}},
+        {"id": "test12", "href": "/data/file3.txt", "format": {"mediaType": "text/plain"}},
     ]
     assert convert_input_values_schema(inputs_ogc, ProcessSchema.OGC) == inputs_ogc
     assert convert_input_values_schema(inputs_ogc, ProcessSchema.OLD) == inputs_old

--- a/weaver/processes/convert.py
+++ b/weaver/processes/convert.py
@@ -1429,7 +1429,10 @@ def convert_input_values_schema(inputs, schema):
             else:
                 # when repeated input ID are found, they must be regrouped as list under that ID
                 input_prev = input_dict[input_id]
-                input_dict[input_id] = [input_prev, input_data]
+                if not isinstance(input_prev, list):
+                    input_prev = [input_prev]
+                input_prev.append(input_data)
+                input_dict[input_id] = input_prev
         return input_dict
     if schema == ProcessSchema.OLD:
         input_list = []


### PR DESCRIPTION
Initial problem was found while trying to execute a process through the CLI, using in it's inputs an array of three or more elements all using the same input ID.

The problem was isolated to the `convert_input_values_schema` function.

Under the OGC schema, when building the list for repeated IDs, the function simply added the previous list to a new list:

```
# Old
input_prev = input_dict[input_id]
input_dict[input_id] = [input_prev, input_data]
```
Trying to add to `input_dict` a second element worked fine, but when adding a third, the result became `[[input_prev], input_date]`

Added a small check to convert `input_prev` if not already a list and switched to an append function.

Tests were adjusted to include lists of more than 2 elements and everything seems alright.

Also tested with my initial process and it also succeeded.