### PR TITLE
add $schema OpenAPI references and apply official CWL JSON schema reference

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -32,7 +32,8 @@ limit-inference-results=100
 # usually to register additional checkers.
 # https://pylint.pycqa.org/en/latest/technical_reference/extensions.html
 load-plugins=pylint.extensions.docparams,
-             pylint.extensions.mccabe
+             pylint.extensions.mccabe,
+             pylint_per_file_ignores
 
 # https://pylint.pycqa.org/en/latest/technical_reference/extensions.html#design-checker-options
 max-complexity = 24
@@ -124,6 +125,9 @@ disable=C0111,missing-docstring,
         W9016,missing-type-doc
 
 # note: (C0412, ungrouped-imports) is managed via isort tool, ignore false positives
+
+per-file-ignores =
+  tests/*:R1729
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,11 +12,12 @@ Changes
 
 Changes:
 --------
-- No change.
-
-Fixes:
-------
-- No change.
+- Add the official `CWL` `JSON` schema reference
+  (`common-workflow-language/cwl-v1.2#256 <https://github.com/common-workflow-language/cwl-v1.2/pull/256>`_)
+  as ``$schema`` parameter returned in under the `OpenAPI` schema for the `CWL` component employed by `Weaver`
+  (fixes `#547 <https://github.com/crim-ca/weaver/issues/547>`_).
+- Add ``$schema`` field auto-insertion into the generated `OpenAPI` schema definition by ``CorniceSwagger`` when
+  corresponding ``colander.SchemaNode`` definitions contain a ``_schema = "<URL>"`` attribute.
 
 .. _changes_4.30.1:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,10 @@ Changes:
   corresponding ``colander.SchemaNode`` definitions contain a ``_schema = "<URL>"`` attribute
   (fixes `#157 <https://github.com/crim-ca/weaver/issues/157>`_).
 
+Fixes:
+------
+- Fix broken `OpenAPI` schema link references to `OGC API - Processes` repository.
+
 .. _changes_4.30.1:
 
 `4.30.1 <https://github.com/crim-ca/weaver/tree/4.30.1>`_ (2023-07-07)
@@ -727,7 +731,7 @@ Changes:
   The previous schema for deployment with nested ``process`` field remains supported for backward compatibility.
 
 .. |ogc-app-pkg| replace:: OGC Application Package
-.. _ogc-app-pkg: https://github.com/opengeospatial/ogcapi-processes/blob/master/extensions/deploy_replace_undeploy/standard/openapi/schemas/ogcapppkg.yaml
+.. _ogc-app-pkg: https://github.com/opengeospatial/ogcapi-processes/blob/master/openapi/schemas/processes-dru/ogcapppkg.yaml
 
 Fixes:
 ------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,7 +17,8 @@ Changes:
   as ``$schema`` parameter returned in under the `OpenAPI` schema for the `CWL` component employed by `Weaver`
   (fixes `#547 <https://github.com/crim-ca/weaver/issues/547>`_).
 - Add ``$schema`` field auto-insertion into the generated `OpenAPI` schema definition by ``CorniceSwagger`` when
-  corresponding ``colander.SchemaNode`` definitions contain a ``_schema = "<URL>"`` attribute.
+  corresponding ``colander.SchemaNode`` definitions contain a ``_schema = "<URL>"`` attribute
+  (fixes `#157 <https://github.com/crim-ca/weaver/issues/157>`_).
 
 .. _changes_4.30.1:
 

--- a/README.rst
+++ b/README.rst
@@ -331,7 +331,7 @@ It is part of `PAVICS`_ and `Birdhouse`_ ecosystems and is available within the 
 .. |ogc-api-proc-part2| replace:: `OGC API - Processes - Part 2: Deploy, Replace, Undeploy`_ (DRU) extension
 .. _`OGC API - Processes - Part 2: Deploy, Replace, Undeploy`: https://github.com/opengeospatial/ogcapi-processes/tree/master/extensions/deploy_replace_undeploy
 .. |ogc-apppkg| replace:: `OGC Application Package`
-.. _ogc-apppkg: https://github.com/opengeospatial/ogcapi-processes/blob/master/extensions/deploy_replace_undeploy/standard/openapi/schemas/ogcapppkg.yaml
+.. _ogc-apppkg: https://github.com/opengeospatial/ogcapi-processes/blob/master/openapi/schemas/processes-dru/ogcapppkg.yaml
 .. _PAVICS: https://ouranosinc.github.io/pavics-sdi/index.html
 .. _Birdhouse: http://bird-house.github.io/
 .. _birdhouse-deploy: https://github.com/bird-house/birdhouse-deploy

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -25,7 +25,7 @@ pytest<7
 pydocstyle
 pylint>=2.11,!=2.12,<2.14; python_version <= "3.6"
 pylint>=2.15.4; python_version >= "3.7"
-pylint-per-file-ignores
+pylint-per-file-ignores; python_version >= "3.7"
 pylint_quotes
 responses
 safety

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -25,6 +25,7 @@ pytest<7
 pydocstyle
 pylint>=2.11,!=2.12,<2.14; python_version <= "3.6"
 pylint>=2.15.4; python_version >= "3.7"
+pylint-per-file-ignores
 pylint_quotes
 responses
 safety

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -194,6 +194,7 @@ class TestWeaverClient(TestWeaverClientBase):
         providers = result.body["providers"]
         for prov in providers:
             prov.pop("$schema", None)
+            prov.pop("$id", None)
         assert providers == [
             {"id": prov1.name, "processes": resources.TEST_EMU_WPS1_PROCESSES},
             {"id": prov2.name, "processes": resources.TEST_HUMMINGBIRD_WPS1_PROCESSES},
@@ -379,6 +380,7 @@ class TestWeaverClient(TestWeaverClientBase):
         output_formats = result.body["outputs"]["output"]["formats"]
         for out_fmt in output_formats:
             out_fmt.pop("$schema", None)
+            out_fmt.pop("$id", None)
         assert output_formats == [{"default": True, "mediaType": ContentType.TEXT_PLAIN}]
         assert "undefined" not in result.message, "CLI should not have confused process description as response detail."
         assert result.body["description"] == (
@@ -459,7 +461,7 @@ class TestWeaverClient(TestWeaverClientBase):
         Test a typical case of :term:`Job` execution, result retrieval and download, but with manual monitoring.
 
         Manual monitoring can be valid in cases where a *very* long :term:`Job` must be executed, and the user does
-        not intend to wait after it. This avoids leaving some shell/notebook/etc. open of a long time and provide a
+        not intend to wait for it. This avoids leaving some shell/notebook/etc. open of a long time and provide a
         massive ``timeout`` value. Instead, the user can simply re-call :meth:`WeaverClient.monitor` at a later time
         to resume monitoring. Other situation can be if the connection was dropped or script runner crashed, and the
         want to pick up monitoring again.
@@ -1198,10 +1200,11 @@ class TestWeaverCLI(TestWeaverClientBase):
             out_oas_fmt = {"default": True, "mediaType": ContentType.APP_JSON}
             out_any_fmt = [out_cwl_fmt, out_oas_fmt]
             # ignore schema specifications for comparison only of contents
-            in_schema.pop("$schema", None)
-            out_schema.pop("$schema", None)
-            for out_fmt in out_formats:
-                out_fmt.pop("$schema", None)
+            for field in ["$id", "$schema"]:
+                in_schema.pop(field, None)
+                out_schema.pop(field, None)
+                for out_fmt in out_formats:
+                    out_fmt.pop(field, None)
             # if any of the below definitions don't include user-provided information,
             # CLI did not combine it as intended prior to sending deployment request
             assert in_schema == in_oas  # injected by user provided process description

--- a/tests/functional/test_docker_app.py
+++ b/tests/functional/test_docker_app.py
@@ -13,8 +13,8 @@ from weaver.formats import ContentType
 from weaver.processes.wps_package import CWL_REQUIREMENT_APP_DOCKER
 from weaver.utils import fetch_file, get_any_value, load_file, str2bytes
 from weaver.wps.utils import get_wps_url
-from weaver.wps_restapi.utils import get_wps_restapi_base_url
 from weaver.wps_restapi.swagger_definitions import CWL_SCHEMA_URL
+from weaver.wps_restapi.utils import get_wps_restapi_base_url
 
 
 @pytest.mark.functional

--- a/tests/functional/test_docker_app.py
+++ b/tests/functional/test_docker_app.py
@@ -14,6 +14,7 @@ from weaver.processes.wps_package import CWL_REQUIREMENT_APP_DOCKER
 from weaver.utils import fetch_file, get_any_value, load_file, str2bytes
 from weaver.wps.utils import get_wps_url
 from weaver.wps_restapi.utils import get_wps_restapi_base_url
+from weaver.wps_restapi.swagger_definitions import CWL_SCHEMA_URL
 
 
 @pytest.mark.functional
@@ -119,8 +120,17 @@ class WpsPackageDockerAppTest(WpsConfigBase):
         # process already deployed by setUpClass
         body = self.get_deploy_body()
         process = self.process_store.fetch_by_id(self.process_id)
-        assert process.package == body["executionUnit"][0]["unit"]
-        assert process.payload == body
+        assert "$id" in process.package
+        assert process.package["$id"] == CWL_SCHEMA_URL
+
+        payload = process.payload
+        payload.pop("$schema", None)
+        payload.pop("$id", None)
+        package = process.package
+        package.pop("$schema", None)
+        package.pop("$id", None)
+        assert package == body["executionUnit"][0]["unit"]
+        assert payload == body
 
     def test_execute_wps_rest_resp_json(self):
         """

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -127,6 +127,7 @@ def test_format_variations(test_format, expect_format):
     try:
         result_format = format_schema.deserialize(test_format)
         result_format.pop("$schema", None)
+        result_format.pop("$id", None)
         assert result_format == expect_format
     except colander.Invalid:
         pytest.fail(f"Expected format to be valid: [{test_format}]")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -647,7 +647,7 @@ def test_request_extra_zero_values():
 
     # since backoff factor multiplies all incrementally increasing delays between requests,
     # proper detection of input backoff=0 makes all sleep calls equal to zero
-    assert all(backoff == 0 for backoff in sleep_counter["called_with"])
+    assert all([backoff == 0 for backoff in sleep_counter["called_with"]])
     assert sleep_counter["called_count"] == 3  # first direct call doesn't have any sleep from retry
 
 

--- a/tests/wps_restapi/test_api.py
+++ b/tests/wps_restapi/test_api.py
@@ -114,6 +114,13 @@ class GenericApiRoutesTestCase(unittest.TestCase):
         assert "openapi" in resp.json
         assert "basePath" in resp.json
 
+    def test_openapi_includes_schema(self):
+        resp = self.testapp.get(sd.openapi_json_service.path, headers=self.json_headers)
+        assert resp.status_code == 200
+        body = resp.json
+        assert "$id" in body["components"]["schemas"]["CWL"]
+        assert body["components"]["schemas"]["CWL"]["$id"] == sd.CWL_SCHEMA_URL
+
     def test_status_unauthorized_and_forbidden(self):
         """
         Validates that 401/403 status codes are correctly handled and that the appropriate one is returned.

--- a/tests/wps_restapi/test_jobs.py
+++ b/tests/wps_restapi/test_jobs.py
@@ -1494,6 +1494,7 @@ class WpsRestApiJobsTest(unittest.TestCase, JobUtils):
 
         job_none = sd.Execute().deserialize({})
         job_none.pop("$schema", None)
+        job_none.pop("$id", None)
         assert job_none == {
             "inputs": {},
             "outputs": {},
@@ -1503,6 +1504,7 @@ class WpsRestApiJobsTest(unittest.TestCase, JobUtils):
 
         job_in_none = sd.Execute().deserialize({"outputs": {"random": default_trans_mode}})
         job_in_none.pop("$schema", None)
+        job_in_none.pop("$id", None)
         assert job_in_none == {
             "inputs": {},
             "outputs": {"random": default_trans_mode},
@@ -1512,6 +1514,7 @@ class WpsRestApiJobsTest(unittest.TestCase, JobUtils):
 
         job_in_empty_dict = sd.Execute().deserialize({"inputs": {}, "outputs": {"random": default_trans_mode}})
         job_in_empty_dict.pop("$schema", None)
+        job_in_empty_dict.pop("$id", None)
         assert job_in_empty_dict == {
             "inputs": {},
             "outputs": {"random": default_trans_mode},
@@ -1521,6 +1524,7 @@ class WpsRestApiJobsTest(unittest.TestCase, JobUtils):
 
         job_in_empty_list = sd.Execute().deserialize({"inputs": [], "outputs": {"random": default_trans_mode}})
         job_in_empty_list.pop("$schema", None)
+        job_in_empty_list.pop("$id", None)
         assert job_in_empty_list == {
             "inputs": [],
             "outputs": {"random": default_trans_mode},
@@ -1530,6 +1534,7 @@ class WpsRestApiJobsTest(unittest.TestCase, JobUtils):
 
         job_out_none = sd.Execute().deserialize({"inputs": {"random": "ok"}})
         job_out_none.pop("$schema", None)
+        job_out_none.pop("$id", None)
         assert job_out_none == {
             "inputs": {"random": "ok"},
             "outputs": {},
@@ -1539,6 +1544,7 @@ class WpsRestApiJobsTest(unittest.TestCase, JobUtils):
 
         job_out_empty_dict = sd.Execute().deserialize({"inputs": {"random": "ok"}, "outputs": {}})
         job_out_empty_dict.pop("$schema", None)
+        job_out_empty_dict.pop("$id", None)
         assert job_out_empty_dict == {
             "inputs": {"random": "ok"},
             "outputs": {},
@@ -1548,6 +1554,7 @@ class WpsRestApiJobsTest(unittest.TestCase, JobUtils):
 
         job_out_empty_list = sd.Execute().deserialize({"inputs": {"random": "ok"}, "outputs": []})
         job_out_empty_list.pop("$schema", None)
+        job_out_empty_list.pop("$id", None)
         assert job_out_empty_list == {
             "inputs": {"random": "ok"},
             "outputs": [],
@@ -1560,6 +1567,7 @@ class WpsRestApiJobsTest(unittest.TestCase, JobUtils):
             "outputs": {"random": {"transmissionMode": ExecuteTransmissionMode.REFERENCE}}
         })
         job_out_defined.pop("$schema", None)
+        job_out_defined.pop("$id", None)
         assert job_out_defined == {
             "inputs": {"random": "ok"},
             "outputs": {"random": {"transmissionMode": ExecuteTransmissionMode.REFERENCE}},

--- a/tests/wps_restapi/test_processes.py
+++ b/tests/wps_restapi/test_processes.py
@@ -979,6 +979,8 @@ class WpsRestApiProcessesTest(unittest.TestCase):
             cwl["outputs"] = [cwl_out]
             cwl.pop("$schema", None)
             cwl.pop("$id", None)
+            pkg.pop("$schema", None)
+            pkg.pop("$id", None)
             assert pkg == cwl
 
             # process description should have been generated with relevant I/O

--- a/tests/wps_restapi/test_processes.py
+++ b/tests/wps_restapi/test_processes.py
@@ -977,6 +977,8 @@ class WpsRestApiProcessesTest(unittest.TestCase):
             cwl_out = cwl["outputs"]["output"]
             cwl_out["id"] = "output"
             cwl["outputs"] = [cwl_out]
+            cwl.pop("$schema", None)
+            cwl.pop("$id", None)
             assert pkg == cwl
 
             # process description should have been generated with relevant I/O

--- a/weaver/datatype.py
+++ b/weaver/datatype.py
@@ -2510,9 +2510,9 @@ class Process(Base):
             for io_type in ["inputs", "outputs"]:
                 process[io_type] = normalize_ordered_io(process[io_type], io_hints[io_type])
             process.update({"process": dict(process)})
-            return sd.ProcessDescriptionOLD().deserialize(process)
+            return sd.ProcessDescriptionOLD(schema_meta_include=True).deserialize(process)
         # process fields directly at root + I/O as mappings
-        return sd.ProcessDescriptionOGC().deserialize(process)
+        return sd.ProcessDescriptionOGC(schema_meta_include=True).deserialize(process)
 
     def summary(self, revision=False, links=True, container=None):
         # type: (bool, bool, Optional[AnySettingsContainer]) -> JSON

--- a/weaver/processes/utils.py
+++ b/weaver/processes/utils.py
@@ -355,6 +355,7 @@ def deploy_process_from_payload(payload, container, overwrite=False):  # pylint:
     payload_copy = deepcopy(payload)
     payload = _check_deploy(payload)
     payload.pop("$schema", None)
+    payload.pop("$id", None)
 
     # validate identifier naming for unsupported characters
     process_desc = payload.get("processDescription", {})  # empty possible if CWL directly passed
@@ -462,6 +463,7 @@ def deploy_process_from_payload(payload, container, overwrite=False):  # pylint:
     # remove schema to avoid later deserialization error if different, but remaining content is valid
     # also, avoid storing this field in the process object, regenerate it as needed during responses
     process_info.pop("$schema", None)
+    process_info.pop("$id", None)
 
     try:
         process = Process(process_info)  # if 'version' was provided in deploy info, it will be added as hint here

--- a/weaver/processes/utils.py
+++ b/weaver/processes/utils.py
@@ -195,7 +195,7 @@ def _check_deploy(payload):
     """
     message = "Process deployment definition is invalid."
     try:
-        results = sd.Deploy().deserialize(payload)
+        results = sd.Deploy(schema_meta_include=False, schema_include=False).deserialize(payload)
         # Because many fields are optional during deployment to allow flexibility between compatible WPS/CWL
         # definitions, any invalid field at lower-level could make a full higher-level definition to be dropped.
         # Verify the result to ensure this was not the case for known cases to attempt early detection.
@@ -239,7 +239,10 @@ def _check_deploy(payload):
         r_exec_unit = results.get("executionUnit", [{}])
         if p_exec_unit and p_exec_unit != r_exec_unit:
             message = "Process deployment execution unit is invalid."
-            d_exec_unit = sd.ExecutionUnitList().deserialize(p_exec_unit)  # raises directly if caused by invalid schema
+            d_exec_unit = sd.ExecutionUnitList(
+                schema_meta_include=False,
+                schema_include=False,
+            ).deserialize(p_exec_unit)  # raises directly if caused by invalid schema
             if r_exec_unit != d_exec_unit:  # otherwise raise a generic error, don't allow differing definitions
                 message = (
                     "Process deployment execution unit resolved as valid definition but differs from submitted "

--- a/weaver/wps_restapi/colander_extras.py
+++ b/weaver/wps_restapi/colander_extras.py
@@ -80,7 +80,7 @@ from cornice_swagger.converters.schema import (
     convert_regex_validator
 )
 from cornice_swagger.swagger import CorniceSwagger, DefinitionHandler, ParameterHandler, ResponseHandler
-from jsonschema.validators import Draft202012Validator
+from jsonschema.validators import Draft7Validator
 
 if TYPE_CHECKING:
     from typing import Any, Dict, Iterable, List, Optional, Sequence, Type, Union
@@ -1195,7 +1195,7 @@ class SchemaRefMappingSchema(ExtendedNodeInterface, ExtendedSchemaBase):
 
     # typings and attributes to help IDEs flag that the field is available/overridable
 
-    _schema_meta = Draft202012Validator.META_SCHEMA["$schema"]  # type: str
+    _schema_meta = Draft7Validator.META_SCHEMA["$schema"]  # type: str
     _schema_meta_include = False    # type: bool
     _schema = None                  # type: str
     _schema_include = True          # type: bool

--- a/weaver/wps_restapi/swagger_definitions.py
+++ b/weaver/wps_restapi/swagger_definitions.py
@@ -150,12 +150,12 @@ OGC_API_SCHEMA_CORE = f"{OGC_API_SCHEMA_BASE}/openapi/schemas/processes-core"
 OGC_API_EXAMPLES_CORE = f"{OGC_API_SCHEMA_BASE}/core/examples"
 # FIXME: OGC OpenAPI schema restructure (https://github.com/opengeospatial/ogcapi-processes/issues/319)
 # OGC_API_SCHEMA_EXT_DEPLOY = f"{OGC_API_SCHEMA_BASE}/openapi/schemas/processes-dru"
-OGC_API_SCHEMA_EXT_DEPLOY = f"{OGC_API_SCHEMA_BASE}/extensions/deploy_replace_undeploy/standard/openapi/schemas"
+OGC_API_SCHEMA_EXT_DEPLOY = f"{OGC_API_SCHEMA_BASE}/openapi/schemas/processes-dru"
 OGC_API_EXAMPLES_EXT_DEPLOY = f"{OGC_API_SCHEMA_BASE}/extensions/deploy_replace_undeploy/examples"
 # not available yet:
-OGC_API_SCHEMA_EXT_BILL = f"{OGC_API_SCHEMA_BASE}/extensions/billing/standard/openapi/schemas"
-OGC_API_SCHEMA_EXT_QUOTE = f"{OGC_API_SCHEMA_BASE}/extensions/quotation/standard/openapi/schemas"
-OGC_API_SCHEMA_EXT_WORKFLOW = f"{OGC_API_SCHEMA_BASE}/extensions/workflows/standard/openapi/schemas"
+OGC_API_SCHEMA_EXT_BILL = f"{OGC_API_SCHEMA_BASE}/openapi/schemas/processes-billing"
+OGC_API_SCHEMA_EXT_QUOTE = f"{OGC_API_SCHEMA_BASE}/openapi/schemas/processes-quotation"
+OGC_API_SCHEMA_EXT_WORKFLOW = f"{OGC_API_SCHEMA_BASE}/openapi/schemas/processes-workflows"
 
 # official/published references
 OGC_API_PROC_PART1 = "https://schemas.opengis.net/ogcapi/processes/part1/1.0"

--- a/weaver/wps_restapi/swagger_definitions.py
+++ b/weaver/wps_restapi/swagger_definitions.py
@@ -5950,7 +5950,7 @@ class ProcessesListing(ProcessCollection, ProcessListingLinks):
 
 
 class MultiProcessesListing(DescriptionSchema, ProcessesListing, ProvidersProcessesCollection, ProcessListingMetadata):
-    pass
+    _schema_meta_include = True
 
 
 class OkGetProcessesListResponse(ExtendedMappingSchema):

--- a/weaver/wps_restapi/swagger_definitions.py
+++ b/weaver/wps_restapi/swagger_definitions.py
@@ -121,6 +121,10 @@ DOC_URL = f"{__meta__.__documentation_url__}/en/latest"
 
 CWL_VERSION = "v1.2"
 CWL_REPO_URL = "https://github.com/common-workflow-language"
+CWL_SCHEMA_BRANCH = "1.2.1_proposed"
+CWL_SCHEMA_PATH = "json-schema/cwl.yaml"
+CWL_SCHEMA_REPO = f"https://raw.githubusercontent.com/common-workflow-language/cwl-{CWL_VERSION}"
+CWL_SCHEMA_URL = f"{CWL_SCHEMA_REPO}/{CWL_SCHEMA_BRANCH}/{CWL_SCHEMA_PATH}"
 CWL_BASE_URL = "https://www.commonwl.org"
 CWL_SPEC_URL = f"{CWL_BASE_URL}/#Specification"
 CWL_USER_GUIDE_URL = f"{CWL_BASE_URL}/user_guide"
@@ -4807,7 +4811,8 @@ class CWLApp(PermissiveMappingSchema):
 
 
 class CWL(CWLBase, CWLApp):
-    _sort_first = ["cwlVersion", "id", "class"]
+    _schema = CWL_SCHEMA_URL
+    _sort_first = ["$schema", "cwlVersion", "id", "class"]
 
 
 class Unit(ExtendedMappingSchema):
@@ -4936,7 +4941,7 @@ class ResultReferenceList(ExtendedSequenceSchema):
 
 
 class ResultData(OneOfKeywordSchema):
-    _schema = f"{OGC_API_PROC_PART1_SCHEMAS}/result.yaml"
+    _schema = f"{OGC_API_PROC_PART1_SCHEMAS}/inlineOrRefData.yaml"
     _one_of = [
         # must place formatted value first since both value/format fields are simultaneously required
         # other classes require only one of the two, and therefore are more permissive during schema validation
@@ -4953,7 +4958,7 @@ class Result(ExtendedMappingSchema):
     """
     Result outputs obtained from a successful process job execution.
     """
-    example_ref = f"{OGC_API_PROC_PART1_SCHEMAS}/result.yaml"
+    _schema = f"{OGC_API_PROC_PART1_SCHEMAS}/results.yaml"
     output_id = ResultData(
         variable="{output-id}", title="ResultData",
         description=(
@@ -5214,9 +5219,9 @@ class CWLGraphList(ExtendedSequenceSchema):
 class CWLGraphBase(ExtendedMappingSchema):
     graph = CWLGraphList(
         name="$graph", description=(
-            "Graph definition that defines *exactly one* CWL application package represented as list. "
+            "Graph definition that defines *exactly one* CWL Application Package represented as list. "
             "Multiple definitions simultaneously deployed is NOT supported currently."
-            # "Graph definition that combines one or many CWL application packages within a single payload. "
+            # "Graph definition that combines one or many CWL Application Packages within a single payload. "
             # "If a single application is given (list of one item), it will be deployed as normal CWL by itself. "
             # "If multiple applications are defined, the first MUST be the top-most Workflow process. "
             # "Deployment of other items will be performed, and the full deployment will be persisted only if all are "
@@ -6005,7 +6010,7 @@ class OkGetProcessInfoResponse(ExtendedMappingSchema):
 
 class OkGetProcessPackageSchema(ExtendedMappingSchema):
     header = ResponseHeaders()
-    body = NoContent()
+    body = CWL()
 
 
 class OkGetProcessPayloadSchema(ExtendedMappingSchema):

--- a/weaver/wps_restapi/swagger_definitions.py
+++ b/weaver/wps_restapi/swagger_definitions.py
@@ -824,8 +824,8 @@ class Format(ExtendedMappingSchema):
     """
     Used to respect ``mediaType`` field as suggested per `OGC-API`.
     """
+    _schema_include = False  # exclude "$id" added on each sub-deserialize (too verbose, only for reference)
     _schema = f"{OGC_API_PROC_PART1_SCHEMAS}/format.yaml"
-    _ext_schema_fields = []  # exclude "$schema" added on each sub-deserialize (too verbose, only for reference)
 
     mediaType = MediaType(default=ContentType.TEXT_PLAIN, example=ContentType.APP_JSON)
     encoding = ExtendedSchemaNode(String(), missing=drop)


### PR DESCRIPTION
- Add the official `CWL` `JSON` schema reference
  (https://github.com/common-workflow-language/cwl-v1.2/pull/256)
  as ``$schema`` parameter returned in under the `OpenAPI` schema for the `CWL` component employed by `Weaver`
  (fixes #547).
- Add ``$schema`` field auto-insertion into the generated `OpenAPI` schema definition by ``CorniceSwagger`` when
  corresponding ``colander.SchemaNode`` definitions contain a ``_schema = "<URL>"`` attribute (fixes #157).