### PR TITLE
fix schema validation prohibiting job execution with empty string input

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,9 +23,10 @@ Changes:
 Fixes:
 ------
 - Fix broken `OpenAPI` schema link references to `OGC API - Processes` repository.
+- Fix ``GET /providers/{provider_id}`` response using ``$schema`` instead of ``$id`` to provide its content schema.
 - Fix `Job` creation failing when submitting an empty string as input for a `Process` that allows it due
   to schema validation incorrectly preventing it.
-- Fix ``GET /providers/{provider_id}`` response using ``$schema`` instead of ``$id`` to provide its content schema.
+- Fix human-readable `JSON`-like content cleanup to preserve sequences of quotes corresponding to valid empty strings.
 
 .. _changes_4.30.1:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,8 @@ Changes:
 Fixes:
 ------
 - Fix broken `OpenAPI` schema link references to `OGC API - Processes` repository.
+- Fix `Job` creation failing when submitting an empty string as input for a `Process` that allows it due
+  to schema validation incorrectly preventing it.
 
 .. _changes_4.30.1:
 

--- a/tests/functional/test_wps_app.py
+++ b/tests/functional/test_wps_app.py
@@ -20,6 +20,7 @@ from tests.utils import (
     setup_config_with_celery,
     setup_config_with_mongodb,
     setup_config_with_pywps,
+    setup_mongodb_jobstore,
     setup_mongodb_processstore
 )
 from weaver import xml_util
@@ -45,6 +46,7 @@ class WpsAppTest(unittest.TestCase):
         config = setup_config_with_pywps(config)
         config = setup_config_with_celery(config)
         self.process_store = setup_mongodb_processstore(config)
+        self.job_store = setup_mongodb_jobstore(config)
         self.app = get_test_weaver_app(config=config, settings=settings)
 
         # add processes by database Process type
@@ -145,6 +147,24 @@ class WpsAppTest(unittest.TestCase):
         resp.mustcontain("<wps:ExecuteResponse")
         resp.mustcontain("<wps:ProcessAccepted")
         resp.mustcontain(f"PyWPS Process {HelloWPS.identifier}")
+
+    def test_execute_allowed_empty_string(self):
+        template = "service=wps&request=execute&version=1.0.0&identifier={}&datainputs=name="
+        params = template.format(HelloWPS.identifier)
+        url = self.make_url(params)
+        with contextlib.ExitStack() as stack_exec:
+            for mock_exec in mocked_execute_celery():
+                stack_exec.enter_context(mock_exec)
+            resp = self.app.get(url)
+        assert resp.status_code == 200  # FIXME: replace by 202 Accepted (?) https://github.com/crim-ca/weaver/issues/14
+        assert resp.content_type in ContentType.ANY_XML
+        resp.mustcontain("<wps:ExecuteResponse")
+        resp.mustcontain("<wps:ProcessAccepted")
+        resp.mustcontain(f"PyWPS Process {HelloWPS.identifier}")
+        loc = resp.xml.get("statusLocation")
+        job_id = loc.rsplit("/", 1)[-1].split(".", 1)[0]
+        job = self.job_store.fetch_by_id(job_id)
+        assert job.inputs[0]["data"] == ""
 
     def test_execute_deployed_with_visibility_allowed(self):
         headers = {"Accept": ContentType.APP_XML}

--- a/tests/test_owsexceptions.py
+++ b/tests/test_owsexceptions.py
@@ -1,8 +1,11 @@
+import pytest
+
 from weaver.owsexceptions import OWSException
 
 
-def test_owsexceptions_json_formatter():
-    test_cases = [
+@pytest.mark.parametrize(
+    ["test", "expect"],
+    [
         ("\nLeading new-line",
          "Leading new-line."),
         ("\nnew-lines\n\neverywhere\n",
@@ -19,6 +22,8 @@ def test_owsexceptions_json_formatter():
          "Loads of dots remains..."),
         ("Contains some u''strings' not escaped",
          "Contains some 'strings' not escaped."),
+        ("Does not remove double quotes \"\" or '' that represent an empty string: {\"test\": \"\", \"other\": ''}.",
+         "Does not remove double quotes '' or '' that represent an empty string: {'test': '', 'other': ''}."),
         ("With \"double quotes\" not escaped.",
          "With 'double quotes' not escaped."),
         ("With \'single quotes\' not escaped.",
@@ -37,17 +42,17 @@ def test_owsexceptions_json_formatter():
          "Another long line, with many commas and newlines, but placed differently, just for the heck of it."),
         ("Literal new-lines are\\nresolved to space", "Literal new-lines are resolved to space."),
     ]
-
+)
+def test_owsexceptions_json_formatter(test, expect):
     test_code = 418
     test_status = f"{test_code} I'm a teapot"
-    for test, expect in test_cases:
-        json_body = OWSException.json_formatter(status=test_status, body=test, title="SomeCode", environ={})
-        assert json_body["code"] == "SomeCode"
-        assert json_body["error"]["code"] == test_code
-        assert json_body["error"]["status"] == test_status
-        result = json_body["description"]
-        assert json_body["description"] == expect, (
-            "Result does not match expected value"
-            f"\n  Result: '{result}'"
-            f"\n  Expect: '{expect}'"
-        )
+    json_body = OWSException.json_formatter(status=test_status, body=test, title="SomeCode", environ={})
+    assert json_body["code"] == "SomeCode"
+    assert json_body["error"]["code"] == test_code
+    assert json_body["error"]["status"] == test_status
+    result = json_body["description"]
+    assert json_body["description"] == expect, (
+        "Result does not match expected value"
+        f"\n  Result: '{result}'"
+        f"\n  Expect: '{expect}'"
+    )

--- a/weaver/processes/convert.py
+++ b/weaver/processes/convert.py
@@ -2861,10 +2861,10 @@ def wps2json_job_payload(wps_request, wps_process):
         for input_value in input_list:
             input_data = input_value.get("data")
             input_href = input_value.get("href")
-            if input_data:
-                data["inputs"].append({"id": iid, "data": input_data})
-            elif input_href:
+            if input_href:  # when href is provided, it must always be non-empty
                 data["inputs"].append({"id": iid, "href": input_href})
+            else:  # no check if value to allow possible empty string, numeric zero or explicit null
+                data["inputs"].append({"id": iid, "data": input_data})
     output_ids = list(wps_request.outputs)
     for output in wps_process.outputs:
         oid = output.identifier

--- a/weaver/store/mongodb.py
+++ b/weaver/store/mongodb.py
@@ -891,7 +891,7 @@ class MongodbJobStore(StoreJobs, MongodbStore, ListingMixin):
         result = self.collection.delete_one({"id": job_id})
         return result.deleted_count == 1
 
-    def c(self, job_id):
+    def fetch_by_id(self, job_id):
         # type: (AnyUUID) -> Job
         """
         Gets job for given ``job_id`` from `MongoDB` storage.

--- a/weaver/store/mongodb.py
+++ b/weaver/store/mongodb.py
@@ -891,7 +891,7 @@ class MongodbJobStore(StoreJobs, MongodbStore, ListingMixin):
         result = self.collection.delete_one({"id": job_id})
         return result.deleted_count == 1
 
-    def fetch_by_id(self, job_id):
+    def c(self, job_id):
         # type: (AnyUUID) -> Job
         """
         Gets job for given ``job_id`` from `MongoDB` storage.

--- a/weaver/utils.py
+++ b/weaver/utils.py
@@ -3488,7 +3488,7 @@ def clean_json_text_body(body, remove_newlines=True, remove_indents=True):
     """
     # cleanup various escape characters and u'' stings
     replaces = [(",\n", ", "), ("\\n", " "), (" \n", " "), ("\n'", "'"), ("\"", "\'"),
-                ("u\'", "\'"), ("u\"", "\'"), ("\'\'", "\'"), ("'. ", ""), ("'. '", ""),
+                ("u\'", "\'"), ("u\"", "\'"), ("'. ", ""), ("'. '", ""),
                 ("}'", "}"), ("'{", "{")]
     if remove_indents:
         replaces.extend([("\\", " "), ("  ", " ")])

--- a/weaver/wps_restapi/swagger_definitions.py
+++ b/weaver/wps_restapi/swagger_definitions.py
@@ -1340,6 +1340,7 @@ class AnyLiteralType(OneOfKeywordSchema):
             description="Literal data type representing a boolean flag.",
         ),
         ExtendedSchemaNode(
+            # pylint: disable=C0301,line-too-long
             # FIXME: support byte/binary type (string + format:byte) ?
             #   https://github.com/opengeospatial/ogcapi-processes/blob/master/openapi/schemas/processes-core/binaryInputValue.yaml
             #   see if we can use 'encoding' parameter available for below 'String' schema-type to handle this?

--- a/weaver/wps_restapi/swagger_definitions.py
+++ b/weaver/wps_restapi/swagger_definitions.py
@@ -1314,8 +1314,6 @@ class BoundingBoxInputType(ExtendedMappingSchema):
     supportedCRS = SupportedCRSList()
 
 
-# FIXME: support byte/binary type (string + format:byte) ?
-#   https://github.com/opengeospatial/ogcapi-processes/blob/master/openapi/schemas/processes-core/binaryInputValue.yaml
 class AnyLiteralType(OneOfKeywordSchema):
     """
     Submitted values that correspond to literal data.
@@ -1326,10 +1324,29 @@ class AnyLiteralType(OneOfKeywordSchema):
         - :class:`AnyLiteralDefaultType`
     """
     _one_of = [
-        ExtendedSchemaNode(Float(), description="Literal data type representing a floating point number."),
-        ExtendedSchemaNode(Integer(), description="Literal data type representing an integer number."),
-        ExtendedSchemaNode(Boolean(), description="Literal data type representing a boolean flag."),
-        ExtendedSchemaNode(String(), description="Literal data type representing a generic string."),
+        ExtendedSchemaNode(
+            Float(),
+            title="LiteralDataFloat",
+            description="Literal data type representing a floating point number.",
+        ),
+        ExtendedSchemaNode(
+            Integer(),
+            title="LiteralDataInteger",
+            description="Literal data type representing an integer number.",
+        ),
+        ExtendedSchemaNode(
+            Boolean(),
+            title="LiteralDataBoolean",
+            description="Literal data type representing a boolean flag.",
+        ),
+        ExtendedSchemaNode(
+            # FIXME: support byte/binary type (string + format:byte) ?
+            #   https://github.com/opengeospatial/ogcapi-processes/blob/master/openapi/schemas/processes-core/binaryInputValue.yaml
+            #   see if we can use 'encoding' parameter available for below 'String' schema-type to handle this?
+            String(allow_empty=True),  # valid to submit a process with empty string
+            title="LiteralDataString",
+            description="Literal data type representing a generic string.",
+        ),
     ]
 
 
@@ -3489,14 +3506,9 @@ class ExecuteInputFile(AnyOfKeywordSchema):
 #   https://github.com/opengeospatial/ogcapi-processes/blob/master/openapi/schemas/processes-core/binaryInputValue.yaml
 # FIXME: does not support bbox
 #   https://github.com/opengeospatial/ogcapi-processes/blob/master/openapi/schemas/processes-core/bbox.yaml
-class ExecuteInputInlineValue(OneOfKeywordSchema):
+class ExecuteInputInlineValue(AnyLiteralType):
+    title = "ExecuteInputInlineValue"
     description = "Execute input value provided inline."
-    _one_of = [
-        ExtendedSchemaNode(Float(), title="ExecuteInputValueFloat"),
-        ExtendedSchemaNode(Integer(), title="ExecuteInputValueInteger"),
-        ExtendedSchemaNode(Boolean(), title="ExecuteInputValueBoolean"),
-        ExtendedSchemaNode(String(), title="ExecuteInputValueString"),
-    ]
 
 
 # https://github.com/opengeospatial/ogcapi-processes/blob/master/openapi/schemas/processes-core/inputValue.yaml


### PR DESCRIPTION
## Fixes

- Fix `Job` creation failing when submitting an empty string as input for a `Process` that allows it due
  to schema validation incorrectly preventing it.