### PR TITLE
support callback request subscribers and job notification refactoring

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,7 @@ Changes:
   parsing of its value if provided in the `JSON` body during `Job` submission for backward compatibility support of
   existing servers. The ``Job.notification_email`` attribute is removed to avoid duplicate references.
 - Add notification email for `Job` ``started`` status, only available through the ``subscribers`` property.
+- Add `CLI` and ``WeaverClient`` options to support ``subscribers`` specification for submitted `Job` execution.
 - Add ``{PROCESS_ID}/{STATUS}.mako`` template detection under the ``weaver.wps_email_notify_template_dir`` location
   to allow per-`Process` and per-`Job` status email customization.
 - Refactor ``weaver/notify.py`` and ``weaver/processes/execution.py`` to avoid mixed references to the
@@ -28,7 +29,7 @@ Changes:
 
 Fixes:
 ------
-- No change.
+- Fix ``weaver.cli`` logger not properly configured when executed from `CLI` causing log messages to not be reported.
 
 .. _changes_4.33.0:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,7 +12,18 @@ Changes
 
 Changes:
 --------
-- No change.
+- Add `Job` ``subscribers`` support to define `OGC`-compliant callback URLs where HTTP(S) requests will be sent upon
+  reaching certain `Job` status milestones (resolves `#230 <https://github.com/crim-ca/weaver/issues/230>`_).
+- Add email notification support to the new ``subscribers`` definition (extension over `OGC` minimal requirements).
+- Deprecate `Job` ``notification_email`` in the `OpenAPI` specification in favor of ``subscribers``, but preserve
+  parsing of its value if provided in the `JSON` body during `Job` submission for backward compatibility support of
+  existing servers. The ``Job.notification_email`` attribute is removed to avoid duplicate references.
+- Add notification email for `Job` ``started`` status, only available through the ``subscribers`` property.
+- Add ``{PROCESS_ID}/{STATUS}.mako`` template detection under the ``weaver.wps_email_notify_template_dir`` location
+  to allow per-`Process` and per-`Job` status email customization.
+- Refactor ``weaver/notify.py`` and ``weaver/processes/execution.py`` to avoid mixed references to the
+  encryption/decryption logic employed for notification emails. All notifications including emails and
+  callback requests are now completely handled and contained in the ``weaver/notify.py`` module.
 
 Fixes:
 ------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,7 @@ Changes:
 - Refactor ``weaver/notify.py`` and ``weaver/processes/execution.py`` to avoid mixed references to the
   encryption/decryption logic employed for notification emails. All notifications including emails and
   callback requests are now completely handled and contained in the ``weaver/notify.py`` module.
+- Remove partially duplicate Mako Template definition as hardcoded string and separate file for email notification.
 
 Fixes:
 ------

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -337,7 +337,7 @@ above :term:`CLI` variations, but it is usually more intuitive to use a Python :
             {"href": "http://another.com/data.json"},
         ],
         "single": {
-            "href": "/workspace/data.xml@mediaType",  # note: uploaded to vault automatically before execution
+            "href": "/workspace/data.xml",  # note: uploaded to vault automatically before execution
             "type": "text/xml",
         }
     })

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -221,7 +221,7 @@ they are optional and which default value or operation is applied in each situat
   | The *path* variant **SHOULD** start with ``/`` for appropriate concatenation with ``weaver.url``, although this is
     not strictly enforced.
 
-- | ``weaver.wps_metadata_[...]`` (multiple settings)
+- | ``weaver.wps_metadata_[...]`` (multiple settings) [:class:`str`]
   |
   | Metadata fields that will be rendered by either or both the WPS-1/2 and WPS-REST endpoints
     (:ref:`GetCapabilities <proc_op_getcap>`).

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -228,14 +228,29 @@ they are optional and which default value or operation is applied in each situat
 
 - | ``weaver.wps_email_[...]`` (multiple settings)
   |
-  | Defines configuration of email notification functionality on job completion.
+  | Defines configuration of email notification functionality on :term:`Job` status milestones.
   |
-  | Encryption settings as well as custom email templates are available. Default email template defined in
-    `email-template`_ is employed if none is provided. Email notifications are sent only on job
-    completion if an email was provided in the :ref:`Execute <proc_op_execute>` request body
-    (see also: :ref:`Email Notification`).
+  | Encryption settings as well as custom email templates are available.
+    Default email template defined in `email-template`_ is employed if none is provided or when specified template
+    file or directory cannot be resolved.
+  |
+  | When looking up for templates within ``weaver.wps_email_notify_template_dir``, the following resolution order is
+    followed to attempt matching files. The first one that is found will be employed for the notification email.
+  |
+  | 1. file ``{TEMPLATE_DIR}/{PROCESS_ID}/{STATUS}.mako`` used for a specific :term:`Process` and :term:`Job` status
+  | 2. file ``{TEMPLATE_DIR}/{PROCESS_ID}.mako`` used for a specific :term:`Process` but any :term:`Job` status
+  | 3. file ``{TEMPLATE_DIR}/{weaver.wps_email_notify_template_default}`` used for any combination if specified
+  | 4. file ``{TEMPLATE_DIR}/default.mako`` used for any combination if an alternate default name was not specified
+  | 5. file `email-template`_ by default as last resort
+  |
+  | Email notifications are sent only when corresponding :term:`Job` status milestones are reached and when
+    email(s) were provided in the :ref:`Execute <proc_op_execute>` request body.
+
+.. seealso::
+    See :ref:`Notification Subscribers <proc_op_execute_subscribers>` for more details.
 
 .. versionadded:: 4.15
+.. versionchanged:: 4.34
 
 - | ``weaver.execute_sync_max_wait = <int>`` [:class:`int`, seconds]
   | (default: ``20``)

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -230,9 +230,9 @@ they are optional and which default value or operation is applied in each situat
   |
   | Defines configuration of email notification functionality on :term:`Job` status milestones.
   |
-  | Encryption settings as well as custom email templates are available.
-    Default email template defined in `email-template`_ is employed if none is provided or when specified template
-    file or directory cannot be resolved.
+  | Encryption settings as well as custom email template locations are available.
+    The |default-notify-email-template|_ is employed if none is provided or when specified template
+    files or directory cannot be resolved.
   |
   | When looking up for templates within ``weaver.wps_email_notify_template_dir``, the following resolution order is
     followed to attempt matching files. The first one that is found will be employed for the notification email.
@@ -241,10 +241,11 @@ they are optional and which default value or operation is applied in each situat
   | 2. file ``{TEMPLATE_DIR}/{PROCESS_ID}.mako`` used for a specific :term:`Process` but any :term:`Job` status
   | 3. file ``{TEMPLATE_DIR}/{weaver.wps_email_notify_template_default}`` used for any combination if specified
   | 4. file ``{TEMPLATE_DIR}/default.mako`` used for any combination if an alternate default name was not specified
-  | 5. file `email-template`_ by default as last resort
+  | 5. file |default-notify-email-template|_ as last resort
   |
   | Email notifications are sent only when corresponding :term:`Job` status milestones are reached and when
-    email(s) were provided in the :ref:`Execute <proc_op_execute>` request body.
+    email(s) were provided in the :ref:`Execute <proc_op_execute>` request body. Emails will not be sent if
+    the request body did not include a subscription to those notifications, even if the templates were configured.
 
 .. seealso::
     See :ref:`Notification Subscribers <proc_op_execute_subscribers>` for more details.

--- a/docs/source/processes.rst
+++ b/docs/source/processes.rst
@@ -1394,13 +1394,29 @@ the configured :term:`WPS` output directory.
 .. versionadded:: 4.3
     Addition of the ``X-WPS-Output-Context`` header.
 
-Email Notification
+.. _proc_op_execute_subscribers:
+
+Notification Subscribers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When submitting a :term:`Job` for execution, it is possible to provide the ``notification_email`` field.
 Doing so will tell `Weaver` to send an email to the specified address with successful or failure details
 upon :term:`Job` completion. The format of the email is configurable from `weaver.ini.example`_ file with
 email-specific settings (see: :ref:`Configuration`).
+
+Alternatively to ``notification_email``, the ``subscribers`` field of the :term:`API` can be employed during :term:`Job`
+submission. Using this field will take precedence over ``notification_email`` for corresponding email and status
+combinations. The :term:`Job` ``subscribers`` allow more fined-grained control over which emails will be sent for
+the various combinations of :term:`Job` status milestones.
+
+Furthermore, ``subscribers`` allow specifying URLs where HTTP(S) requests will be sent with
+the :ref:`Job Status <proc_op_status>` or :ref:`Job Results <proc_op_result>` contents directly in :term:`JSON` format.
+This allows users and/or servers to directly receive the necessary details using a push-notification mechanism instead
+of the polling-based method on the :ref:`Job Status <proc_op_status>` endpoint otherwise required to obtain updated
+:term:`Job` details.
+
+.. seealso::
+    Refer to the |oas-rtd|_ of the |exec-req|_ request for all available ``subscribers`` properties.
 
 .. _proc_op_status:
 .. _proc_op_monitor:

--- a/docs/source/references.rst
+++ b/docs/source/references.rst
@@ -137,7 +137,8 @@
 .. _request_options.yml.example: ../../../config/request_options.yml.example
 .. _Dockerfile-manager: ../../../docker/Dockerfile-manager
 .. _Dockerfile-worker: ../../../docker/Dockerfile-worker
-.. _email-template: ../../../weaver/wps_restapi/templates/notification_email_example.mako
+.. _default-notify-email-template: ../../../weaver/wps_restapi/templates/notification_email_example.mako
+.. |default-notify-email-template| replace:: Default Notification Email Mako Template
 .. |opensearch-deploy| replace:: OpenSearch Deploy
 .. _opensearch-deploy: ../../../tests/opensearch/json/opensearch_deploy.json
 .. |opensearch-examples| replace:: OpenSearch Examples

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -624,11 +624,12 @@ class TestWeaverClient(TestWeaverClientBase):
             assert mocked_requests.call_args_list[1].kwargs["json"] == expect_outputs  # results JSON
 
             # first argument None is 'from_addr' not configured, this is allowed if provided by 'From' email header
+            test_proc_byte = self.test_process["Echo"]
             assert mocked_emails.call_count == 2, "Should not have sent both failed/success email notifications"
             assert mocked_emails.call_args_list[0].args[:2] == (None, subscribers["inProgressEmail"])
-            assert b"Job test-client-Echo Started" in mocked_emails.call_args_list[0].args[-1]
+            assert f"Job {test_proc_byte} Started".encode() in mocked_emails.call_args_list[0].args[-1]
             assert mocked_emails.call_args_list[1].args[:2] == (None, subscribers["successEmail"])
-            assert b"Job test-client-Echo Succeeded" in mocked_emails.call_args_list[1].args[-1]
+            assert f"Job {test_proc_byte} Succeeded".encode() in mocked_emails.call_args_list[1].args[-1]
 
     # NOTE:
     #   For all below '<>_auto_resolve_vault' test cases, the local file referenced in the Execute request body

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,7 +2,6 @@
 Unit test for :mod:`weaver.cli` utilities.
 """
 import argparse
-
 import base64
 import inspect
 import json
@@ -370,4 +369,4 @@ def test_subscriber_parsing(expect_error, subscriber_option, subscriber_dest, su
         assert isinstance(exc, expect_error), f"Test expected to raise {expect_error}, but raised {exc!s} instead."
     else:
         assert expect_error is None, f"Test was expected to fail with {expect_error}, but did not raise"
-        assert dict(**vars(ns)) == subscriber_result
+        assert dict(**vars(ns)) == subscriber_result  # pylint: disable=R1735

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -50,7 +50,7 @@ def test_encrypt_decrypt_email_raise(email_func):
         pytest.fail("Should have raised for invalid/missing settings")
 
 
-def test_notify_job_complete():
+def test_notify_email_job_complete():
     test_url = "https://test-weaver.example.com"
     settings = {
         "weaver.url": test_url,

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -7,7 +7,7 @@ import mock
 import pytest
 
 from weaver.datatype import Job
-from weaver.notify import decrypt_email, encrypt_email, notify_job_complete
+from weaver.notify import decrypt_email, encrypt_email, notify_job_email
 from weaver.status import Status
 
 
@@ -74,7 +74,7 @@ def test_notify_email_job_complete():
         mock_smtp.return_value.sendmail.return_value = None  # sending worked
 
         test_job.status = Status.SUCCEEDED
-        notify_job_complete(test_job, notify_email, settings)
+        notify_job_email(test_job, notify_email, settings)
         mock_smtp.assert_called_with("xyz.test.com", 12345, timeout=1)
         assert mock_smtp.return_value.sendmail.call_args[0][0] == "test-weaver@email.com"
         assert mock_smtp.return_value.sendmail.call_args[0][1] == notify_email
@@ -89,7 +89,7 @@ def test_notify_email_job_complete():
         assert test_job_err_url not in message
 
         test_job.status = Status.FAILED
-        notify_job_complete(test_job, notify_email, settings)
+        notify_job_email(test_job, notify_email, settings)
         assert mock_smtp.return_value.sendmail.call_args[0][0] == "test-weaver@email.com"
         assert mock_smtp.return_value.sendmail.call_args[0][1] == notify_email
         message_encoded = mock_smtp.return_value.sendmail.call_args[0][2]
@@ -103,7 +103,7 @@ def test_notify_email_job_complete():
         assert test_job_err_url in message
 
 
-def test_notify_job_complete_custom_template():
+def test_notify_job_email_custom_template():
     with tempfile.NamedTemporaryFile(mode="w", encoding="utf-8", suffix=".mako") as email_template_file:
         email_template_file.writelines([
             "From: Weaver\n",
@@ -137,7 +137,7 @@ def test_notify_job_complete_custom_template():
 
         with mock.patch("smtplib.SMTP_SSL", autospec=smtplib.SMTP_SSL) as mock_smtp:
             mock_smtp.return_value.sendmail.return_value = None  # sending worked
-            notify_job_complete(test_job, notify_email, settings)
+            notify_job_email(test_job, notify_email, settings)
 
         message_encoded = mock_smtp.return_value.sendmail.call_args[0][2]
         message = message_encoded.decode("utf8")

--- a/weaver/cli.py
+++ b/weaver/cli.py
@@ -1984,9 +1984,10 @@ class SubscriberAction(argparse.Action):
 
     def validate(self, option, value):
         # type: (str, Any) -> None
-        if "email" in option:
+        metavar = self.metavar or ""
+        if any("email" in opt.lower() for opt in [option, self.field, metavar]):
             pattern = re.compile(EMAIL_RE, flags=re.IGNORECASE)
-        elif "callback" in option:
+        elif any("callback" in opt.lower() for opt in [option, self.field, metavar]):
             pattern = re.compile(URL_REGEX, flags=re.IGNORECASE)
         else:
             raise NotImplementedError(f"Cannot parse option: '{option}'")

--- a/weaver/cli.py
+++ b/weaver/cli.py
@@ -1984,9 +1984,9 @@ class SubscriberAction(argparse.Action):
 
     def validate(self, option, value):
         # type: (str, Any) -> None
-        if "email" in self.field:
+        if "email" in option:
             pattern = re.compile(EMAIL_RE, flags=re.IGNORECASE)
-        elif "callback" in self.field:
+        elif "callback" in option:
             pattern = re.compile(URL_REGEX, flags=re.IGNORECASE)
         else:
             raise NotImplementedError(f"Cannot parse option: '{option}'")

--- a/weaver/cli.py
+++ b/weaver/cli.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
 import yaml
+from colander import EMAIL_RE, URL_REGEX
 from pyramid.httpexceptions import HTTPNotImplemented
 from requests.auth import AuthBase, HTTPBasicAuth
 from requests.sessions import Session
@@ -37,6 +38,7 @@ from weaver.processes.wps_package import get_process_definition
 from weaver.sort import Sort, SortMethods
 from weaver.status import JOB_STATUS_CATEGORIES, Status, StatusCategory, map_status
 from weaver.utils import (
+    Lazify,
     OutputMethod,
     copy_doc,
     fetch_reference,
@@ -70,8 +72,10 @@ if TYPE_CHECKING:
             AnyResponseType,
             CWL,
             ExecutionInputsMap,
+            ExecutionResultObjectRef,
             ExecutionResults,
             HeadersType,
+            JobSubscribers,
             JSON
         )
     except ImportError:
@@ -92,7 +96,7 @@ if TYPE_CHECKING:
     PostHelpFormatter = Callable[[str], str]
     ArgumentParserRule = Tuple[argparse._ActionsContainer, Callable[[argparse.Namespace], Optional[bool]], str]  # noqa
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = logging.getLogger("weaver.cli")  # do not use '__name__' since it becomes '__main__' from CLI call
 
 OPERATION_ARGS_TITLE = "Operation Arguments"
 OPTIONAL_ARGS_TITLE = "Optional Arguments"
@@ -1050,6 +1054,7 @@ class WeaverClient(object):
                 monitor=False,          # type: bool
                 timeout=None,           # type: Optional[int]
                 interval=None,          # type: Optional[int]
+                subscribers=None,       # type: Optional[JobSubscribers]
                 url=None,               # type: Optional[str]
                 auth=None,              # type: Optional[AuthHandler]
                 headers=None,           # type: Optional[AnyHeadersContainer]
@@ -1094,6 +1099,9 @@ class WeaverClient(object):
             Monitoring timeout (seconds) if requested.
         :param interval:
             Monitoring interval (seconds) between job status polling requests.
+        :param subscribers:
+            Job status subscribers to obtain email or callback request notifications.
+            The subscriber keys indicate which type of subscriber and for which status the notification will be sent.
         :param url: Instance URL if not already provided during client creation.
         :param auth:
             Instance authentication handler if not already created during client creation.
@@ -1136,7 +1144,12 @@ class WeaverClient(object):
             # FIXME: allow filtering 'outputs' (https://github.com/crim-ca/weaver/issues/380)
             "outputs": {}
         }
+        if subscribers:
+            LOGGER.debug("Adding job execution subscribers:\n%s", Lazify(lambda: repr_json(subscribers, indent=2)))
+            data["subscribers"] = subscribers
+
         # omit x-headers on purpose for 'describe', assume they are intended for 'execute' operation only
+        LOGGER.debug("Looking up process [%s] (provider: %s) to execute on [%s]", process_id, provider_id, base)
         result = self.describe(process_id, provider_id=provider_id, url=base, auth=auth)
         if not result.success:
             return OperationResult(False, "Could not obtain process description for execution.",
@@ -1560,15 +1573,15 @@ class WeaverClient(object):
             link, params = link_header.split(";", 1)
             href = link.strip("<>")
             params = parse_kvp(params, multi_value_sep=None, accumulate_keys=False)
-            ctype = (params.get("type") or [None])[0]
+            ctype = (params.get("type") or [None])[0]  # type: str
             rel = params["rel"][0].split(".")
             output = rel[0]
             is_array = len(rel) > 1 and str.isnumeric(rel[1])
             ref_path = fetch_reference(href, out_dir, auth=auth,
                                        out_method=OutputMethod.COPY, out_listing=False)
-            value = {"href": href, "type": ctype, "path": ref_path, "source": "link"}
+            value = {"href": href, "type": ctype, "path": ref_path, "source": "link"}  # type: ExecutionResultObjectRef
             if output in outputs:
-                if isinstance(outputs[output], dict):  # in case 'rel="<output>.<index"' was not employed
+                if isinstance(outputs[output], dict):  # in case 'rel="<output>.<index>"' was not employed
                     outputs[output] = [outputs[output], value]
                 else:
                     outputs[output].append(value)
@@ -1939,6 +1952,106 @@ def add_timeout_param(parser):
     parser.add_argument(
         "-W", "--wait", "--interval", dest="interval", type=int, default=WeaverClient.monitor_interval,
         help="Wait interval (seconds) between each job status polling during monitoring (default: %(default)ss)."
+    )
+
+
+class SubscriberAction(argparse.Action):
+    """
+    Action that will validate that the input argument references a valid subscriber argument.
+
+    If valid, the returned value with be an updated subscriber definition.
+    All arguments using ``action=SubscriberType`` should include a ``dest="<holder>.<subscriber>"`` parameter that will
+    map the ``subscriber`` value under a dictionary ``holder`` that will be passed to the :class:`argparse.Namespace`.
+    """
+
+    def __init__(self, *option_strings, dest=None, **kwargs):
+        # type: (str, str, Any) -> None
+        if not isinstance(dest, str) or "." not in dest:
+            raise ValueError("Using 'SubscriberAction' requires 'dest=<holder>.<subscriber>' parameter.")
+        dest, self.field = dest.split(".", 1)
+        super(SubscriberAction, self).__init__(*option_strings, dest=dest, **kwargs)
+
+    def __call__(self, parser, namespace, subscriber_param, option_string=None):
+        # type: (argparse.ArgumentParser, argparse.Namespace, str, Optional[str]) -> None
+
+        sub_options = "/".join(self.option_strings)
+        self.validate(sub_options, subscriber_param)
+
+        subs_params = getattr(namespace, self.dest, {}) or {}
+        subs_params[self.field] = subscriber_param
+        setattr(namespace, self.dest, subs_params)
+
+    def validate(self, option, value):
+        # type: (str, Any) -> None
+        if "email" in option:
+            pattern = re.compile(EMAIL_RE, flags=re.IGNORECASE)
+        elif "callback" in option:
+            pattern = re.compile(URL_REGEX, flags=re.IGNORECASE)
+        else:
+            raise NotImplementedError(f"Cannot parse option: '{option}'")
+        if not re.match(pattern, value):
+            raise argparse.ArgumentError(self, f"Value '{value} is a valid subscriber argument for '{option}'.")
+
+
+def add_subscribers_params(parser):
+    # type: (argparse.ArgumentParser) -> None
+    subs_args = parser.add_argument_group(
+        title="Notification Subscribers",
+        description=(
+            "Email or callback request URL to obtain notification of job status milestones.\n\n"
+            "Note that for email notifications, the targeted server must have properly configured SMTP settings."
+        ),
+    )
+    subs_args.add_argument(
+        "-sEP", "--subscriber-email-progress",
+        action=SubscriberAction,
+        metavar="EMAIL",
+        dest="subscribers.inProgressEmail",
+        help="Send a notification email to this address once the job started execution."
+    )
+    subs_args.add_argument(
+        "-sEF", "--subscriber-email-failed",
+        action=SubscriberAction,
+        metavar="EMAIL",
+        dest="subscribers.failedEmail",
+        help="Send a notification email to this address if the job execution completed with failure."
+    )
+    subs_args.add_argument(
+        "-sES", "--subscriber-email-success",
+        action=SubscriberAction,
+        metavar="EMAIL",
+        dest="subscribers.successEmail",
+        help="Send a notification email to this address if the job execution completed successfully."
+
+    )
+    subs_args.add_argument(
+        "-sCP", "--subscriber-callback-progress",
+        action=SubscriberAction,
+        metavar="URL",
+        dest="subscribers.inProgressUri",
+        help=(
+            "Send an HTTP callback request to this URL once the job started execution.\n\n"
+            "The request body will contain the JSON representation of the job status details."
+        )
+    )
+    subs_args.add_argument(
+        "-sCF", "--subscriber-callback-failed",
+        action=SubscriberAction,
+        metavar="URL",
+        dest="subscribers.failedUri",
+        help=(
+            "Send an HTTP callback request to this URL if the job execution completed with failure.\n\n"
+            "The request body will contain the JSON representation of the job status details."
+        )
+    )
+    subs_args.add_argument(
+        "-sCS", "--subscriber-callback-success",
+        action=SubscriberAction,
+        metavar="URL",
+        dest="subscribers.successUri",
+        help=(
+            "The request body will contain the JSON representation of the job results."
+        )
     )
 
 
@@ -2552,6 +2665,7 @@ def make_parser():
              "If not requested, the created job status location is directly returned."
     )
     add_timeout_param(op_execute)
+    add_subscribers_params(op_execute)
 
     op_jobs = WeaverArgumentParser(
         "jobs",

--- a/weaver/cli.py
+++ b/weaver/cli.py
@@ -1960,7 +1960,7 @@ class SubscriberAction(argparse.Action):
     """
     Action that will validate that the input argument references a valid subscriber argument.
 
-    If valid, the returned value with be an updated subscriber definition.
+    If valid, the returned value will be an updated subscriber definition.
     All arguments using ``action=SubscriberType`` should include a ``dest="<holder>.<subscriber>"`` parameter that will
     map the ``subscriber`` value under a dictionary ``holder`` that will be passed to the :class:`argparse.Namespace`.
     """
@@ -1991,7 +1991,7 @@ class SubscriberAction(argparse.Action):
         else:
             raise NotImplementedError(f"Cannot parse option: '{option}'")
         if not re.match(pattern, value):
-            raise argparse.ArgumentError(self, f"Value '{value} is a valid subscriber argument for '{option}'.")
+            raise argparse.ArgumentError(self, f"Value '{value}' is not a valid subscriber argument for '{option}'.")
 
 
 def add_subscribers_params(parser):
@@ -2051,6 +2051,7 @@ def add_subscribers_params(parser):
         metavar="URL",
         dest="subscribers.successUri",
         help=(
+            "Send an HTTP callback request to this URL if the job execution completed successfully.\n\n"
             "The request body will contain the JSON representation of the job results."
         )
     )

--- a/weaver/notify.py
+++ b/weaver/notify.py
@@ -37,14 +37,21 @@ def resolve_email_template(job, settings):
     """
     Finds the most appropriate Mako Template email notification file based on configuration and :term:`Job` context.
 
-    .. note::
-        The example template is used by default if the template directory is not overridden
-        (weaver/wps_restapi/templates/notification_email_example.mako).
+    The example template is used by default *ONLY* if the template directory was not overridden. If overridden, failing
+    to match any of the template file locations will raise to report the issue instead of silently using the default.
+
+    .. seealso::
+        https://github.com/crim-ca/weaver/blob/master/weaver/wps_restapi/templates/notification_email_example.mako
+
+    :raises IOError:
+        If the template directory was configured explicitly, but cannot be resolved, or if any of the possible
+        combinations of template file names cannot be resolved under that directory.
+    :returns: Matched template instance based on resolution order as described in the documentation.
     """
     template_dir = settings.get("weaver.wps_email_notify_template_dir") or ""
 
     # find appropriate template according to settings
-    if not os.path.isdir(template_dir):
+    if not template_dir and not os.path.isdir(template_dir):
         LOGGER.warning("No default email template directory configured. Using default template.")
         template_file = os.path.join(WEAVER_MODULE_DIR, "wps_restapi/templates/notification_email_example.mako")
         template = Template(filename=template_file)  # nosec: B702

--- a/weaver/notify.py
+++ b/weaver/notify.py
@@ -177,7 +177,7 @@ def map_job_subscribers(job_body, settings):
     definitions were not provided for the corresponding subscriber email fields.
     """
     notification_email = job_body.get("notification_email")
-    submit_subscribers = job_body.get("subscribers")
+    submit_subscribers = job_body.get("subscribers") or {}
     mapped_subscribers = {}
     for status, name, sub_type, alt in [
         (Status.STARTED, "inProgressEmail", "emails", None),

--- a/weaver/notify.py
+++ b/weaver/notify.py
@@ -47,7 +47,7 @@ def resolve_email_template(job, settings):
     if not os.path.isdir(template_dir):
         LOGGER.warning("No default email template directory configured. Using default template.")
         template_file = os.path.join(WEAVER_MODULE_DIR, "wps_restapi/templates/notification_email_example.mako")
-        template = Template(filename=template_file)
+        template = Template(filename=template_file)  # nosec: B702
     else:
         default_setting = "weaver.wps_email_notify_template_default"
         default_default = "default.mako"

--- a/weaver/notify.py
+++ b/weaver/notify.py
@@ -16,13 +16,13 @@ from weaver import WEAVER_MODULE_DIR
 from weaver.datatype import Job
 from weaver.processes.constants import JobInputsOutputsSchema
 from weaver.status import Status
-from weaver.utils import bytes2str, fully_qualified_name, get_settings, str2bytes, request_extra
+from weaver.utils import bytes2str, fully_qualified_name, get_settings, request_extra, str2bytes
 from weaver.wps_restapi.jobs.utils import get_results
 
 if TYPE_CHECKING:
     from typing import Optional
 
-    from weaver.typedefs import AnySettingsContainer, ExecutionSubscribers, SettingsType, JSON
+    from weaver.typedefs import AnySettingsContainer, ExecutionSubscribers, JSON, SettingsType
 
 LOGGER = logging.getLogger(__name__)
 

--- a/weaver/notify.py
+++ b/weaver/notify.py
@@ -51,7 +51,7 @@ def resolve_email_template(job, settings):
     else:
         default_setting = "weaver.wps_email_notify_template_default"
         default_default = "default.mako"
-        default_name = settings.get(default_setting, default_default)
+        default_name = settings.get(default_setting) or default_default
         process_name = f"{job.process!s}.mako"
         process_status_name = f"{job.process!s}/{job.status!s}.mako"
         default_template = os.path.join(template_dir, default_name)
@@ -84,7 +84,7 @@ def notify_job_email(job, to_email_recipient, container):
     port = settings.get("weaver.wps_email_notify_port")
     ssl = asbool(settings.get("weaver.wps_email_notify_ssl", True))
 
-    if not smtp_host or not port:
+    if not smtp_host or not port:  # pragma: no cover  # only raise to warn service manager
         # note: don't expose the values to avoid leaking them in logs
         raise ValueError(
             "The email server configuration is missing or incomplete. "

--- a/weaver/store/base.py
+++ b/weaver/store/base.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
         DatetimeIntervalType,
         ExecutionInputs,
         ExecutionOutputs,
+        ExecutionSubscribers,
         JSON,
         SettingsType,
         TypedDict
@@ -179,7 +180,7 @@ class StoreJobs(StoreInterface):
                  user_id=None,              # type: Optional[int]
                  access=None,               # type: Optional[AnyVisibility]
                  context=None,              # type: Optional[str]
-                 notification_email=None,   # type: Optional[str]
+                 subscribers=None,          # type: Optional[ExecutionSubscribers]
                  accept_language=None,      # type: Optional[str]
                  created=None,              # type: Optional[datetime.datetime]
                  ):                         # type: (...) -> Job

--- a/weaver/store/mongodb.py
+++ b/weaver/store/mongodb.py
@@ -78,8 +78,8 @@ if TYPE_CHECKING:
         AnyVersion,
         ExecutionInputs,
         ExecutionOutputs,
-        JSON,
-        SettingsType
+        ExecutionSubscribers,
+        JSON
     )
     from weaver.visibility import AnyVisibility
 
@@ -796,7 +796,7 @@ class MongodbJobStore(StoreJobs, MongodbStore, ListingMixin):
                  user_id=None,              # type: Optional[int]
                  access=None,               # type: Optional[AnyVisibility]
                  context=None,              # type: Optional[str]
-                 notification_email=None,   # type: Optional[str]
+                 subscribers=None,          # type: Optional[ExecutionSubscribers]
                  accept_language=None,      # type: Optional[str]
                  created=None,              # type: Optional[datetime.datetime]
                  ):                         # type: (...) -> Job
@@ -836,7 +836,7 @@ class MongodbJobStore(StoreJobs, MongodbStore, ListingMixin):
                 "tags": list(set(tags)),  # remove duplicates
                 "access": access,
                 "context": context,
-                "notification_email": notification_email,
+                "subscribers": subscribers,
                 "accept_language": accept_language,
             })
             self.collection.insert_one(new_job.params())

--- a/weaver/typedefs.py
+++ b/weaver/typedefs.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING  # pragma: no cover
 if TYPE_CHECKING:
     import os
     import sys
-    import typing
     import uuid
     from datetime import datetime
     from decimal import Decimal
@@ -413,6 +412,14 @@ if TYPE_CHECKING:
     JobOutputs = List[JobOutputItem]
     JobResults = List[JobValueItem]
     JobMonitorReference = Any  # typically a URI of the remote job status or an execution object/handler
+    JobSubscribers = TypedDict("JobSubscribers", {
+        "failedUri": NotRequired[str],
+        "successUri": NotRequired[str],
+        "inProgressUri": NotRequired[str],
+        "failedEmail": NotRequired[str],
+        "successEmail": NotRequired[str],
+        "inProgressEmail": NotRequired[str],
+    }, total=True)
 
     # when schema='weaver.processes.constants.ProcessSchema.OGC'
     ExecutionInputsMap = Dict[str, Union[JobValueObject, List[JobValueObject]]]
@@ -432,8 +439,10 @@ if TYPE_CHECKING:
     ExecutionOutputsMap = Dict[str, ExecutionOutputObject]
     ExecutionOutputs = Union[ExecutionOutputsList, ExecutionOutputsMap]
     ExecutionResultObjectRef = TypedDict("ExecutionResultObjectRef", {
-        "href": Optional[str],
+        "href": str,
         "type": NotRequired[str],
+        "title": NotRequired[str],
+        "rel": NotRequired[str],
     }, total=False)
     ExecutionResultObjectValue = TypedDict("ExecutionResultObjectValue", {
         "value": Optional[AnyValueType],
@@ -845,5 +854,6 @@ if TYPE_CHECKING:
         "response": NotRequired[AnyExecuteResponse],
         "inputs": NotRequired[ExecutionInputs],
         "outputs": NotRequired[ExecutionOutputs],
-        "notification_email": NotRequired[str],
+        "subscribers": NotRequired[JobSubscribers],
+        "notification_email": NotRequired[str],  # deprecated, backward-compatibility
     }, total=False)

--- a/weaver/typedefs.py
+++ b/weaver/typedefs.py
@@ -69,7 +69,7 @@ if TYPE_CHECKING:
     from weaver.execute import AnyExecuteControlOption, AnyExecuteMode, AnyExecuteResponse, AnyExecuteTransmissionMode
     from weaver.processes.constants import CWL_RequirementNames
     from weaver.processes.wps_process_base import WpsProcessInterface
-    from weaver.status import AnyStatusType
+    from weaver.status import AnyStatusType, StatusType
     from weaver.visibility import AnyVisibility
 
     Path = Union[os.PathLike, str, bytes]
@@ -443,6 +443,10 @@ if TYPE_CHECKING:
     ExecutionResultArray = List[ExecutionResultObject]
     ExecutionResultValue = Union[ExecutionResultObject, ExecutionResultArray]
     ExecutionResults = Dict[str, ExecutionResultValue]
+    ExecutionSubscribers = TypedDict("ExecutionSubscribers", {
+        "emails": NotRequired[Dict[StatusType, str]],
+        "callbacks": NotRequired[Dict[StatusType, str]],
+    }, total=True)
 
     # reference employed as 'JobMonitorReference' by 'WPS1Process'
     JobExecution = TypedDict("JobExecution", {"execution": WPSExecution})

--- a/weaver/wps_restapi/api.py
+++ b/weaver/wps_restapi/api.py
@@ -210,8 +210,7 @@ def get_conformance(category):
         f"{ogcapi_proc_core}/rec/job-list/next-1",
         f"{ogcapi_proc_core}/rec/job-list/next-2",
         f"{ogcapi_proc_core}/rec/job-list/next-3",
-        # FIXME: https://github.com/crim-ca/weaver/issues/230
-        # ogcapi_proc_core + "/req/callback/job-callback",
+        f"{ogcapi_proc_core}/req/callback/job-callback",
         f"{ogcapi_proc_core}/req/core",
         f"{ogcapi_proc_core}/req/core/api-definition-op",
         f"{ogcapi_proc_core}/req/core/api-definition-success",

--- a/weaver/wps_restapi/jobs/jobs.py
+++ b/weaver/wps_restapi/jobs/jobs.py
@@ -133,7 +133,7 @@ def get_job_status(request):
     Retrieve the status of a job.
     """
     job = get_job(request)
-    job_status = job.json(request, self_link="status")
+    job_status = job.json(request)
     return HTTPOk(json=job_status)
 
 

--- a/weaver/wps_restapi/jobs/utils.py
+++ b/weaver/wps_restapi/jobs/utils.py
@@ -326,7 +326,7 @@ def get_results(job,                                # type: Job
     :param schema:
         Selects which schema to employ for representing the output results (listing or mapping).
     :param link_references:
-        If enabled, an output that was requested by reference instead of value will be returned as ``Link`` reference.
+        If enabled, an output that was requested by reference instead of by value will be returned as ``Link`` header.
     :returns:
         Tuple with:
             - List or mapping of all outputs each with minimally an ID and value under the requested key.

--- a/weaver/wps_restapi/swagger_definitions.py
+++ b/weaver/wps_restapi/swagger_definitions.py
@@ -26,7 +26,7 @@ import duration
 import jsonschema
 import yaml
 from babel.numbers import list_currencies
-from colander import All, DateTime, Email, Length, Money, OneOf, Range, Regex, drop, null, required
+from colander import All, DateTime, Email as EmailRegex, Length, Money, OneOf, Range, Regex, drop, null, required
 from dateutil import parser as date_parser
 
 from weaver import WEAVER_SCHEMA_DIR, __meta__
@@ -357,6 +357,13 @@ class URL(ExtendedSchemaNode):
     schema_type = String
     description = "URL reference."
     format = "url"
+
+
+class Email(ExtendedSchemaNode):
+    schema_type = String
+    description = "Email recipient."
+    format = "email"
+    validator = EmailRegex()
 
 
 class MediaType(ExtendedSchemaNode):
@@ -1859,18 +1866,35 @@ class JobGroupsCommaSeparated(ExpandStringList, ExtendedSchemaNode):
 class JobExecuteSubscribers(ExtendedMappingSchema):
     _schema = f"{OGC_API_PROC_PART1_SCHEMAS}/subscriber.yaml"
     description = "Optional URIs for callbacks for this job."
+    # basic OGC subscribers
     success_uri = URL(
         name="successUri",
         description="Location where to POST the job results on successful completion.",
     )
-    process_uri = URL(
-        name="inProgressUri",
-        description="Location where to POST the job status once it starts running.",
-        missing=drop,
-    )
     failure_uri = URL(
         name="failedUri",
         description="Location where to POST the job status if it fails execution.",
+        missing=drop,
+    )
+    started_uri = URL(
+        name="inProgressUri",
+        description="Location where to POST the job status once it starts execution.",
+        missing=drop,
+    )
+    # additional subscribers
+    success_email = Email(
+        name="successEmail",
+        description="Email recipient to send a notification on successful job completion.",
+        missing=drop,
+    )
+    failure_email = Email(
+        name="failedEmail",
+        description="Email recipient to send a notification on failed job completion.",
+        missing=drop,
+    )
+    started_email = Email(
+        name="inProgressEmail",
+        description="Email recipient to send a notification of job status once it starts execution.",
         missing=drop,
     )
 
@@ -2311,7 +2335,7 @@ class OWSAddress(ExtendedMappingSchema, OWSNamespace):
     admin_area = OWSString(name="AdministrativeArea", title="AdministrativeArea", missing=drop)
     postal_code = OWSString(name="PostalCode", title="OWSPostalCode", example="A1B 2C3", missing=drop)
     email = OWSString(name="ElectronicMailAddress", title="OWSElectronicMailAddress",
-                      example="mail@me.com", validator=Email, missing=drop)
+                      example="mail@me.com", validator=EmailRegex, missing=drop)
 
 
 class OWSContactInfo(ExtendedMappingSchema, OWSNamespace):
@@ -3675,11 +3699,13 @@ class Execute(ExecuteInputOutputs):
         ),
         validator=OneOf(ExecuteResponse.values())
     )
-    notification_email = ExtendedSchemaNode(
-        String(),
+    notification_email = Email(
         missing=drop,
-        validator=Email(),
-        description="Optionally send a notification email when the job is done."
+        deprecated=True,
+        description=(
+            "Optionally send a notification email when the job is completed. "
+            "This is equivalent to using subscribers for both failed and successful job status emails simultaneously."
+        )
     )
     subscribers = JobExecuteSubscribers(missing=drop)
 

--- a/weaver/wps_restapi/swagger_definitions.py
+++ b/weaver/wps_restapi/swagger_definitions.py
@@ -1856,6 +1856,25 @@ class JobGroupsCommaSeparated(ExpandStringList, ExtendedSchemaNode):
     validator = StringOneOf(["process", "provider", "service", "status"], delimiter=",", case_sensitive=True)
 
 
+class JobExecuteSubscribers(ExtendedMappingSchema):
+    _schema = f"{OGC_API_PROC_PART1_SCHEMAS}/subscriber.yaml"
+    description = "Optional URIs for callbacks for this job."
+    success_uri = URL(
+        name="successUri",
+        description="Location where to POST the job results on successful completion.",
+    )
+    process_uri = URL(
+        name="inProgressUri",
+        description="Location where to POST the job status once it starts running.",
+        missing=drop,
+    )
+    failure_uri = URL(
+        name="failedUri",
+        description="Location where to POST the job status if it fails execution.",
+        missing=drop,
+    )
+
+
 class LaunchJobQuerystring(ExtendedMappingSchema):
     tags = JobTagsCommaSeparated()
 
@@ -3662,6 +3681,7 @@ class Execute(ExecuteInputOutputs):
         validator=Email(),
         description="Optionally send a notification email when the job is done."
     )
+    subscribers = JobExecuteSubscribers(missing=drop)
 
 
 class QuoteStatusSchema(ExtendedSchemaNode):

--- a/weaver/wps_restapi/templates/notification_email_example.mako
+++ b/weaver/wps_restapi/templates/notification_email_example.mako
@@ -1,29 +1,41 @@
-## -*- coding: utf-8 -*-
 <%doc>
-    This is an example notification message to be sent by email when a job is done
-    It is formatted using the Mako template library (https://www.makotemplates.org/)
+    This is an example notification message to be sent by email when a job is done.
+    It is formatted using the Mako template library (https://www.makotemplates.org/).
+    The content must also include the message header.
 
     The provided variables are:
-    job: a weaver.datatype.Job object
+    to: Recipient's address
+    job: weaver.datatype.Job object
+    settings: application settings
 
-    And every variable returned by the `weaver.wps_restapi.jobs.jobs.job_format_json` function:
-    status:           success, failure, etc
-    logs:             url to the logs
-    jobID:	          example "617f23d3-f474-47f9-a8ec-55da9dd6ac71"
-    result:           url to the outputs
-    duration:         example "0:01:02"
-    message:          example "Job succeeded."
-    percentCompleted: example "100"
+    And every variable returned by the `weaver.datatype.Job.json` method.
+    Below is a non-exhaustive list of example parameters from this method.
+    Refer to the method for complete listing.
+
+        status:           succeeded, failed, started
+        logs:             url to the logs
+        jobID:            example "617f23d3-f474-47f9-a8ec-55da9dd6ac71"
+        result:           url to the outputs
+        duration:         example "0:01:02"
+        message:          example "Job succeeded."
+        percentCompleted: example 100
 </%doc>
+From: Weaver
+To: ${to}
+Subject: Job ${job.process} ${job.status.title()}
+Content-Type: text/plain; charset=UTF-8
 
 Dear user,
 
-Your job submitted on ${job.created.strftime('%Y/%m/%d %H:%M %Z')} ${job.status}.
+Your job submitted on ${job.created.strftime("%Y/%m/%d %H:%M %Z")} to ${settings.get("weaver.url")} ${job.status}.
 
-% if job.status == 'succeeded':
-You can retrieve the output(s) at the following link: ${result}
+% if job.status == "succeeded":
+You can retrieve the output(s) at the following link: ${job.results_url(settings)}
+% elif job.status == "failed":
+You can retrieve potential error details from the following link: ${job.exceptions_url(settings)}
 % endif
 
-The logs are available here: ${logs}
+The job logs are available at the following link: ${job.logs_url(settings)}
 
 Regards,
+Weaver


### PR DESCRIPTION
## Changes

- Add `Job` ``subscribers`` support to define `OGC`-compliant callback URLs where HTTP(S) requests will be sent upon
  reaching certain `Job` status milestones (fixes #230).
- Add email notification support to the new ``subscribers`` definition (extension over `OGC` minimal requirements).
- Deprecate `Job` ``notification_email`` in the `OpenAPI` specification in favor of ``subscribers``, but preserve
  parsing of its value if provided in the `JSON` body during `Job` submission for backward compatibility support of
  existing servers. The ``Job.notification_email`` attribute is removed to avoid duplicate references.
- Add notification email for `Job` ``started`` status, only available through the ``subscribers`` property.
- Add ``{PROCESS_ID}/{STATUS}.mako`` template detection under the ``weaver.wps_email_notify_template_dir`` location
  to allow per-`Process` and per-`Job` status email customization.
- Refactor ``weaver/notify.py`` and ``weaver/processes/execution.py`` to avoid mixed references to the
  encryption/decryption logic employed for notification emails. All notifications including emails and
  callback requests are now completely handled and contained in the ``weaver/notify.py`` module.
- Remove partially duplicate Mako Template definition as hardcoded string and separate file for email notification.

## References

- Relates to https://github.com/opengeospatial/ogcapi-processes/issues/366
- Relates to #571
- Relates to #568 
- Fixes #230

