### PR TITLE
[wip] utility CLI to build CWL directly from notebook

### DIFF
--- a/requirements-cli.txt
+++ b/requirements-cli.txt
@@ -1,0 +1,6 @@
+-r requirements.txt
+# following for building utilities in the CLI
+ipython2cwl
+jupyter-repo2docker
+# add missing dependencies that are incorrectly resolved
+ipython_genutils

--- a/tests/functional/test_ncml2stac.ipynb
+++ b/tests/functional/test_ncml2stac.ipynb
@@ -1,0 +1,541 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "source": [
+    "# NCML metadata conversion to STAC Item using CWL Application Package annotation\n",
+    "\n",
+    "This notebook should be compiled into a standalone *CWL* definition using the following command:\n",
+    "\n",
+    "```shell\n",
+    "jupyter-repo2cwl test_ncml2stac.ipynb -o test_ncml2stac.cwl\n",
+    "```\n",
+    "\n",
+    "It can then be deployed in *Weaver* using the CLI:\n",
+    "\n",
+    "```shell\n",
+    "weaver deploy -u http://example.com/weaver --cwl test_ncml2stac.cwl\n",
+    "```"
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "26df8dd0cc0f3ddb"
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Define the CWL Inputs for this Notebook\n",
+    "\n",
+    "A real notebook does not even need to import `ipython2cwl` types!\n",
+    "It is sufficient to use only the string typing annotation to avoid import errors when this dependency is not installed!"
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "96140609ef555d44"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "outputs": [],
+   "source": [
+    "from typing import TYPE_CHECKING\n",
+    "\n",
+    "if TYPE_CHECKING:\n",
+    "    from ipython2cwl.iotypes import CWLFilePathInput, CWLFilePathOutput\n",
+    "\n",
+    "input_ncml: \"CWLFilePathInput\" = \"https://raw.githubusercontent.com/crim-ca/stac-populator/ce268cdcde6030b3813f858ab1342b7cafa463e3/tests/data/o3_Amon_GFDL-ESM4_historical_r1i1p1f1_gr1_185001-194912.xml\""
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-09-27T22:12:55.559741225Z",
+     "start_time": "2023-09-27T22:12:55.348033103Z"
+    }
+   },
+   "id": "61f43c81dc3aa6c2"
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Define the Core functionality of this Notebook\n",
+    "\n",
+    "This code assumes that the following reference and all its dependencies are installed:\n",
+    "\n",
+    "https://github.com/crim-ca/stac-populator/commit/ce268cdcde6030b3813f858ab1342b7cafa463e3"
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "5c58db2f3f6ab21b"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cloning into '/home/francis/.esdoc/pyessv-archive'...\r\n",
+      "remote: Enumerating objects: 63068, done.\u001B[K\r\n",
+      "remote: Counting objects: 100% (1557/1557), done.\u001B[K6/1557)\u001B[K\r\n",
+      "remote: Compressing objects: 100% (476/476), done.\u001B[K\r\n",
+      "remote: Total 63068 (delta 1258), reused 1327 (delta 1070), pack-reused 61511\u001B[Ks:  27% (17029/63068), 1.33 MiB | 1.31 MiB/sReceiving objects:  29% (18290/63068), 1.33 MiB | 1.31 MiB/sReceiving objects:  33% (20813/63068), 1.33 MiB | 1.31 MiB/sReceiving objects:  36% (22705/63068), 1.33 MiB | 1.31 MiB/sReceiving objects:  39% (24597/63068), 1.33 MiB | 1.31 MiB/sReceiving objects:  42% (26489/63068), 2.12 MiB | 1.38 MiB/sReceiving objects:  48% (30273/63068), 2.12 MiB | 1.38 MiB/sReceiving objects:  52% (32796/63068), 2.12 MiB | 1.38 MiB/sReceiving objects:  57% (35949/63068), 2.12 MiB | 1.38 MiB/sReceiving objects:  61% (38912/63068), 2.12 MiB | 1.38 MiB/sReceiving objects:  64% (40364/63068), 2.96 MiB | 1.45 MiB/sReceiving objects:  71% (44779/63068), 2.96 MiB | 1.45 MiB/sReceiving objects:  78% (49194/63068), 2.96 MiB | 1.45 MiB/sReceiving objects:  80% (50455/63068), 2.96 MiB | 1.45 MiB/sReceiving objects:  82% (51716/63068), 2.96 MiB | 1.45 MiB/sReceiving objects:  84% (52978/63068), 4.29 MiB | 1.68 MiB/sReceiving objects:  88% (55500/63068), 4.29 MiB | 1.68 MiB/sReceiving objects:  93% (58654/63068), 4.29 MiB | 1.68 MiB/sReceiving objects:  98% (61807/63068), 4.29 MiB | 1.68 MiB/s\r\n",
+      "Receiving objects: 100% (63068/63068), 6.06 MiB | 2.02 MiB/s, done.\r\n",
+      "Resolving deltas: 100% (60270/60270), done.\r\n",
+      "\r\n",
+      "Local identity for pyessv-archive set to \"Francis Charette Migneault <francis.charette.migneault@gmail.com>\"\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "!rm -fr ~/.esdoc/pyessv-archive\n",
+    "!mkdir -p ~/.esdoc/\n",
+    "!git clone https://github.com/ES-DOC/pyessv-archive ~/.esdoc/pyessv-archive"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-09-27T22:13:02.695354212Z",
+     "start_time": "2023-09-27T22:12:55.413642180Z"
+    }
+   },
+   "id": "f10d85e12b47da43"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2023-09-27 22:13:03.244828 [INFO] :: PYESSV :: Loading vocabularies from /home/francis/.esdoc/pyessv-archive ... please wait\n",
+      "2023-09-27 22:13:03.656407 [INFO] :: PYESSV :: Loading vocabularies from /home/francis/.esdoc/pyessv-archive ... please wait\n",
+      "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n",
+      "<ncml:netcdf xmlns:ncml=\"http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2\" location=\"https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/testdata/xclim/cmip6/sic_SImon_CCCma-CanESM5_ssp245_r13i1p2f1_2020.nc\">\n",
+      "  <ncml:attribute name=\"CCCma_model_hash\" value=\"fc4bb7db954c862d023b546e19aec6c588bc0552\" />\n",
+      "  <ncml:attribute name=\"CCCma_parent_runid\" value=\"p2-his13\" />\n",
+      "  <ncml:attribute name=\"CCCma_pycmor_hash\" value=\"26c970628162d607fffd14254956ebc6dd3b6f49\" />\n",
+      "  <ncml:attribute name=\"CCCma_runid\" value=\"p2-s4513\" />\n",
+      "  <ncml:attribute name=\"Conventions\" value=\"CF-1.7 CMIP-6.2\" />\n",
+      "  <ncml:attribute name=\"YMDH_branch_time_in_child\" value=\"2015:01:01:00\" />\n",
+      "  <ncml:attribute name=\"YMDH_branch_time_in_parent\" value=\"2015:01:01:00\" />\n",
+      "  <ncml:attribute name=\"activity_id\" value=\"ScenarioMIP\" />\n",
+      "  <ncml:attribute name=\"branch_method\" value=\"Spin-up documentation\" />\n",
+      "  <ncml:attribute name=\"branch_time_in_child\" type=\"double\" value=\"60225.0\" />\n",
+      "  <ncml:attribute name=\"branch_time_in_parent\" type=\"double\" value=\"60225.0\" />\n",
+      "  <ncml:attribute name=\"contact\" value=\"ec.cccma.info-info.ccmac.ec@canada.ca\" />\n",
+      "  <ncml:attribute name=\"creation_date\" value=\"2019-09-25T23:01:33Z\" />\n",
+      "  <ncml:attribute name=\"data_specs_version\" value=\"01.00.30\" />\n",
+      "  <ncml:attribute name=\"experiment\" value=\"update of RCP4.5 based on SSP2\" />\n",
+      "  <ncml:attribute name=\"experiment_id\" value=\"ssp245\" />\n",
+      "  <ncml:attribute name=\"external_variables\" value=\"areacello\" />\n",
+      "  <ncml:attribute name=\"forcing_index\" type=\"int\" value=\"1\" />\n",
+      "  <ncml:attribute name=\"frequency\" value=\"mon\" />\n",
+      "  <ncml:attribute name=\"further_info_url\" value=\"https://furtherinfo.es-doc.org/CMIP6.CCCma.CanESM5.ssp245.none.r13i1p2f1\" />\n",
+      "  <ncml:attribute name=\"grid\" value=\"ORCA1 tripolar grid, 1 deg with refinement to 1/3 deg within 20 degrees of the equator; 361 x 290 longitude/latitude; 45 vertical levels; top grid cell 0-6.19 m\" />\n",
+      "  <ncml:attribute name=\"grid_label\" value=\"gn\" />\n",
+      "  <ncml:attribute name=\"history\" value=\"2019-09-25T23:01:33Z ;rewrote data to be consistent with ScenarioMIP for variable siconc found in table SImon.\" />\n",
+      "  <ncml:attribute name=\"initialization_index\" type=\"int\" value=\"1\" />\n",
+      "  <ncml:attribute name=\"institution\" value=\"Canadian Centre for Climate Modelling and Analysis, Environment and Climate Change Canada, Victoria, BC V8P 5C2, Canada\" />\n",
+      "  <ncml:attribute name=\"institution_id\" value=\"CCCma\" />\n",
+      "  <ncml:attribute name=\"mip_era\" value=\"CMIP6\" />\n",
+      "  <ncml:attribute name=\"nominal_resolution\" value=\"100 km\" />\n",
+      "  <ncml:attribute name=\"parent_activity_id\" value=\"CMIP\" />\n",
+      "  <ncml:attribute name=\"parent_experiment_id\" value=\"historical\" />\n",
+      "  <ncml:attribute name=\"parent_mip_era\" value=\"CMIP6\" />\n",
+      "  <ncml:attribute name=\"parent_source_id\" value=\"CanESM5\" />\n",
+      "  <ncml:attribute name=\"parent_time_units\" value=\"days since 1850-01-01 0:0:0.0\" />\n",
+      "  <ncml:attribute name=\"parent_variant_label\" value=\"r13i1p2f1\" />\n",
+      "  <ncml:attribute name=\"physics_index\" type=\"int\" value=\"2\" />\n",
+      "  <ncml:attribute name=\"product\" value=\"model-output\" />\n",
+      "  <ncml:attribute name=\"realization_index\" type=\"int\" value=\"13\" />\n",
+      "  <ncml:attribute name=\"realm\" value=\"seaIce\" />\n",
+      "  <ncml:attribute name=\"references\" value=\"Geophysical Model Development Special issue on CanESM5 (https://www.geosci-model-dev.net/special_issue989.html)\" />\n",
+      "  <ncml:attribute name=\"source\" value=\"CanESM5 (2019): &#xA;aerosol: interactive&#xA;atmos: CanAM5 (T63L49 native atmosphere, T63 Linear Gaussian Grid; 128 x 64 longitude/latitude; 49 levels; top level 1 hPa)&#xA;atmosChem: specified oxidants for aerosols&#xA;land: CLASS3.6/CTEM1.2&#xA;landIce: specified ice sheets&#xA;ocean: NEMO3.4.1 (ORCA1 tripolar grid, 1 deg with refinement to 1/3 deg within 20 degrees of the equator; 361 x 290 longitude/latitude; 45 vertical levels; top grid cell 0-6.19 m)&#xA;ocnBgchem: Canadian Model of Ocean Carbon (CMOC); NPZD ecosystem with OMIP prescribed carbonate chemistry&#xA;seaIce: LIM2\" />\n",
+      "  <ncml:attribute name=\"source_id\" value=\"CanESM5\" />\n",
+      "  <ncml:attribute name=\"source_type\" value=\"AOGCM\" />\n",
+      "  <ncml:attribute name=\"sub_experiment\" value=\"none\" />\n",
+      "  <ncml:attribute name=\"sub_experiment_id\" value=\"none\" />\n",
+      "  <ncml:attribute name=\"table_id\" value=\"SImon\" />\n",
+      "  <ncml:attribute name=\"table_info\" value=\"Creation Date:(09 May 2019) MD5:38ea1fbdf3f31659e83c719fb4c48428\" />\n",
+      "  <ncml:attribute name=\"title\" value=\"CanESM5 output prepared for CMIP6\" />\n",
+      "  <ncml:attribute name=\"variable_id\" value=\"siconc\" />\n",
+      "  <ncml:attribute name=\"variant_label\" value=\"r13i1p2f1\" />\n",
+      "  <ncml:attribute name=\"version\" value=\"v20190429\" />\n",
+      "  <ncml:attribute name=\"license\" value=\"CMIP6 model data produced by The Government of Canada (Canadian Centre for Climate Modelling and Analysis, Environment and Climate Change Canada) is licensed under a Creative Commons Attribution ShareAlike 4.0 International License (https://creativecommons.org/licenses). Consult https://pcmdi.llnl.gov/CMIP6/TermsOfUse for terms of use governing CMIP6 output, including citation requirements and proper acknowledgment. Further information about this data, including some limitations, can be found via the further_info_url (recorded as a global attribute in this file) and at https:///pcmdi.llnl.gov/. The data producers and data providers make no warranty, either express or implied, including, but not limited to, warranties of merchantability and fitness for a particular purpose. All liabilities arising from the supply of the information (including any liability arising in negligence) are excluded to the fullest extent permitted by law.\" />\n",
+      "  <ncml:attribute name=\"cmor_version\" value=\"3.5.0\" />\n",
+      "  <ncml:attribute name=\"tracking_id\" value=\"hdl:21.14100/9e4f804b-c161-44fa-acd1-c2e94e220c95\" />\n",
+      "  <ncml:attribute name=\"DODS.strlen\" type=\"int\" value=\"7\" />\n",
+      "  <ncml:attribute name=\"DODS.dimName\" value=\"strlen\" />\n",
+      "  <ncml:attribute name=\"DODS_EXTRA.Unlimited_Dimension\" value=\"time\" />\n",
+      "  <ncml:attribute name=\"_CoordSysBuilder\" value=\"ucar.nc2.dataset.conv.CF1Convention\" />\n",
+      "  <ncml:dimension name=\"time\" length=\"12\" isUnlimited=\"true\" />\n",
+      "  <ncml:dimension name=\"bnds\" length=\"2\" />\n",
+      "  <ncml:dimension name=\"vertices\" length=\"4\" />\n",
+      "  <ncml:dimension name=\"maxStrlen64\" length=\"64\" />\n",
+      "  <ncml:dimension name=\"j\" length=\"291\" />\n",
+      "  <ncml:dimension name=\"i\" length=\"360\" />\n",
+      "  <group xmlns=\"http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2\" name=\"CFMetadata\">\n",
+      "    <attribute name=\"geospatial_lon_min\" value=\".0498\" type=\"float\" />\n",
+      "    <attribute name=\"geospatial_lat_min\" value=\"-78.3935\" type=\"float\" />\n",
+      "    <attribute name=\"geospatial_lon_max\" value=\"359.99493\" type=\"float\" />\n",
+      "    <attribute name=\"geospatial_lat_max\" value=\"89.74177\" type=\"float\" />\n",
+      "    <attribute name=\"geospatial_lon_units\" value=\"degrees_east\" />\n",
+      "    <attribute name=\"geospatial_lat_units\" value=\"degrees_north\" />\n",
+      "    <attribute name=\"geospatial_lon_resolution\" value=\"0.0034359351726440477\" />\n",
+      "    <attribute name=\"geospatial_lat_resolution\" value=\"0.0016049720708009724\" />\n",
+      "    <attribute name=\"time_coverage_start\" value=\"2019-12-06T12:00:00Z\" />\n",
+      "    <attribute name=\"time_coverage_end\" value=\"2020-11-04T12:00:00Z\" />\n",
+      "    <attribute name=\"time_coverage_units\" value=\"seconds\" />\n",
+      "    <attribute name=\"time_coverage_resolution\" value=\"2623418.0\" />\n",
+      "    <attribute name=\"time_coverage_duration\" value=\"P0Y0M334DT0H0M0.000S\" />\n",
+      "  </group>\n",
+      "  <group xmlns=\"http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2\" name=\"NCISOMetadata\">\n",
+      "    <attribute name=\"metadata_creation\" value=\"2023-09-22\" />\n",
+      "    <attribute name=\"nciso_version\" value=\"2.2.3\" />\n",
+      "  </group>\n",
+      "  <group xmlns=\"http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2\" name=\"THREDDSMetadata\">\n",
+      "    <attribute name=\"id\" value=\"birdhouse/testdata/xclim/cmip6/sic_SImon_CCCma-CanESM5_ssp245_r13i1p2f1_2020.nc\" />\n",
+      "    <attribute name=\"full_name\" value=\"cmip6/sic_SImon_CCCma-CanESM5_ssp245_r13i1p2f1_2020.nc\" />\n",
+      "    <group name=\"services\">\n",
+      "      <attribute name=\"httpserver_service\" value=\"https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/fileServer/birdhouse/testdata/xclim/cmip6/sic_SImon_CCCma-CanESM5_ssp245_r13i1p2f1_2020.nc\" />\n",
+      "      <attribute name=\"opendap_service\" value=\"https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/testdata/xclim/cmip6/sic_SImon_CCCma-CanESM5_ssp245_r13i1p2f1_2020.nc\" />\n",
+      "      <attribute name=\"wcs_service\" value=\"https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/wcs/birdhouse/testdata/xclim/cmip6/sic_SImon_CCCma-CanESM5_ssp245_r13i1p2f1_2020.nc?service=WCS&amp;version=1.0.0&amp;request=GetCapabilities\" />\n",
+      "      <attribute name=\"wms_service\" value=\"https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/wms/birdhouse/testdata/xclim/cmip6/sic_SImon_CCCma-CanESM5_ssp245_r13i1p2f1_2020.nc?service=WMS&amp;version=1.3.0&amp;request=GetCapabilities\" />\n",
+      "      <attribute name=\"nccs_service\" value=\"https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/ncss/birdhouse/testdata/xclim/cmip6/sic_SImon_CCCma-CanESM5_ssp245_r13i1p2f1_2020.nc/dataset.html\" />\n",
+      "    </group>\n",
+      "    <group name=\"dates\">\n",
+      "      <attribute name=\"date\" value=\"2021-02-15T14:37:21.508Z\" type=\"modified\" />\n",
+      "    </group>\n",
+      "  </group>\n",
+      "  <ncml:variable name=\"time_bnds\" shape=\"time bnds\" type=\"double\">\n",
+      "    <ncml:attribute name=\"_FillValue\" type=\"double\" value=\"NaN\" />\n",
+      "    <ncml:attribute name=\"_ChunkSizes\" type=\"int\" value=\"1 2\" />\n",
+      "    <ncml:attribute name=\"coordinates\" value=\"type\" />\n",
+      "  </ncml:variable>\n",
+      "  <ncml:variable name=\"vertices_latitude\" shape=\"j i vertices\" type=\"double\">\n",
+      "    <ncml:attribute name=\"_FillValue\" type=\"double\" value=\"NaN\" />\n",
+      "    <ncml:attribute name=\"_ChunkSizes\" type=\"int\" value=\"291 360 4\" />\n",
+      "    <ncml:attribute name=\"coordinates\" value=\"longitude latitude type\" />\n",
+      "  </ncml:variable>\n",
+      "  <ncml:variable name=\"vertices_longitude\" shape=\"j i vertices\" type=\"double\">\n",
+      "    <ncml:attribute name=\"_FillValue\" type=\"double\" value=\"NaN\" />\n",
+      "    <ncml:attribute name=\"_ChunkSizes\" type=\"int\" value=\"291 360 4\" />\n",
+      "    <ncml:attribute name=\"coordinates\" value=\"longitude latitude type\" />\n",
+      "  </ncml:variable>\n",
+      "  <ncml:variable name=\"siconc\" shape=\"time j i\" type=\"float\">\n",
+      "    <ncml:attribute name=\"_FillValue\" type=\"float\" value=\"NaN\" />\n",
+      "    <ncml:attribute name=\"standard_name\" value=\"sea_ice_area_fraction\" />\n",
+      "    <ncml:attribute name=\"long_name\" value=\"Sea-Ice Area Percentage (Ocean Grid)\" />\n",
+      "    <ncml:attribute name=\"comment\" value=\"Percentage of grid cell covered by sea ice\" />\n",
+      "    <ncml:attribute name=\"units\" value=\"%\" />\n",
+      "    <ncml:attribute name=\"original_name\" value=\"soicecov\" />\n",
+      "    <ncml:attribute name=\"history\" value=\"mltby100_ocn 2019-09-25T23:01:33Z altered by CMOR: Treated scalar dimension: 'type'.\" />\n",
+      "    <ncml:attribute name=\"cell_methods\" value=\"area: mean where sea time: mean\" />\n",
+      "    <ncml:attribute name=\"cell_measures\" value=\"area: areacello\" />\n",
+      "    <ncml:attribute name=\"_ChunkSizes\" type=\"int\" value=\"1 291 360\" />\n",
+      "    <ncml:attribute name=\"coordinates\" value=\"type latitude longitude\" />\n",
+      "  </ncml:variable>\n",
+      "  <ncml:variable name=\"areacello\" shape=\"j i\" type=\"float\">\n",
+      "    <ncml:attribute name=\"_FillValue\" type=\"float\" value=\"1.0E20\" />\n",
+      "    <ncml:attribute name=\"standard_name\" value=\"cell_area\" />\n",
+      "    <ncml:attribute name=\"long_name\" value=\"Grid-Cell Area for Ocean Variables\" />\n",
+      "    <ncml:attribute name=\"comment\" value=\"Horizontal area of ocean grid cells\" />\n",
+      "    <ncml:attribute name=\"units\" value=\"m2\" />\n",
+      "    <ncml:attribute name=\"original_name\" value=\"areacello\" />\n",
+      "    <ncml:attribute name=\"cell_methods\" value=\"area: sum\" />\n",
+      "    <ncml:attribute name=\"_ChunkSizes\" type=\"int\" value=\"291 360\" />\n",
+      "    <ncml:attribute name=\"coordinates\" value=\"latitude longitude\" />\n",
+      "    <ncml:attribute name=\"missing_value\" type=\"float\" value=\"1.0E20\" />\n",
+      "  </ncml:variable>\n",
+      "  <ncml:variable name=\"time\" shape=\"time\" type=\"double\">\n",
+      "    <ncml:attribute name=\"_FillValue\" type=\"double\" value=\"NaN\" />\n",
+      "    <ncml:attribute name=\"bounds\" value=\"time_bnds\" />\n",
+      "    <ncml:attribute name=\"axis\" value=\"T\" />\n",
+      "    <ncml:attribute name=\"long_name\" value=\"time\" />\n",
+      "    <ncml:attribute name=\"standard_name\" value=\"time\" />\n",
+      "    <ncml:attribute name=\"_ChunkSizes\" type=\"int\" value=\"512\" />\n",
+      "    <ncml:attribute name=\"units\" value=\"days since 1850-01-01\" />\n",
+      "    <ncml:attribute name=\"calendar\" value=\"365_day\" />\n",
+      "    <ncml:attribute name=\"_CoordinateAxisType\" value=\"Time\" />\n",
+      "  </ncml:variable>\n",
+      "  <ncml:variable name=\"j\" shape=\"j\" type=\"int\">\n",
+      "    <ncml:attribute name=\"units\" value=\"1\" />\n",
+      "    <ncml:attribute name=\"long_name\" value=\"cell index along second dimension\" />\n",
+      "  </ncml:variable>\n",
+      "  <ncml:variable name=\"i\" shape=\"i\" type=\"int\">\n",
+      "    <ncml:attribute name=\"units\" value=\"1\" />\n",
+      "    <ncml:attribute name=\"long_name\" value=\"cell index along first dimension\" />\n",
+      "  </ncml:variable>\n",
+      "  <ncml:variable name=\"type\" shape=\"maxStrlen64\" type=\"char\">\n",
+      "    <ncml:attribute name=\"long_name\" value=\"Sea Ice area type\" />\n",
+      "    <ncml:attribute name=\"standard_name\" value=\"area_type\" />\n",
+      "  </ncml:variable>\n",
+      "  <ncml:variable name=\"latitude\" shape=\"j i\" type=\"double\">\n",
+      "    <ncml:attribute name=\"_FillValue\" type=\"double\" value=\"1.0E20\" />\n",
+      "    <ncml:attribute name=\"standard_name\" value=\"latitude\" />\n",
+      "    <ncml:attribute name=\"long_name\" value=\"latitude\" />\n",
+      "    <ncml:attribute name=\"units\" value=\"degrees_north\" />\n",
+      "    <ncml:attribute name=\"bounds\" value=\"vertices_latitude\" />\n",
+      "    <ncml:attribute name=\"_ChunkSizes\" type=\"int\" value=\"291 360\" />\n",
+      "    <ncml:attribute name=\"missing_value\" type=\"double\" value=\"1.0E20\" />\n",
+      "    <ncml:attribute name=\"_CoordinateAxisType\" value=\"Lat\" />\n",
+      "  </ncml:variable>\n",
+      "  <ncml:variable name=\"longitude\" shape=\"j i\" type=\"double\">\n",
+      "    <ncml:attribute name=\"_FillValue\" type=\"double\" value=\"1.0E20\" />\n",
+      "    <ncml:attribute name=\"standard_name\" value=\"longitude\" />\n",
+      "    <ncml:attribute name=\"long_name\" value=\"longitude\" />\n",
+      "    <ncml:attribute name=\"units\" value=\"degrees_east\" />\n",
+      "    <ncml:attribute name=\"bounds\" value=\"vertices_longitude\" />\n",
+      "    <ncml:attribute name=\"_ChunkSizes\" type=\"int\" value=\"291 360\" />\n",
+      "    <ncml:attribute name=\"missing_value\" type=\"double\" value=\"1.0E20\" />\n",
+      "    <ncml:attribute name=\"_CoordinateAxisType\" value=\"Lon\" />\n",
+      "  </ncml:variable>\n",
+      "</ncml:netcdf>\n"
+     ]
+    }
+   ],
+   "source": [
+    "import json\n",
+    "import pystac\n",
+    "from pystac.extensions import datacube\n",
+    "import requests\n",
+    "import tempfile\n",
+    "import xncml\n",
+    "from shapely.geometry.polygon import Polygon\n",
+    "from dateutil.parser import parse as dt_parse\n",
+    "\n",
+    "import pyessv\n",
+    "pyessv.init()\n",
+    "\n",
+    "from STACpopulator.extensions import cmip6\n",
+    "\n",
+    "# retrieve the file contents\n",
+    "if not (input_ncml.startswith(\"/\") or input_ncml.startswith(\"file:///\")):\n",
+    "    resp = requests.get(input_ncml, headers={\"Accept\": \"text/xml, application/xml\"}, timeout=5)\n",
+    "    if not resp.status_code == 200 and resp.text.startswith(\"<?xml\"):\n",
+    "        raise ValueError(f\"Could not retrieve NCML XML file contents from [{input_ncml}]. Error: [{resp.status_code}]: {resp.text!s}\")\n",
+    "    with tempfile.NamedTemporaryFile(mode=\"w\", encoding=\"utf-8\", delete=False) as tmp_file:\n",
+    "        tmp_file.write(resp.text)\n",
+    "        input_ncml = tmp_file.name\n",
+    "\n",
+    "# for debugging purposes, display the contents:\n",
+    "with open(input_ncml, mode=\"r\", encoding=\"utf-8\") as input_ncml_file:\n",
+    "    print(input_ncml_file.read())"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-09-27T22:13:04.191448522Z",
+     "start_time": "2023-09-27T22:13:02.465029823Z"
+    }
+   },
+   "id": "4fc2f66493dc56c5"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/francis/dev/conda/envs/weaver/lib/python3.10/site-packages/xncml/core.py:482: UserWarning: Could not cast date:\n",
+      "'modified' is not a valid DataType\n",
+      "  warn(f\"Could not cast {attr['@name']}:\\n{exc}\")\n"
+     ]
+    }
+   ],
+   "source": [
+    "ds = xncml.Dataset(input_ncml)\n",
+    "attrs = ds.to_cf_dict()\n",
+    "cfmeta = attrs[\"groups\"][\"CFMetadata\"][\"attributes\"]\n",
+    "bbox = [\n",
+    "    cfmeta[\"geospatial_lon_min\"][0],\n",
+    "    cfmeta[\"geospatial_lon_max\"][0],\n",
+    "    cfmeta[\"geospatial_lat_min\"][0],\n",
+    "    cfmeta[\"geospatial_lat_max\"][0],\n",
+    "]\n",
+    "geom = Polygon.from_bounds(*bbox)\n",
+    "\n",
+    "assets = {\n",
+    "    svc.rsplit(\"_service\", 1)[0]: pystac.Asset(href=svc_link)\n",
+    "    for svc, svc_link in\n",
+    "    attrs[\"groups\"][\"THREDDSMetadata\"][\"groups\"][\"services\"][\"attributes\"].items()\n",
+    "}\n",
+    "\n",
+    "item = pystac.Item(\n",
+    "    id=\"test\",\n",
+    "    start_datetime=dt_parse(cfmeta[\"time_coverage_start\"]),\n",
+    "    end_datetime=dt_parse(cfmeta[\"time_coverage_end\"]),\n",
+    "    datetime=None,  # uses start/end instead\n",
+    "    bbox=bbox,\n",
+    "    geometry=geom.__geo_interface__,  # GeoJSON\n",
+    "    properties={},  # filled by extension after\n",
+    "    assets=assets,\n",
+    ")\n",
+    "\n",
+    "dc_dims = {}\n",
+    "dim_spatial_axis = {\n",
+    "    \"i\": \"x\",\n",
+    "    \"j\": \"y\",\n",
+    "    \"k\": \"z\",\n",
+    "    \"x\": \"x\",\n",
+    "    \"y\": \"y\",\n",
+    "    \"z\": \"z\",\n",
+    "}\n",
+    "for dim, val in attrs[\"dimensions\"].items():\n",
+    "    dim_props = {\n",
+    "        \"type\": (\n",
+    "            datacube.DimensionType.SPATIAL if dim in list(dim_spatial_axis) else\n",
+    "            datacube.DimensionType.TEMPORAL if dim in [\"date\", \"time\", \"date-time\", \"datetime\"] else\n",
+    "            \"other\"\n",
+    "        ),\n",
+    "        \"length\": val\n",
+    "    }\n",
+    "    if dim_props[\"type\"] == datacube.DimensionType.SPATIAL.value:\n",
+    "        dim_props[\"axis\"] = dim_spatial_axis[dim]\n",
+    "    dc_dims[dim] = datacube.Dimension(dim_props)\n",
+    "\n",
+    "dc_vars = {}\n",
+    "for var, props in attrs[\"variables\"].items():\n",
+    "    var_dims = props[\"shape\"]\n",
+    "    var_props = {\n",
+    "        \"type\": (\n",
+    "            datacube.VariableType.DATA\n",
+    "            if all(_dim in dc_dims for _dim in var_dims)\n",
+    "            else datacube.VariableType.AUXILIARY\n",
+    "        ),\n",
+    "        \"dimensions\": var_dims,\n",
+    "    }\n",
+    "    var_unit = props.get(\"attributes\", {}).get(\"units\")\n",
+    "    if var_unit:\n",
+    "        var_props[\"unit\"] = var_unit\n",
+    "    dc_vars[var] = datacube.Variable(var_props)\n",
+    "\n",
+    "datacube_ext = datacube.DatacubeExtension.ext(item, add_if_missing=True)\n",
+    "datacube_ext.apply(dimensions=dc_dims, variables=dc_vars)\n",
+    "\n",
+    "cmip6_attrs = attrs[\"attributes\"]\n",
+    "cmip6_ext = cmip6.CMIP6Extension.ext(item, add_if_missing=True)\n",
+    "cmip6_ext.apply(cmip6_attrs)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-09-27T22:13:04.297953077Z",
+     "start_time": "2023-09-27T22:13:04.203138258Z"
+    }
+   },
+   "id": "299946ccd58e2efc"
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Display the result for validation"
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "4ffa19f1ab7063b8"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "{'type': 'Feature',\n 'stac_version': '1.0.0',\n 'id': 'test',\n 'properties': {'start_datetime': None,\n  'end_datetime': None,\n  'cube:dimensions': {'time': {'type': <DimensionType.TEMPORAL: 'temporal'>,\n    'length': 12},\n   'bnds': {'type': 'other', 'length': 2},\n   'vertices': {'type': 'other', 'length': 4},\n   'maxStrlen64': {'type': 'other', 'length': 64},\n   'j': {'type': <DimensionType.SPATIAL: 'spatial'>,\n    'length': 291,\n    'axis': 'y'},\n   'i': {'type': <DimensionType.SPATIAL: 'spatial'>,\n    'length': 360,\n    'axis': 'x'}},\n  'cube:variables': {'time': {'type': <VariableType.DATA: 'data'>,\n    'dimensions': ['time'],\n    'unit': 'days since 1850-01-01'},\n   'j': {'type': <VariableType.DATA: 'data'>,\n    'dimensions': ['j'],\n    'unit': '1'},\n   'i': {'type': <VariableType.DATA: 'data'>,\n    'dimensions': ['i'],\n    'unit': '1'},\n   'time_bnds': {'type': <VariableType.DATA: 'data'>,\n    'dimensions': ['time', 'bnds']},\n   'vertices_latitude': {'type': <VariableType.DATA: 'data'>,\n    'dimensions': ['j', 'i', 'vertices']},\n   'vertices_longitude': {'type': <VariableType.DATA: 'data'>,\n    'dimensions': ['j', 'i', 'vertices']},\n   'siconc': {'type': <VariableType.DATA: 'data'>,\n    'dimensions': ['time', 'j', 'i'],\n    'unit': '%'},\n   'areacello': {'type': <VariableType.DATA: 'data'>,\n    'dimensions': ['j', 'i'],\n    'unit': 'm2'},\n   'type': {'type': <VariableType.DATA: 'data'>,\n    'dimensions': ['maxStrlen64']},\n   'latitude': {'type': <VariableType.DATA: 'data'>,\n    'dimensions': ['j', 'i'],\n    'unit': 'degrees_north'},\n   'longitude': {'type': <VariableType.DATA: 'data'>,\n    'dimensions': ['j', 'i'],\n    'unit': 'degrees_east'}},\n  'datetime': None,\n  'Conventions': 'CF-1.7 CMIP-6.2',\n  'activity_id': 'ScenarioMIP',\n  'creation_date': datetime.datetime(2019, 9, 25, 23, 1, 33, tzinfo=TzInfo(UTC)),\n  'data_specs_version': '01.00.30',\n  'experiment': 'update of RCP4.5 based on SSP2',\n  'experiment_id': 'ssp245',\n  'frequency': 'mon',\n  'further_info_url': Url('https://furtherinfo.es-doc.org/CMIP6.CCCma.CanESM5.ssp245.none.r13i1p2f1'),\n  'grid_label': 'gn',\n  'institution': 'Canadian Centre for Climate Modelling and Analysis, Environment and Climate Change Canada, Victoria, BC V8P 5C2, Canada',\n  'institution_id': 'CCCma',\n  'nominal_resolution': '100 km',\n  'realm': ['seaIce'],\n  'source': 'CanESM5 (2019): \\naerosol: interactive\\natmos: CanAM5 (T63L49 native atmosphere, T63 Linear Gaussian Grid; 128 x 64 longitude/latitude; 49 levels; top level 1 hPa)\\natmosChem: specified oxidants for aerosols\\nland: CLASS3.6/CTEM1.2\\nlandIce: specified ice sheets\\nocean: NEMO3.4.1 (ORCA1 tripolar grid, 1 deg with refinement to 1/3 deg within 20 degrees of the equator; 361 x 290 longitude/latitude; 45 vertical levels; top grid cell 0-6.19 m)\\nocnBgchem: Canadian Model of Ocean Carbon (CMOC); NPZD ecosystem with OMIP prescribed carbonate chemistry\\nseaIce: LIM2',\n  'source_id': 'CanESM5',\n  'source_type': ['AOGCM'],\n  'sub_experiment': 'none',\n  'sub_experiment_id': 'none',\n  'table_id': 'SImon',\n  'variable_id': 'siconc',\n  'variant_label': 'r13i1p2f1',\n  'initialization_index': 1,\n  'physics_index': 2,\n  'realization_index': 13,\n  'forcing_index': 1,\n  'tracking_id': 'hdl:21.14100/9e4f804b-c161-44fa-acd1-c2e94e220c95',\n  'version': 'v20190429',\n  'product': 'model-output',\n  'license': 'CMIP6 model data produced by The Government of Canada (Canadian Centre for Climate Modelling and Analysis, Environment and Climate Change Canada) is licensed under a Creative Commons Attribution ShareAlike 4.0 International License (https://creativecommons.org/licenses). Consult https://pcmdi.llnl.gov/CMIP6/TermsOfUse for terms of use governing CMIP6 output, including citation requirements and proper acknowledgment. Further information about this data, including some limitations, can be found via the further_info_url (recorded as a global attribute in this file) and at https:///pcmdi.llnl.gov/. The data producers and data providers make no warranty, either express or implied, including, but not limited to, warranties of merchantability and fitness for a particular purpose. All liabilities arising from the supply of the information (including any liability arising in negligence) are excluded to the fullest extent permitted by law.',\n  'grid': 'ORCA1 tripolar grid, 1 deg with refinement to 1/3 deg within 20 degrees of the equator; 361 x 290 longitude/latitude; 45 vertical levels; top grid cell 0-6.19 m',\n  'mip_era': 'CMIP6'},\n 'geometry': {'type': 'Polygon',\n  'coordinates': (((0.049800001084804535, 359.99493408203125),\n    (0.049800001084804535, 89.74176788330078),\n    (-78.39350128173828, 89.74176788330078),\n    (-78.39350128173828, 359.99493408203125),\n    (0.049800001084804535, 359.99493408203125)),)},\n 'links': [],\n 'assets': {'httpserver': {'href': 'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/fileServer/birdhouse/testdata/xclim/cmip6/sic_SImon_CCCma-CanESM5_ssp245_r13i1p2f1_2020.nc'},\n  'opendap': {'href': 'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/testdata/xclim/cmip6/sic_SImon_CCCma-CanESM5_ssp245_r13i1p2f1_2020.nc'},\n  'wcs': {'href': 'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/wcs/birdhouse/testdata/xclim/cmip6/sic_SImon_CCCma-CanESM5_ssp245_r13i1p2f1_2020.nc?service=WCS&version=1.0.0&request=GetCapabilities'},\n  'wms': {'href': 'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/wms/birdhouse/testdata/xclim/cmip6/sic_SImon_CCCma-CanESM5_ssp245_r13i1p2f1_2020.nc?service=WMS&version=1.3.0&request=GetCapabilities'},\n  'nccs': {'href': 'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/ncss/birdhouse/testdata/xclim/cmip6/sic_SImon_CCCma-CanESM5_ssp245_r13i1p2f1_2020.nc/dataset.html'}},\n 'bbox': [0.0498, 359.99493, -78.3935, 89.74177],\n 'stac_extensions': ['https://stac-extensions.github.io/datacube/v2.0.0/schema.json',\n  'https://stac-extensions.github.io/cmip6/v1.0.0/schema.json']}"
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "stac_item = item.to_dict()\n",
+    "stac_item"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-09-27T22:13:04.353755221Z",
+     "start_time": "2023-09-27T22:13:04.294777698Z"
+    }
+   },
+   "id": "4eeb52c23edccb31"
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Define the CWL Outputs for this Notebook"
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "9035d51a814b74c3"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "outputs": [
+    {
+     "ename": "TypeError",
+     "evalue": "Object of type datetime is not JSON serializable",
+     "output_type": "error",
+     "traceback": [
+      "\u001B[0;31m---------------------------------------------------------------------------\u001B[0m",
+      "\u001B[0;31mTypeError\u001B[0m                                 Traceback (most recent call last)",
+      "Cell \u001B[0;32mIn[7], line 2\u001B[0m\n\u001B[1;32m      1\u001B[0m \u001B[38;5;28;01mwith\u001B[39;00m tempfile\u001B[38;5;241m.\u001B[39mNamedTemporaryFile(mode\u001B[38;5;241m=\u001B[39m\u001B[38;5;124m\"\u001B[39m\u001B[38;5;124mw\u001B[39m\u001B[38;5;124m\"\u001B[39m, encoding\u001B[38;5;241m=\u001B[39m\u001B[38;5;124m\"\u001B[39m\u001B[38;5;124mutf-8\u001B[39m\u001B[38;5;124m\"\u001B[39m, delete\u001B[38;5;241m=\u001B[39m\u001B[38;5;28;01mFalse\u001B[39;00m) \u001B[38;5;28;01mas\u001B[39;00m out_file:\n\u001B[0;32m----> 2\u001B[0m     \u001B[43mjson\u001B[49m\u001B[38;5;241;43m.\u001B[39;49m\u001B[43mdump\u001B[49m\u001B[43m(\u001B[49m\u001B[43mstac_item\u001B[49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[43mout_file\u001B[49m\u001B[43m)\u001B[49m\n\u001B[1;32m      4\u001B[0m output: \u001B[38;5;124m\"\u001B[39m\u001B[38;5;124mCWLFilePathOutput\u001B[39m\u001B[38;5;124m\"\u001B[39m \u001B[38;5;241m=\u001B[39m out_file\u001B[38;5;241m.\u001B[39mname\n",
+      "File \u001B[0;32m~/dev/conda/envs/weaver/lib/python3.10/json/__init__.py:179\u001B[0m, in \u001B[0;36mdump\u001B[0;34m(obj, fp, skipkeys, ensure_ascii, check_circular, allow_nan, cls, indent, separators, default, sort_keys, **kw)\u001B[0m\n\u001B[1;32m    173\u001B[0m     iterable \u001B[38;5;241m=\u001B[39m \u001B[38;5;28mcls\u001B[39m(skipkeys\u001B[38;5;241m=\u001B[39mskipkeys, ensure_ascii\u001B[38;5;241m=\u001B[39mensure_ascii,\n\u001B[1;32m    174\u001B[0m         check_circular\u001B[38;5;241m=\u001B[39mcheck_circular, allow_nan\u001B[38;5;241m=\u001B[39mallow_nan, indent\u001B[38;5;241m=\u001B[39mindent,\n\u001B[1;32m    175\u001B[0m         separators\u001B[38;5;241m=\u001B[39mseparators,\n\u001B[1;32m    176\u001B[0m         default\u001B[38;5;241m=\u001B[39mdefault, sort_keys\u001B[38;5;241m=\u001B[39msort_keys, \u001B[38;5;241m*\u001B[39m\u001B[38;5;241m*\u001B[39mkw)\u001B[38;5;241m.\u001B[39miterencode(obj)\n\u001B[1;32m    177\u001B[0m \u001B[38;5;66;03m# could accelerate with writelines in some versions of Python, at\u001B[39;00m\n\u001B[1;32m    178\u001B[0m \u001B[38;5;66;03m# a debuggability cost\u001B[39;00m\n\u001B[0;32m--> 179\u001B[0m \u001B[38;5;28;01mfor\u001B[39;00m chunk \u001B[38;5;129;01min\u001B[39;00m iterable:\n\u001B[1;32m    180\u001B[0m     fp\u001B[38;5;241m.\u001B[39mwrite(chunk)\n",
+      "File \u001B[0;32m~/dev/conda/envs/weaver/lib/python3.10/json/encoder.py:431\u001B[0m, in \u001B[0;36m_make_iterencode.<locals>._iterencode\u001B[0;34m(o, _current_indent_level)\u001B[0m\n\u001B[1;32m    429\u001B[0m     \u001B[38;5;28;01myield from\u001B[39;00m _iterencode_list(o, _current_indent_level)\n\u001B[1;32m    430\u001B[0m \u001B[38;5;28;01melif\u001B[39;00m \u001B[38;5;28misinstance\u001B[39m(o, \u001B[38;5;28mdict\u001B[39m):\n\u001B[0;32m--> 431\u001B[0m     \u001B[38;5;28;01myield from\u001B[39;00m _iterencode_dict(o, _current_indent_level)\n\u001B[1;32m    432\u001B[0m \u001B[38;5;28;01melse\u001B[39;00m:\n\u001B[1;32m    433\u001B[0m     \u001B[38;5;28;01mif\u001B[39;00m markers \u001B[38;5;129;01mis\u001B[39;00m \u001B[38;5;129;01mnot\u001B[39;00m \u001B[38;5;28;01mNone\u001B[39;00m:\n",
+      "File \u001B[0;32m~/dev/conda/envs/weaver/lib/python3.10/json/encoder.py:405\u001B[0m, in \u001B[0;36m_make_iterencode.<locals>._iterencode_dict\u001B[0;34m(dct, _current_indent_level)\u001B[0m\n\u001B[1;32m    403\u001B[0m         \u001B[38;5;28;01melse\u001B[39;00m:\n\u001B[1;32m    404\u001B[0m             chunks \u001B[38;5;241m=\u001B[39m _iterencode(value, _current_indent_level)\n\u001B[0;32m--> 405\u001B[0m         \u001B[38;5;28;01myield from\u001B[39;00m chunks\n\u001B[1;32m    406\u001B[0m \u001B[38;5;28;01mif\u001B[39;00m newline_indent \u001B[38;5;129;01mis\u001B[39;00m \u001B[38;5;129;01mnot\u001B[39;00m \u001B[38;5;28;01mNone\u001B[39;00m:\n\u001B[1;32m    407\u001B[0m     _current_indent_level \u001B[38;5;241m-\u001B[39m\u001B[38;5;241m=\u001B[39m \u001B[38;5;241m1\u001B[39m\n",
+      "File \u001B[0;32m~/dev/conda/envs/weaver/lib/python3.10/json/encoder.py:405\u001B[0m, in \u001B[0;36m_make_iterencode.<locals>._iterencode_dict\u001B[0;34m(dct, _current_indent_level)\u001B[0m\n\u001B[1;32m    403\u001B[0m         \u001B[38;5;28;01melse\u001B[39;00m:\n\u001B[1;32m    404\u001B[0m             chunks \u001B[38;5;241m=\u001B[39m _iterencode(value, _current_indent_level)\n\u001B[0;32m--> 405\u001B[0m         \u001B[38;5;28;01myield from\u001B[39;00m chunks\n\u001B[1;32m    406\u001B[0m \u001B[38;5;28;01mif\u001B[39;00m newline_indent \u001B[38;5;129;01mis\u001B[39;00m \u001B[38;5;129;01mnot\u001B[39;00m \u001B[38;5;28;01mNone\u001B[39;00m:\n\u001B[1;32m    407\u001B[0m     _current_indent_level \u001B[38;5;241m-\u001B[39m\u001B[38;5;241m=\u001B[39m \u001B[38;5;241m1\u001B[39m\n",
+      "File \u001B[0;32m~/dev/conda/envs/weaver/lib/python3.10/json/encoder.py:438\u001B[0m, in \u001B[0;36m_make_iterencode.<locals>._iterencode\u001B[0;34m(o, _current_indent_level)\u001B[0m\n\u001B[1;32m    436\u001B[0m         \u001B[38;5;28;01mraise\u001B[39;00m \u001B[38;5;167;01mValueError\u001B[39;00m(\u001B[38;5;124m\"\u001B[39m\u001B[38;5;124mCircular reference detected\u001B[39m\u001B[38;5;124m\"\u001B[39m)\n\u001B[1;32m    437\u001B[0m     markers[markerid] \u001B[38;5;241m=\u001B[39m o\n\u001B[0;32m--> 438\u001B[0m o \u001B[38;5;241m=\u001B[39m \u001B[43m_default\u001B[49m\u001B[43m(\u001B[49m\u001B[43mo\u001B[49m\u001B[43m)\u001B[49m\n\u001B[1;32m    439\u001B[0m \u001B[38;5;28;01myield from\u001B[39;00m _iterencode(o, _current_indent_level)\n\u001B[1;32m    440\u001B[0m \u001B[38;5;28;01mif\u001B[39;00m markers \u001B[38;5;129;01mis\u001B[39;00m \u001B[38;5;129;01mnot\u001B[39;00m \u001B[38;5;28;01mNone\u001B[39;00m:\n",
+      "File \u001B[0;32m~/dev/conda/envs/weaver/lib/python3.10/json/encoder.py:179\u001B[0m, in \u001B[0;36mJSONEncoder.default\u001B[0;34m(self, o)\u001B[0m\n\u001B[1;32m    160\u001B[0m \u001B[38;5;28;01mdef\u001B[39;00m \u001B[38;5;21mdefault\u001B[39m(\u001B[38;5;28mself\u001B[39m, o):\n\u001B[1;32m    161\u001B[0m     \u001B[38;5;124;03m\"\"\"Implement this method in a subclass such that it returns\u001B[39;00m\n\u001B[1;32m    162\u001B[0m \u001B[38;5;124;03m    a serializable object for ``o``, or calls the base implementation\u001B[39;00m\n\u001B[1;32m    163\u001B[0m \u001B[38;5;124;03m    (to raise a ``TypeError``).\u001B[39;00m\n\u001B[0;32m   (...)\u001B[0m\n\u001B[1;32m    177\u001B[0m \n\u001B[1;32m    178\u001B[0m \u001B[38;5;124;03m    \"\"\"\u001B[39;00m\n\u001B[0;32m--> 179\u001B[0m     \u001B[38;5;28;01mraise\u001B[39;00m \u001B[38;5;167;01mTypeError\u001B[39;00m(\u001B[38;5;124mf\u001B[39m\u001B[38;5;124m'\u001B[39m\u001B[38;5;124mObject of type \u001B[39m\u001B[38;5;132;01m{\u001B[39;00mo\u001B[38;5;241m.\u001B[39m\u001B[38;5;18m__class__\u001B[39m\u001B[38;5;241m.\u001B[39m\u001B[38;5;18m__name__\u001B[39m\u001B[38;5;132;01m}\u001B[39;00m\u001B[38;5;124m \u001B[39m\u001B[38;5;124m'\u001B[39m\n\u001B[1;32m    180\u001B[0m                     \u001B[38;5;124mf\u001B[39m\u001B[38;5;124m'\u001B[39m\u001B[38;5;124mis not JSON serializable\u001B[39m\u001B[38;5;124m'\u001B[39m)\n",
+      "\u001B[0;31mTypeError\u001B[0m: Object of type datetime is not JSON serializable"
+     ]
+    }
+   ],
+   "source": [
+    "with tempfile.NamedTemporaryFile(mode=\"w\", encoding=\"utf-8\", delete=False) as out_file:\n",
+    "    json.dump(stac_item, out_file)\n",
+    "\n",
+    "output: \"CWLFilePathOutput\" = out_file.name"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-09-27T22:13:04.497948452Z",
+     "start_time": "2023-09-27T22:13:04.305098948Z"
+    }
+   },
+   "id": "e4fa98fcad8b5556"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "name": "conda-env-conda-weaver-py",
+   "language": "python",
+   "display_name": "Python [conda env:conda-weaver]"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/functional/test_ncml2stac.ipynb
+++ b/tests/functional/test_ncml2stac.ipynb
@@ -106,14 +106,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 16,
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2023-09-27 22:13:03.244828 [INFO] :: PYESSV :: Loading vocabularies from /home/francis/.esdoc/pyessv-archive ... please wait\n",
-      "2023-09-27 22:13:03.656407 [INFO] :: PYESSV :: Loading vocabularies from /home/francis/.esdoc/pyessv-archive ... please wait\n",
+      "2023-09-27 22:47:33.681584 [INFO] :: PYESSV :: Loading vocabularies from /home/francis/.esdoc/pyessv-archive ... please wait\n",
       "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n",
       "<ncml:netcdf xmlns:ncml=\"http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2\" location=\"https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/testdata/xclim/cmip6/sic_SImon_CCCma-CanESM5_ssp245_r13i1p2f1_2020.nc\">\n",
       "  <ncml:attribute name=\"CCCma_model_hash\" value=\"fc4bb7db954c862d023b546e19aec6c588bc0552\" />\n",
@@ -301,13 +300,18 @@
    ],
    "source": [
     "import json\n",
+    "import tempfile\n",
+    "from datetime import datetime, date\n",
+    "from dateutil.parser import parse as dt_parse\n",
+    "from enum import Enum\n",
+    "\n",
+    "import numpy as np\n",
+    "import requests\n",
+    "import xncml\n",
     "import pystac\n",
     "from pystac.extensions import datacube\n",
-    "import requests\n",
-    "import tempfile\n",
-    "import xncml\n",
+    "from pydantic.networks import Url\n",
     "from shapely.geometry.polygon import Polygon\n",
-    "from dateutil.parser import parse as dt_parse\n",
     "\n",
     "import pyessv\n",
     "pyessv.init()\n",
@@ -330,8 +334,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-09-27T22:13:04.191448522Z",
-     "start_time": "2023-09-27T22:13:02.465029823Z"
+     "end_time": "2023-09-27T22:47:34.154049178Z",
+     "start_time": "2023-09-27T22:47:33.700947842Z"
     }
    },
    "id": "4fc2f66493dc56c5"
@@ -481,37 +485,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "outputs": [
-    {
-     "ename": "TypeError",
-     "evalue": "Object of type datetime is not JSON serializable",
-     "output_type": "error",
-     "traceback": [
-      "\u001B[0;31m---------------------------------------------------------------------------\u001B[0m",
-      "\u001B[0;31mTypeError\u001B[0m                                 Traceback (most recent call last)",
-      "Cell \u001B[0;32mIn[7], line 2\u001B[0m\n\u001B[1;32m      1\u001B[0m \u001B[38;5;28;01mwith\u001B[39;00m tempfile\u001B[38;5;241m.\u001B[39mNamedTemporaryFile(mode\u001B[38;5;241m=\u001B[39m\u001B[38;5;124m\"\u001B[39m\u001B[38;5;124mw\u001B[39m\u001B[38;5;124m\"\u001B[39m, encoding\u001B[38;5;241m=\u001B[39m\u001B[38;5;124m\"\u001B[39m\u001B[38;5;124mutf-8\u001B[39m\u001B[38;5;124m\"\u001B[39m, delete\u001B[38;5;241m=\u001B[39m\u001B[38;5;28;01mFalse\u001B[39;00m) \u001B[38;5;28;01mas\u001B[39;00m out_file:\n\u001B[0;32m----> 2\u001B[0m     \u001B[43mjson\u001B[49m\u001B[38;5;241;43m.\u001B[39;49m\u001B[43mdump\u001B[49m\u001B[43m(\u001B[49m\u001B[43mstac_item\u001B[49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[43mout_file\u001B[49m\u001B[43m)\u001B[49m\n\u001B[1;32m      4\u001B[0m output: \u001B[38;5;124m\"\u001B[39m\u001B[38;5;124mCWLFilePathOutput\u001B[39m\u001B[38;5;124m\"\u001B[39m \u001B[38;5;241m=\u001B[39m out_file\u001B[38;5;241m.\u001B[39mname\n",
-      "File \u001B[0;32m~/dev/conda/envs/weaver/lib/python3.10/json/__init__.py:179\u001B[0m, in \u001B[0;36mdump\u001B[0;34m(obj, fp, skipkeys, ensure_ascii, check_circular, allow_nan, cls, indent, separators, default, sort_keys, **kw)\u001B[0m\n\u001B[1;32m    173\u001B[0m     iterable \u001B[38;5;241m=\u001B[39m \u001B[38;5;28mcls\u001B[39m(skipkeys\u001B[38;5;241m=\u001B[39mskipkeys, ensure_ascii\u001B[38;5;241m=\u001B[39mensure_ascii,\n\u001B[1;32m    174\u001B[0m         check_circular\u001B[38;5;241m=\u001B[39mcheck_circular, allow_nan\u001B[38;5;241m=\u001B[39mallow_nan, indent\u001B[38;5;241m=\u001B[39mindent,\n\u001B[1;32m    175\u001B[0m         separators\u001B[38;5;241m=\u001B[39mseparators,\n\u001B[1;32m    176\u001B[0m         default\u001B[38;5;241m=\u001B[39mdefault, sort_keys\u001B[38;5;241m=\u001B[39msort_keys, \u001B[38;5;241m*\u001B[39m\u001B[38;5;241m*\u001B[39mkw)\u001B[38;5;241m.\u001B[39miterencode(obj)\n\u001B[1;32m    177\u001B[0m \u001B[38;5;66;03m# could accelerate with writelines in some versions of Python, at\u001B[39;00m\n\u001B[1;32m    178\u001B[0m \u001B[38;5;66;03m# a debuggability cost\u001B[39;00m\n\u001B[0;32m--> 179\u001B[0m \u001B[38;5;28;01mfor\u001B[39;00m chunk \u001B[38;5;129;01min\u001B[39;00m iterable:\n\u001B[1;32m    180\u001B[0m     fp\u001B[38;5;241m.\u001B[39mwrite(chunk)\n",
-      "File \u001B[0;32m~/dev/conda/envs/weaver/lib/python3.10/json/encoder.py:431\u001B[0m, in \u001B[0;36m_make_iterencode.<locals>._iterencode\u001B[0;34m(o, _current_indent_level)\u001B[0m\n\u001B[1;32m    429\u001B[0m     \u001B[38;5;28;01myield from\u001B[39;00m _iterencode_list(o, _current_indent_level)\n\u001B[1;32m    430\u001B[0m \u001B[38;5;28;01melif\u001B[39;00m \u001B[38;5;28misinstance\u001B[39m(o, \u001B[38;5;28mdict\u001B[39m):\n\u001B[0;32m--> 431\u001B[0m     \u001B[38;5;28;01myield from\u001B[39;00m _iterencode_dict(o, _current_indent_level)\n\u001B[1;32m    432\u001B[0m \u001B[38;5;28;01melse\u001B[39;00m:\n\u001B[1;32m    433\u001B[0m     \u001B[38;5;28;01mif\u001B[39;00m markers \u001B[38;5;129;01mis\u001B[39;00m \u001B[38;5;129;01mnot\u001B[39;00m \u001B[38;5;28;01mNone\u001B[39;00m:\n",
-      "File \u001B[0;32m~/dev/conda/envs/weaver/lib/python3.10/json/encoder.py:405\u001B[0m, in \u001B[0;36m_make_iterencode.<locals>._iterencode_dict\u001B[0;34m(dct, _current_indent_level)\u001B[0m\n\u001B[1;32m    403\u001B[0m         \u001B[38;5;28;01melse\u001B[39;00m:\n\u001B[1;32m    404\u001B[0m             chunks \u001B[38;5;241m=\u001B[39m _iterencode(value, _current_indent_level)\n\u001B[0;32m--> 405\u001B[0m         \u001B[38;5;28;01myield from\u001B[39;00m chunks\n\u001B[1;32m    406\u001B[0m \u001B[38;5;28;01mif\u001B[39;00m newline_indent \u001B[38;5;129;01mis\u001B[39;00m \u001B[38;5;129;01mnot\u001B[39;00m \u001B[38;5;28;01mNone\u001B[39;00m:\n\u001B[1;32m    407\u001B[0m     _current_indent_level \u001B[38;5;241m-\u001B[39m\u001B[38;5;241m=\u001B[39m \u001B[38;5;241m1\u001B[39m\n",
-      "File \u001B[0;32m~/dev/conda/envs/weaver/lib/python3.10/json/encoder.py:405\u001B[0m, in \u001B[0;36m_make_iterencode.<locals>._iterencode_dict\u001B[0;34m(dct, _current_indent_level)\u001B[0m\n\u001B[1;32m    403\u001B[0m         \u001B[38;5;28;01melse\u001B[39;00m:\n\u001B[1;32m    404\u001B[0m             chunks \u001B[38;5;241m=\u001B[39m _iterencode(value, _current_indent_level)\n\u001B[0;32m--> 405\u001B[0m         \u001B[38;5;28;01myield from\u001B[39;00m chunks\n\u001B[1;32m    406\u001B[0m \u001B[38;5;28;01mif\u001B[39;00m newline_indent \u001B[38;5;129;01mis\u001B[39;00m \u001B[38;5;129;01mnot\u001B[39;00m \u001B[38;5;28;01mNone\u001B[39;00m:\n\u001B[1;32m    407\u001B[0m     _current_indent_level \u001B[38;5;241m-\u001B[39m\u001B[38;5;241m=\u001B[39m \u001B[38;5;241m1\u001B[39m\n",
-      "File \u001B[0;32m~/dev/conda/envs/weaver/lib/python3.10/json/encoder.py:438\u001B[0m, in \u001B[0;36m_make_iterencode.<locals>._iterencode\u001B[0;34m(o, _current_indent_level)\u001B[0m\n\u001B[1;32m    436\u001B[0m         \u001B[38;5;28;01mraise\u001B[39;00m \u001B[38;5;167;01mValueError\u001B[39;00m(\u001B[38;5;124m\"\u001B[39m\u001B[38;5;124mCircular reference detected\u001B[39m\u001B[38;5;124m\"\u001B[39m)\n\u001B[1;32m    437\u001B[0m     markers[markerid] \u001B[38;5;241m=\u001B[39m o\n\u001B[0;32m--> 438\u001B[0m o \u001B[38;5;241m=\u001B[39m \u001B[43m_default\u001B[49m\u001B[43m(\u001B[49m\u001B[43mo\u001B[49m\u001B[43m)\u001B[49m\n\u001B[1;32m    439\u001B[0m \u001B[38;5;28;01myield from\u001B[39;00m _iterencode(o, _current_indent_level)\n\u001B[1;32m    440\u001B[0m \u001B[38;5;28;01mif\u001B[39;00m markers \u001B[38;5;129;01mis\u001B[39;00m \u001B[38;5;129;01mnot\u001B[39;00m \u001B[38;5;28;01mNone\u001B[39;00m:\n",
-      "File \u001B[0;32m~/dev/conda/envs/weaver/lib/python3.10/json/encoder.py:179\u001B[0m, in \u001B[0;36mJSONEncoder.default\u001B[0;34m(self, o)\u001B[0m\n\u001B[1;32m    160\u001B[0m \u001B[38;5;28;01mdef\u001B[39;00m \u001B[38;5;21mdefault\u001B[39m(\u001B[38;5;28mself\u001B[39m, o):\n\u001B[1;32m    161\u001B[0m     \u001B[38;5;124;03m\"\"\"Implement this method in a subclass such that it returns\u001B[39;00m\n\u001B[1;32m    162\u001B[0m \u001B[38;5;124;03m    a serializable object for ``o``, or calls the base implementation\u001B[39;00m\n\u001B[1;32m    163\u001B[0m \u001B[38;5;124;03m    (to raise a ``TypeError``).\u001B[39;00m\n\u001B[0;32m   (...)\u001B[0m\n\u001B[1;32m    177\u001B[0m \n\u001B[1;32m    178\u001B[0m \u001B[38;5;124;03m    \"\"\"\u001B[39;00m\n\u001B[0;32m--> 179\u001B[0m     \u001B[38;5;28;01mraise\u001B[39;00m \u001B[38;5;167;01mTypeError\u001B[39;00m(\u001B[38;5;124mf\u001B[39m\u001B[38;5;124m'\u001B[39m\u001B[38;5;124mObject of type \u001B[39m\u001B[38;5;132;01m{\u001B[39;00mo\u001B[38;5;241m.\u001B[39m\u001B[38;5;18m__class__\u001B[39m\u001B[38;5;241m.\u001B[39m\u001B[38;5;18m__name__\u001B[39m\u001B[38;5;132;01m}\u001B[39;00m\u001B[38;5;124m \u001B[39m\u001B[38;5;124m'\u001B[39m\n\u001B[1;32m    180\u001B[0m                     \u001B[38;5;124mf\u001B[39m\u001B[38;5;124m'\u001B[39m\u001B[38;5;124mis not JSON serializable\u001B[39m\u001B[38;5;124m'\u001B[39m)\n",
-      "\u001B[0;31mTypeError\u001B[0m: Object of type datetime is not JSON serializable"
-     ]
-    }
-   ],
+   "execution_count": 17,
+   "outputs": [],
    "source": [
+    "def json_encode(obj):\n",
+    "    if isinstance(obj, (np.ndarray, np.number)):\n",
+    "        return obj.tolist()\n",
+    "    if isinstance(obj, (Url, Enum)):\n",
+    "        return str(obj)\n",
+    "    if isinstance(obj, (datetime, date)):\n",
+    "        return obj.isoformat()\n",
+    "    raise TypeError(f\"Type {type(obj)} not serializable\")\n",
+    "\n",
     "with tempfile.NamedTemporaryFile(mode=\"w\", encoding=\"utf-8\", delete=False) as out_file:\n",
-    "    json.dump(stac_item, out_file)\n",
+    "    json.dump(stac_item, out_file, default=json_encode)\n",
     "\n",
     "output: \"CWLFilePathOutput\" = out_file.name"
    ],
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-09-27T22:13:04.497948452Z",
-     "start_time": "2023-09-27T22:13:04.305098948Z"
+     "end_time": "2023-09-27T22:47:38.832969763Z",
+     "start_time": "2023-09-27T22:47:38.710714517Z"
     }
    },
    "id": "e4fa98fcad8b5556"


### PR DESCRIPTION
# Changes

 - add test use-case ncml2stac notebook (depends on https://github.com/crim-ca/stac-populator/pull/22)
- separate repo defined for testing `jupyter-repo2cwl` full-pipeline with remote Git reference: https://github.com/crim-ca/ncml2stac


# References 
 - relates to [DAC-202](https://crim-ca.atlassian.net/browse/DAC-202)
 - relates to [DAC-517](https://crim-ca.atlassian.net/browse/DAC-517)
 - relates to [GD-247](https://crim-ca.atlassian.net/browse/GD-247)
 - fixes https://github.com/crim-ca/weaver/issues/63
