### PR TITLE
fix rendering of provider schema reference in response body 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,7 @@ Changes:
 Fixes:
 ------
 - Fix broken `OpenAPI` schema link references to `OGC API - Processes` repository.
+- Fix ``GET /providers/{provider_id}`` response using ``$schema`` instead of ``$id`` to provide its content schema.
 
 .. _changes_4.30.1:
 

--- a/weaver/wps_restapi/providers/providers.py
+++ b/weaver/wps_restapi/providers/providers.py
@@ -143,7 +143,10 @@ def get_provider(request):
     Get a provider definition (GetCapabilities).
     """
     service, _ = get_service(request)
-    return HTTPOk(json=service.summary(request))
+    data = get_schema_ref(sd.ProviderSummarySchema, request, ref_name=False)
+    info = service.summary(request)
+    data.update(info)
+    return HTTPOk(json=data)
 
 
 @sd.provider_processes_service.get(tags=[sd.TAG_PROVIDERS, sd.TAG_PROCESSES, sd.TAG_PROVIDERS, sd.TAG_GETCAPABILITIES],

--- a/weaver/wps_restapi/swagger_definitions.py
+++ b/weaver/wps_restapi/swagger_definitions.py
@@ -3036,6 +3036,7 @@ class ProviderSummarySchema(DescriptionType, ProviderPublic, DescriptionMeta, De
     url = URL(description="Endpoint of the service provider.")
     type = ExtendedSchemaNode(String())
 
+    _schema_meta_include = True
     _sort_first = PROVIDER_DESCRIPTION_FIELD_FIRST
     _sort_after = PROVIDER_DESCRIPTION_FIELD_AFTER
 

--- a/weaver/wps_restapi/utils.py
+++ b/weaver/wps_restapi/utils.py
@@ -109,7 +109,7 @@ def get_wps_restapi_base_url(container):
     return weaver_rest_url.rstrip("/").strip()
 
 
-def get_schema_ref(schema, container=None, ref_type="$schema", ref_name=True):
+def get_schema_ref(schema, container=None, ref_type="$id", ref_name=True):
     # type: (colander.SchemaNode, Optional[AnySettingsContainer], str, True) -> Dict[str, str]
     """
     Generates the JSON OpenAPI schema reference relative to the current `Weaver` instance.
@@ -123,7 +123,7 @@ def get_schema_ref(schema, container=None, ref_type="$schema", ref_name=True):
 
     :param schema: schema-node instance or type for which to generate the OpenAPI reference.
     :param container: application settings to retrieve the base URL of the schema location.
-    :param ref_type: key employed to form the reference (e.g.: "$schema", "$ref", "@schema", etc.)
+    :param ref_type: key employed to form the reference (e.g.: "$id", "$ref", "$schema", "@id", etc.).
     :param ref_name: indicate if the plain name should also be included under field ``"schema"``.
     :return: OpenAPI schema reference
     """


### PR DESCRIPTION
## Fixes
- Fix ``GET /providers/{provider_id}`` response using ``$schema`` instead of ``$id`` to provide its content schema.

relates to #551

