### PR TITLE
fix zarr requirement under geotiff required by pywps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,8 @@ duration
 esgf-compute-api @ git+https://github.com/ESGF/esgf-compute-api.git@v2.3.7
 # invalid 'zarr' requirement in 'geotiff' dependencies required by 'pywps' fail to install
 # (https://github.com/KipCrossing/geotiff/pull/59)
-geotiff!=0.2.6,!=0.2.7
+geotiff!=0.2.6,!=0.2.7; python_version <= "3.6"
+geotiff>=0.2.8; python_version >= "3.7"
 # gunicorn >20 breaks some config.ini loading parameters (paste)
 # it is also only available for Python >=3.5
 # use pserve to continue supporting config.ini with paste settings


### PR DESCRIPTION
Relates to https://github.com/KipCrossing/geotiff/pull/59