### PR TITLE
add smoke tests scripts to evaluate node.js dependency within built docker image

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,6 +33,7 @@ jobs:
     env:
       # override make command to install directly in active python
       CONDA_CMD: ""
+      DOCKER_TEST_EXEC_ARGS: "-T"
     services:
       # Label used to access the service container
       mongodb:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,7 +16,8 @@ Changes:
 
 Fixes:
 ------
-- No change.
+- Fix missing Node.js requirement in built Docker image in order to evaluate definitions that employ
+  `CWL` ``InlineJavascriptRequirement``, such as ``valueFrom`` employed for numeric ``Enum`` input type validation.
 
 .. _changes_4.31.0:
 

--- a/Makefile
+++ b/Makefile
@@ -811,7 +811,7 @@ docker-test: docker-build stop	## execute smoke test of the built images (valida
 	@curl localhost:4001 | grep "Weaver Information" || \
 		( docker-compose $(DOCKER_TEST_COMPOSES) logs weaver worker || true && \
 		  docker-compose $(DOCKER_TEST_COMPOSES) stop; exit 1 )
-	docker-compose $(DOCKER_TEST_COMPOSES) exec weaver bash /tests/run_tests.sh
+	docker exec -ti smoke_test_weaver bash /tests/run_tests.sh
 	docker-compose $(DOCKER_TEST_COMPOSES) stop
 
 .PHONY: docker-stat

--- a/Makefile
+++ b/Makefile
@@ -802,6 +802,7 @@ docker-push: docker-push-base docker-push-manager docker-push-worker  ## push al
 # if compose up fails, print the logs and force stop
 # if compose up succeeds, query weaver to get frontpage response
 DOCKER_TEST_COMPOSES := -f "$(APP_ROOT)/tests/smoke/docker-compose.smoke-test.yml"
+DOCKER_TEST_EXEC_ARGS ?=
 .PHONY: docker-test
 docker-test: docker-build stop	## execute smoke test of the built images (validate that they boots and reply)
 	@echo "Smoke test of built application docker images"
@@ -811,7 +812,7 @@ docker-test: docker-build stop	## execute smoke test of the built images (valida
 	@curl localhost:4001 | grep "Weaver Information" || \
 		( docker-compose $(DOCKER_TEST_COMPOSES) logs weaver worker || true && \
 		  docker-compose $(DOCKER_TEST_COMPOSES) stop; exit 1 )
-	docker exec -ti smoke_test_weaver bash /tests/run_tests.sh
+	docker-compose $(DOCKER_TEST_COMPOSES) exec $(DOCKER_TEST_EXEC_ARGS) weaver bash /tests/run_tests.sh
 	docker-compose $(DOCKER_TEST_COMPOSES) stop
 
 .PHONY: docker-stat

--- a/Makefile
+++ b/Makefile
@@ -811,6 +811,7 @@ docker-test: docker-build stop	## execute smoke test of the built images (valida
 	@curl localhost:4001 | grep "Weaver Information" || \
 		( docker-compose $(DOCKER_TEST_COMPOSES) logs weaver worker || true && \
 		  docker-compose $(DOCKER_TEST_COMPOSES) stop; exit 1 )
+	docker-compose $(DOCKER_TEST_COMPOSES) exec weaver bash /tests/run_tests.sh
 	docker-compose $(DOCKER_TEST_COMPOSES) stop
 
 .PHONY: docker-stat

--- a/docker/Dockerfile-base
+++ b/docker/Dockerfile-base
@@ -21,6 +21,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         netbase \
         gcc \
         git \
+        nodejs \
     && pip install --no-cache-dir --upgrade -r requirements-sys.txt \
     && pip install --no-cache-dir -r requirements.txt \
     && pip install --no-cache-dir -e ${APP_DIR} \

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,6 +45,7 @@ replace = LABEL version="{new_version}"
 addopts = 
 	--strict-markers
 	--tb=native
+	--ignore=tests/smoke
 	weaver/
 log_cli = false
 log_level = DEBUG

--- a/tests/smoke/docker-compose.smoke-test.yml
+++ b/tests/smoke/docker-compose.smoke-test.yml
@@ -16,6 +16,7 @@ services:
       - "4001:4001"
     volumes:
       - ../../config/weaver.ini.example:/opt/local/src/weaver/config/weaver.ini
+      - ./tests:/tests
     networks:
       - default
     restart: "no"

--- a/tests/smoke/tests/run_tests.sh
+++ b/tests/smoke/tests/run_tests.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+pip install pytest
+pytest /tests -vvv

--- a/tests/smoke/tests/test_cwl_nodejs.py
+++ b/tests/smoke/tests/test_cwl_nodejs.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+"""
+Run operations specifically within the built Docker container to ensure JavaScript runtime dependencies are available.
+"""
+
+import pytest
+from cwl_utils import expression
+from cwltool.process import get_schema
+from cwltool.validate_js import validate_js_expressions
+
+from weaver.processes.constants import CWL_REQUIREMENT_INLINE_JAVASCRIPT
+
+
+def test_cwl_nodejs(caplog: pytest.LogCaptureFixture) -> None:
+    """
+    Run a CWL operation that requires Node.js to be evaluated.
+
+    If JavaScript cannot be parsed and executed in the Docker container, then some requirements are missing.
+    """
+    tool = {
+        "cwlVersion": "v1.0",
+        "class": "CommandLineTool",
+        "baseCommand": "echo",
+        "requirements": [
+            {
+                "class": CWL_REQUIREMENT_INLINE_JAVASCRIPT,
+            }
+        ],
+        "inputs": [
+            {
+                "id": "test",
+                "inputBinding": {
+                    "valueFrom": "${ let x = self + 1; return x; }"
+                }
+            }
+        ],
+        "outputs": {"output": "stdout"}
+    }
+    schema = get_schema(tool["cwlVersion"])[1]
+    clt_schema = schema.names["org.w3id.cwl.cwl.CommandLineTool"]
+    validate_js_expressions(tool, clt_schema)  # type: ignore
+
+    out = expression.do_eval(
+        tool["inputs"][0]["inputBinding"]["valueFrom"],
+        {tool["inputs"][0]["id"]: tool["inputs"][0]},
+        tool["requirements"],
+        None,
+        None,
+        {},
+        context=1,  # value passed as input
+    )
+
+    assert "JSHINT" in caplog.text
+    assert out == 2  # JS 'self + 1'


### PR DESCRIPTION
## Fixes

- Fix missing Node.js requirement in built Docker image in order to evaluate definitions that employ
  `CWL` ``InlineJavascriptRequirement``, such as ``valueFrom`` employed for numeric ``Enum`` input type validation.