### PR TITLE
add CLI package operation + support CWL package retrieval for provider process

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ Changes:
 - Add ``GET /providers/{provider_id}/processes/{process_id}/package`` endpoint that allows retrieval of the `CWL`
   `Application Package` definition generated for the specific `Provider`'s `Process` definition.
 - Add `CLI` ``package`` operation to request the remote `Provider` or local `Process` `CWL` `Application Package`.
+- Add `CLI` output reporting of performed HTTP requests details when using the ``--debug/-d`` option.
 
 Fixes:
 ------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,7 +12,9 @@ Changes
 
 Changes:
 --------
-- No change.
+- Add ``GET /providers/{provider_id}/processes/{process_id}/package`` endpoint that allows retrieval of the `CWL`
+  `Application Package` definition generated for the specific `Provider`'s `Process` definition.
+- Add `CLI` ``package`` operation to request the remote `Provider` or local `Process` `CWL` `Application Package`.
 
 Fixes:
 ------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,13 @@ Changes:
   `Application Package` definition generated for the specific `Provider`'s `Process` definition.
 - Add `CLI` ``package`` operation to request the remote `Provider` or local `Process` `CWL` `Application Package`.
 - Add `CLI` output reporting of performed HTTP requests details when using the ``--debug/-d`` option.
+- Modify default behavior of ``visibility`` field (under ``processDescription`` or ``processDescription.process``)
+  to employ the expected functionality by native `OGC API - Processes` clients that do not support this option
+  (i.e.: ``public`` by default), and to align resolution strategy with deployments by direct `CWL` payload which do not
+  include this feature either. A `Process` deployment that desires to employ this feature (``visibility: private``) will
+  have to provide the value explicitly, or update the deployed `Process` definition afterwards with the relevant
+  ``PUT`` request. Since ``public`` will now be used by default, the `CLI` will not automatically inject the value
+  in the payload anymore when omitted.
 
 Fixes:
 ------
@@ -27,6 +34,10 @@ Fixes:
 - Fix ``get_cwl_io_type`` function that would modify the I/O definition passed as argument, which could lead to failing
   `CWL` ``class`` reference resolutions later on due to different ``type`` with ``org.w3id.cwl.cwl`` prefix simplified
   before ``cwltool`` had the chance to resolve them.
+- Fix ``links`` listing duplicated in response from `Process` deployment.
+  Links will only be listed within the returned ``processSummary`` to respect the `OGC API - Processes` schema.
+- Fix `CLI` not removing embedded ``links`` in ``processSummary`` from ``deploy`` operation response
+  when ``-nL``/``--no-links`` option is specified.
 
 .. _changes_4.31.0:
 

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -102,6 +102,8 @@ class TestWeaverClientBase(WpsConfigBase, ResourcesUtil, JobUtils):
 
 
 class TestWeaverClient(TestWeaverClientBase):
+    test_tmp_dir = None  # type: str
+
     @classmethod
     def setUpClass(cls):
         super(TestWeaverClient, cls).setUpClass()
@@ -341,6 +343,40 @@ class TestWeaverClient(TestWeaverClientBase):
         result = mocked_sub_requests(self.app, self.client.deploy, test_id, deploy, undeploy=True)
         assert result.success
         assert "undefined" not in result.message
+
+    def test_deploy_private_process_description(self):
+        test_id = f"{self.test_process_prefix}private-process-description"
+        payload = self.retrieve_payload("Echo", "deploy", local=True)
+        package = self.retrieve_payload("Echo", "package", local=True)
+        payload.pop("executionUnit", None)
+        process = payload["processDescription"].pop("process")
+        payload["processDescription"].update(process)
+        payload["processDescription"]["visibility"] = Visibility.PRIVATE
+
+        result = mocked_sub_requests(self.app, self.client.deploy, test_id, payload, package)
+        assert result.success
+        assert "processSummary" in result.body
+        assert result.body["processSummary"]["id"] == test_id
+
+        result = mocked_sub_requests(self.app, self.client.describe, test_id)
+        assert not result.success
+        assert result.code == 403
+
+    def test_deploy_private_process_nested(self):
+        test_id = f"{self.test_process_prefix}private-process-nested"
+        payload = self.retrieve_payload("Echo", "deploy", local=True)
+        package = self.retrieve_payload("Echo", "package", local=True)
+        payload.pop("executionUnit", None)
+        payload["processDescription"]["process"]["visibility"] = Visibility.PRIVATE
+
+        result = mocked_sub_requests(self.app, self.client.deploy, test_id, payload, package)
+        assert result.success
+        assert "processSummary" in result.body
+        assert result.body["processSummary"]["id"] == test_id
+
+        result = mocked_sub_requests(self.app, self.client.describe, test_id)
+        assert not result.success
+        assert result.code == 403
 
     def test_undeploy(self):
         # deploy a new process to leave the test one available
@@ -771,6 +807,7 @@ class TestWeaverCLI(TestWeaverClientBase):
                 "-u", self.url,
                 "--body", payload,  # no --process/--id, but available through --body
                 "--cwl", package,
+                "-D",  # avoid conflict just in case
             ],
             trim=False,
             entrypoint=weaver_cli,
@@ -778,6 +815,28 @@ class TestWeaverCLI(TestWeaverClientBase):
         )
         assert any("\"id\": \"Echo\"" in line for line in lines)
         assert any("\"deploymentDone\": true" in line for line in lines)
+
+    def test_deploy_no_links(self):
+        payload = self.retrieve_payload("Echo", "deploy", local=True, ref_found=True)
+        package = self.retrieve_payload("Echo", "package", local=True, ref_found=True)
+        lines = mocked_sub_requests(
+            self.app, run_command,
+            [
+                # "weaver",
+                "deploy",
+                "-u", self.url,
+                "--body", payload,
+                "--cwl", package,
+                "-nL",
+                "-D",
+            ],
+            trim=False,
+            entrypoint=weaver_cli,
+            only_local=True,
+        )
+        # ignore indents of fields from formatted JSON content
+        assert any("\"id\": \"Echo\"" in line for line in lines)
+        assert all("\"links\":" not in line for line in lines)
 
     def test_deploy_docker_auth_help(self):
         """
@@ -1254,6 +1313,49 @@ class TestWeaverCLI(TestWeaverClientBase):
         assert any("\"inputs\": {" in line for line in lines)
         assert any("\"outputs\": {" in line for line in lines)
         assert all("\"links\":" not in line for line in lines)
+
+    def test_package_process(self):
+        payload = self.retrieve_payload("Echo", "deploy", local=True, ref_found=True)
+        package = self.retrieve_payload("Echo", "package", local=True)
+        lines = mocked_sub_requests(
+            self.app, run_command,
+            [
+                # weaver
+                "deploy",
+                "-u", self.url,
+                "--body", payload,
+                "--cwl", package,
+                "--id", "test-echo-get-package"
+            ],
+            trim=False,
+            entrypoint=weaver_cli,
+            only_local=True,
+        )
+        assert any("\"id\": \"test-echo-get-package\"" in line for line in lines)
+
+        lines = mocked_sub_requests(
+            self.app, run_command,
+            [
+                # weaver
+                "package",
+                "-u", self.url,
+                "-p", "test-echo-get-package"
+            ],
+            trim=False,
+            entrypoint=weaver_cli,
+            only_local=True,
+        )
+        assert any("\"cwlVersion\"" in line for line in lines)
+        cwl = json.loads("".join(lines))
+
+        # package not 100% the same, but equivalent definitions
+        # check that what is returned is at least relatively equal
+        cwl.pop("$id", None)
+        cwl.pop("$schema", None)
+        pkg = package.copy()
+        pkg["inputs"] = [dict(id=key, **val) for key, val in package["inputs"].items()]
+        pkg["outputs"] = [dict(id=key, **val) for key, val in package["outputs"].items()]
+        assert cwl == pkg
 
     def test_execute_inputs_capture(self):
         """

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -1353,8 +1353,8 @@ class TestWeaverCLI(TestWeaverClientBase):
         cwl.pop("$id", None)
         cwl.pop("$schema", None)
         pkg = package.copy()
-        pkg["inputs"] = [dict(id=key, **val) for key, val in package["inputs"].items()]  # noqa
-        pkg["outputs"] = [dict(id=key, **val) for key, val in package["outputs"].items()]  # noqa
+        pkg["inputs"] = [{"id": key, **val} for key, val in package["inputs"].items()]  # pylint: disable=E1136
+        pkg["outputs"] = [{"id": key, **val} for key, val in package["outputs"].items()]  # pylint: disable=E1136
         assert cwl == pkg
 
     def test_execute_inputs_capture(self):

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -1353,8 +1353,8 @@ class TestWeaverCLI(TestWeaverClientBase):
         cwl.pop("$id", None)
         cwl.pop("$schema", None)
         pkg = package.copy()
-        pkg["inputs"] = [dict(id=key, **val) for key, val in package["inputs"].items()]
-        pkg["outputs"] = [dict(id=key, **val) for key, val in package["outputs"].items()]
+        pkg["inputs"] = [dict(id=key, **val) for key, val in package["inputs"].items()]  # noqa
+        pkg["outputs"] = [dict(id=key, **val) for key, val in package["outputs"].items()]  # noqa
         assert cwl == pkg
 
     def test_execute_inputs_capture(self):

--- a/tests/functional/utils.py
+++ b/tests/functional/utils.py
@@ -38,6 +38,9 @@ if TYPE_CHECKING:
     from typing import Any, Dict, Iterable, Optional, Tuple, Union
     from typing_extensions import Literal
 
+    from pyramid.config import Configurator
+    from webtest import TestApp
+
     from weaver.typedefs import (
         AnyRequestMethod,
         AnyResponseType,
@@ -305,7 +308,10 @@ class WpsConfigBase(unittest.TestCase):
     json_headers = {"Accept": ContentType.APP_JSON, "Content-Type": ContentType.APP_JSON}
     monitor_timeout = 30
     monitor_interval = 1
-    settings = {}  # type: SettingsType
+    settings = {}   # type: SettingsType
+    config = None   # type: Configurator
+    app = None      # type: TestApp
+    url = None      # type: str
 
     def __init__(self, *args, **kwargs):
         # won't run this as a test suite, only its derived classes

--- a/weaver/cli.py
+++ b/weaver/cli.py
@@ -435,6 +435,8 @@ class WeaverClient(object):
                             for item in nested:
                                 if isinstance(item, dict):
                                     item.pop("links", None)
+                        elif isinstance(nested, dict):
+                            nested.pop("links", None)
                     body.pop("links", None)
                 msg = body.get("description", body.get("message", "undefined"))
             if code >= 400:
@@ -484,7 +486,6 @@ class WeaverClient(object):
                 desc = data.get("processDescription", {}).get("process", {}) or data.get("processDescription", {})
                 desc["id"] = process_id
             data.setdefault("processDescription", desc)  # already applied if description was found/updated at any level
-            desc["visibility"] = Visibility.PUBLIC
         except (ValueError, TypeError, ScannerError) as exc:  # pragma: no cover
             return OperationResult(False, f"Failed resolution of body definition: [{exc!s}]", body)
         return OperationResult(True, "", data)
@@ -711,7 +712,8 @@ class WeaverClient(object):
         resp = self._request("POST", path, json=data,
                              headers=req_headers, x_headers=headers, settings=self._settings, auth=auth,
                              request_timeout=request_timeout, request_retries=request_retries)
-        return self._parse_result(resp, with_links=with_links, with_headers=with_headers, output_format=output_format)
+        return self._parse_result(resp, with_links=with_links, nested_links="processSummary",
+                                  with_headers=with_headers, output_format=output_format)
 
     def undeploy(self,
                  process_id,            # type: str

--- a/weaver/cli.py
+++ b/weaver/cli.py
@@ -53,7 +53,6 @@ from weaver.utils import (
     request_extra,
     setup_loggers
 )
-from weaver.visibility import Visibility
 from weaver.wps_restapi import swagger_definitions as sd
 
 if TYPE_CHECKING:

--- a/weaver/datatype.py
+++ b/weaver/datatype.py
@@ -2247,7 +2247,7 @@ class Process(Base):
     @property
     def visibility(self):
         # type: () -> Visibility
-        return Visibility.get(self.get("visibility"), Visibility.PRIVATE)
+        return Visibility.get(self.get("visibility"), Visibility.PUBLIC)
 
     @visibility.setter
     def visibility(self, visibility):

--- a/weaver/processes/utils.py
+++ b/weaver/processes/utils.py
@@ -450,6 +450,7 @@ def deploy_process_from_payload(payload, container, overwrite=False):  # pylint:
     process_info["jobControlOptions"] = process_desc.get("jobControlOptions", [])
     process_info["outputTransmission"] = process_desc.get("outputTransmission", [])
     process_info["processDescriptionURL"] = description_url
+
     # insert the "resolved" context using details retrieved from "executionUnit"/"href" or directly with "owsContext"
     if "owsContext" not in process_info and reference:
         process_info["owsContext"] = {"offering": {"content": {"href": str(reference)}}}
@@ -476,11 +477,12 @@ def deploy_process_from_payload(payload, container, overwrite=False):  # pylint:
         raise HTTPBadRequest(detail=str(exc))
     except HTTPException:
         raise
+    links = process.links(container)
+    process_summary["links"] = links
     data = {
         "description": sd.OkPostProcessesResponse.description,
         "processSummary": process_summary,
         "deploymentDone": True,
-        "links": process.links(container),
     }
     if deployment_profile_name:
         data["deploymentProfileName"] = deployment_profile_name

--- a/weaver/wps_restapi/providers/__init__.py
+++ b/weaver/wps_restapi/providers/__init__.py
@@ -19,6 +19,7 @@ def includeme(config):
     config.add_route(**sd.service_api_route_info(sd.provider_service, settings))
     config.add_route(**sd.service_api_route_info(sd.provider_processes_service, settings))
     config.add_route(**sd.service_api_route_info(sd.provider_process_service, settings))
+    config.add_route(**sd.service_api_route_info(sd.provider_process_package_service, settings))
     config.add_route(**sd.service_api_route_info(sd.provider_execution_service, settings))
     config.add_view(p.get_providers, route_name=sd.providers_service.name,
                     request_method="GET", renderer=OutputFormat.JSON)
@@ -31,6 +32,8 @@ def includeme(config):
     config.add_view(p.get_provider_processes, route_name=sd.provider_processes_service.name,
                     request_method="GET", renderer=OutputFormat.JSON)
     config.add_view(p.get_provider_process, route_name=sd.provider_process_service.name,
+                    request_method="GET", renderer=OutputFormat.JSON)
+    config.add_view(p.get_provider_process_package, route_name=sd.provider_process_package_service.name,
                     request_method="GET", renderer=OutputFormat.JSON)
     config.add_view(p.submit_provider_job, route_name=sd.provider_jobs_service.name,
                     request_method="POST", renderer=OutputFormat.JSON)

--- a/weaver/wps_restapi/providers/providers.py
+++ b/weaver/wps_restapi/providers/providers.py
@@ -149,7 +149,7 @@ def get_provider(request):
     return HTTPOk(json=data)
 
 
-@sd.provider_processes_service.get(tags=[sd.TAG_PROVIDERS, sd.TAG_PROCESSES, sd.TAG_PROVIDERS, sd.TAG_GETCAPABILITIES],
+@sd.provider_processes_service.get(tags=[sd.TAG_PROVIDERS, sd.TAG_PROCESSES, sd.TAG_GETCAPABILITIES],
                                    renderer=OutputFormat.JSON, schema=sd.ProviderProcessesEndpoint(),
                                    response_schemas=sd.get_provider_processes_responses)
 @log_unhandled_exceptions(logger=LOGGER, message=sd.InternalServerErrorResponseSchema.description)
@@ -190,7 +190,7 @@ def describe_provider_process(request):
     return Process.convert(process, service, get_settings(request))
 
 
-@sd.provider_process_service.get(tags=[sd.TAG_PROVIDERS, sd.TAG_PROCESSES, sd.TAG_PROVIDERS, sd.TAG_DESCRIBEPROCESS],
+@sd.provider_process_service.get(tags=[sd.TAG_PROVIDERS, sd.TAG_PROCESSES, sd.TAG_DESCRIBEPROCESS],
                                  renderer=OutputFormat.JSON, schema=sd.ProviderProcessEndpoint(),
                                  response_schemas=sd.get_provider_process_responses)
 @log_unhandled_exceptions(logger=LOGGER, message=sd.InternalServerErrorResponseSchema.description)
@@ -199,7 +199,7 @@ def describe_provider_process(request):
 def get_provider_process(request):
     # type: (PyramidRequest) -> AnyViewResponse
     """
-    Retrieve a process description (DescribeProcess).
+    Retrieve a remote provider's process description (DescribeProcess).
     """
     process = describe_provider_process(request)
     schema = request.params.get("schema")
@@ -207,10 +207,24 @@ def get_provider_process(request):
     return HTTPOk(json=offering)
 
 
-@sd.provider_execution_service.post(tags=[sd.TAG_PROVIDERS, sd.TAG_PROVIDERS, sd.TAG_EXECUTE, sd.TAG_JOBS],
+@sd.provider_process_package_service.get(tags=[sd.TAG_PROVIDERS, sd.TAG_PROCESSES, sd.TAG_DESCRIBEPROCESS],
+                                         renderer=OutputFormat.JSON, schema=sd.ProviderProcessPackageEndpoint(),
+                                         response_schemas=sd.get_provider_process_package_responses)
+@log_unhandled_exceptions(logger=LOGGER, message=sd.InternalServerErrorResponseSchema.description)
+@check_provider_requirements
+def get_provider_process_package(request):
+    # type: (PyramidRequest) -> AnyViewResponse
+    """
+    Retrieve a remote provider's process Application Package definition.
+    """
+    process = describe_provider_process(request)
+    return HTTPOk(json=process.package or {})
+
+
+@sd.provider_execution_service.post(tags=[sd.TAG_PROVIDERS, sd.TAG_PROCESSES, sd.TAG_EXECUTE, sd.TAG_JOBS],
                                     renderer=OutputFormat.JSON, schema=sd.PostProviderProcessJobRequest(),
                                     response_schemas=sd.post_provider_process_job_responses)
-@sd.provider_jobs_service.post(tags=[sd.TAG_PROVIDERS, sd.TAG_PROVIDERS, sd.TAG_EXECUTE, sd.TAG_JOBS],
+@sd.provider_jobs_service.post(tags=[sd.TAG_PROVIDERS, sd.TAG_PROCESSES, sd.TAG_EXECUTE, sd.TAG_JOBS],
                                renderer=OutputFormat.JSON, schema=sd.PostProviderProcessJobRequest(),
                                response_schemas=sd.post_provider_process_job_responses)
 @log_unhandled_exceptions(logger=LOGGER, message=sd.InternalServerErrorResponseSchema.description)

--- a/weaver/wps_restapi/swagger_definitions.py
+++ b/weaver/wps_restapi/swagger_definitions.py
@@ -311,6 +311,7 @@ providers_service = Service(name="providers", path="/providers")
 provider_service = Service(name="provider", path=f"{providers_service.path}/{{provider_id}}")
 provider_processes_service = Service(name="provider_processes", path=provider_service.path + processes_service.path)
 provider_process_service = Service(name="provider_process", path=provider_service.path + process_service.path)
+provider_process_package_service = Service(name="provider_process_pkg", path=f"{provider_process_service.path}/package")
 provider_jobs_service = Service(name="provider_jobs", path=provider_service.path + process_jobs_service.path)
 provider_job_service = Service(name="provider_job", path=provider_service.path + process_job_service.path)
 provider_results_service = Service(name="provider_results", path=provider_service.path + process_results_service.path)
@@ -2794,6 +2795,10 @@ class ProcessEndpoint(LocalProcessPath):
 class ProcessPackageEndpoint(LocalProcessPath):
     header = RequestHeaders()
     querystring = LocalProcessQuery()
+
+
+class ProviderProcessPackageEndpoint(ProviderProcessPath, ProcessPackageEndpoint):
+    pass
 
 
 class ProcessPayloadEndpoint(LocalProcessPath):
@@ -6633,6 +6638,10 @@ get_provider_process_responses = {
     "405": MethodNotAllowedErrorResponseSchema(),
     "500": InternalServerErrorResponseSchema(),
 }
+get_provider_process_package_responses = copy(get_process_package_responses)
+get_provider_process_package_responses.update({
+    "403": ForbiddenProviderAccessResponseSchema(),
+})
 post_provider_responses = {
     "201": CreatedPostProvider(description="success"),
     "400": ExtendedMappingSchema(description=OWSMissingParameterValue.description),

--- a/weaver/wps_restapi/swagger_definitions.py
+++ b/weaver/wps_restapi/swagger_definitions.py
@@ -4844,14 +4844,6 @@ class Unit(ExtendedMappingSchema):
     unit = CWL(description=f"Execution unit definition as CWL package specification. {CWL_DOC_MESSAGE}")
 
 
-class UndeploymentResult(ExtendedMappingSchema):
-    id = AnyIdentifier()
-
-
-class DeploymentResult(ExtendedMappingSchema):
-    processSummary = ProcessSummary()
-
-
 class ProviderSummaryList(ExtendedSequenceSchema):
     provider_service = ProviderSummarySchema()
 


### PR DESCRIPTION
## Changes

- Add ``GET /providers/{provider_id}/processes/{process_id}/package`` endpoint that allows retrieval of the `CWL`
  `Application Package` definition generated for the specific `Provider`'s `Process` definition.
- Add `CLI` ``package`` operation to request the remote `Provider` or local `Process` `CWL` `Application Package`.
- Add `CLI` output reporting of performed HTTP requests details when using the ``--debug/-d`` option.
- Modify default behavior of ``visibility`` field (under ``processDescription`` or ``processDescription.process``)
  to employ the expected functionality by native `OGC API - Processes` clients that do not support this option
  (i.e.: ``public`` by default), and to align resolution strategy with deployments by direct `CWL` payload which do not
  include this feature either. A `Process` deployment that desires to employ this feature (``visibility: private``) will
  have to provide the value explicitly, or update the deployed `Process` definition afterwards with the relevant
  ``PUT`` request. Since ``public`` will now be used by default, the `CLI` will not automatically inject the value
  in the payload anymore when omitted.

## Fixes

- Fix ``links`` listing duplicated in response from `Process` deployment.
  Links will only be listed within the returned ``processSummary`` to respect the `OGC API - Processes` schema.
- Fix `CLI` not removing embedded ``links`` in ``processSummary`` from ``deploy`` operation response
  when ``-nL``/``--no-links`` option is specified.