### PR TITLE
add alternative executionUnit formats to support OGC-API schemas

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1562,7 +1562,8 @@ Fixes:
   file path explicitly instead of returning an invalid directory.
 - Fix `CWL` package path resolution under Windows incorrectly parsed partition as URL protocol.
 - Fix ``AttributeError`` of ``pywps.inout.formats.Format`` equality check compared to ``null`` object (using getter
-  patch on ``null`` since fix `#507 <https://github.com/geopython/pywps/pull/507>`_ not released at this point).
+  patch on ``null`` since fix `geopython/pywps#507 <https://github.com/geopython/pywps/pull/507>`_ not released at
+  this point).
 - Fix potential invalid database state that could have saved an invalid process although the following
   ``ProcessSummary`` schema validation would fail and return ``HTTPBadRequest [400]``. The process is now saved only
   after complete and successful schema validation.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1312,7 +1312,7 @@ Changes:
   operation of pre-existing processes. When those fields are detected, they are converted inplace in favor of their
   corresponding new names aligned with `OGC-API`.
 - Update ``mimeType`` to ``mediaType`` as format type representation according to `OGC-API`
-  (relates to `#211  <https://github.com/crim-ca/weaver/issues/211>`_).
+  (relates to `#211 <https://github.com/crim-ca/weaver/issues/211>`_).
 - Add explicit pattern validation (``type/subtype``) of format string definitions with ``MediaType`` schema.
 - Add sorting capability to generate mapping schemas for API responses using overrides of
   properties ``_sort_first`` and ``_sort_after`` using lists of desired ordered field names.
@@ -1338,7 +1338,7 @@ Changes:
   URL formatted strings are allowed, or alternatively an explicit JSON definition. Previous definitions that would
   indicate an empty string schema are dropped since ``schema`` is optional.
 - Block unknown and ``builtin`` process types during deployment from the API
-  (fixes `#276  <https://github.com/crim-ca/weaver/issues/276>`_).
+  (fixes `#276 <https://github.com/crim-ca/weaver/issues/276>`_).
   Type ``builtin`` can only be registered by `Weaver` itself at startup. Other unknown types that have
   no indication for mapping to an appropriate ``Process`` implementation are preemptively validated.
 - Add parsing and generation of additional ``literalDataDomains`` for specification of WPS I/O data constrains and
@@ -1358,7 +1358,7 @@ Fixes:
 - Fix `#203 <https://github.com/crim-ca/weaver/issues/203>`_ with explicit validation test of ``ProcessSummary``
   schema for providers response.
 - Fix failing ``minOccurs`` and ``maxOccurs`` generation from a remote provider ``Process`` to support `OGC-API` format
-  (relates to `#263  <https://github.com/crim-ca/weaver/issues/263>`_).
+  (relates to `#263 <https://github.com/crim-ca/weaver/issues/263>`_).
 - Fix schemas references and apply deserialization to providers listing request.
 - Fix failing deserialization of ``variable`` children schema under mapping when this variable element is allowed
   to be undefined (i.e.: defined with ``missing=drop``). Allows support of empty ``inputs`` mapping of `OGC-API`
@@ -1437,7 +1437,7 @@ Changes:
 Fixes:
 ------
 - Fix ``minOccurs`` and ``maxOccurs`` representation according to `OGC-API`
-  (fixes `#263  <https://github.com/crim-ca/weaver/issues/263>`_).
+  (fixes `#263 <https://github.com/crim-ca/weaver/issues/263>`_).
 - Fixed the format of the output file URL. When the prefix ``/`` was not present,
   URL was incorrectly handled by not prepending the required base URL location.
 
@@ -1473,12 +1473,12 @@ Changes:
 Fixes:
 ------
 - Pin ``pywps==4.4.3`` and fix incompatibility introduced by its refactor of I/O base classes in
-  `#602 <https://github.com/geopython/pywps/pull/602>`_
+  `geopython/pywps#602 <https://github.com/geopython/pywps/pull/602>`_
   (specifically `commit 343d825 <https://github.com/geopython/pywps/commit/343d82539576b1e73eee3102654749c3d3137cff>`_),
   which broke the ``ComplexInput`` work-around to avoid useless of file URLs
-  (see issue `#526 <https://github.com/geopython/pywps/issues/526>`_).
+  (see issue `geopython/pywps#526 <https://github.com/geopython/pywps/issues/526>`_).
 - Fix default execution mode specification in process job control options
-  (fixes `#182 <https://github.com/opengeospatial/ogcapi-processes/pull/182>`_).
+  (fixes `opengeospatial/ogcapi-processes#182 <https://github.com/opengeospatial/ogcapi-processes/pull/182>`_).
 - Fix old OGC-API WPS REST bindings link in landing page for the more recent `OGC-API Processes` specification.
 - Fix invalid deserialization of schemas using ``not`` keyword that would result in all fields returned instead of
   limiting them to the expected fields from the schema definitions for ``LiteralInputType`` in process description.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,7 +12,14 @@ Changes
 
 Changes:
 --------
-- No change.
+- Support alternative representations from `OGC API - Processes` schemas for ``executionUnit`` definition
+  during `Process` deployment. The *unit* does not need to be nested under ``unit`` or a list anymore, and can instead
+  be directly provided as `JSON` mapping. For backward compatibility, the previous list representation is still allowed
+  (fixes `#507 <https://github.com/crim-ca/weaver/issues/507>`_).
+- Support an additional ``type`` property along a ``unit`` item describing an ``executionUnit`` to specify an IANA
+  Media-Type that categories the ``unit`` contents, similarly to how it could be provided for its ``href`` counterpart.
+  For the moment, only `CWL`-based ``unit`` are supported, but this could allow future extensions to provide alternate
+  representations of an `Application Package`.
 
 Fixes:
 ------

--- a/tests/wps_restapi/test_processes.py
+++ b/tests/wps_restapi/test_processes.py
@@ -1064,7 +1064,7 @@ class WpsRestApiProcessesTest(unittest.TestCase):
             p_id = "test-docker-python-version"
             body = {
                 "processDescription": {"process": {"id": p_id}},
-                "executionUnit": {"unit": cwl, "type": ContentType.APP_JSON},
+                "executionUnit": {"unit": cwl, "type": ContentType.APP_CWL_JSON},
                 "deploymentProfileName": "http://www.opengis.net/profiles/eoc/dockerizedApplication",
             }
             desc = self.deploy_process_make_visible_and_fetch_deployed(body, p_id, assert_io=False)

--- a/tests/wps_restapi/test_processes.py
+++ b/tests/wps_restapi/test_processes.py
@@ -1018,6 +1018,82 @@ class WpsRestApiProcessesTest(unittest.TestCase):
                 "formats": [{"default": True, "mediaType": "text/plain"}]
             }]
 
+    def test_deploy_process_CWL_DockerRequirement_executionUnit_DirectUnit(self):
+        with contextlib.ExitStack() as stack:
+            stack.enter_context(mocked_wps_output(self.settings))
+            cwl = self.get_cwl_docker_python_version()
+
+            p_id = "test-docker-python-version"
+            body = {
+                "processDescription": {"process": {"id": p_id}},
+                "executionUnit": cwl,
+                "deploymentProfileName": "http://www.opengis.net/profiles/eoc/dockerizedApplication",
+            }
+            desc = self.deploy_process_make_visible_and_fetch_deployed(body, p_id, assert_io=False)
+            pkg = self.get_application_package(p_id)
+            assert desc["deploymentProfile"] == "http://www.opengis.net/profiles/eoc/dockerizedApplication"
+
+            # once parsed, CWL I/O are converted to listing form
+            # rest should remain intact with the original definition
+            cwl["inputs"] = []
+            cwl_out = cwl["outputs"]["output"]
+            cwl_out["id"] = "output"
+            cwl["outputs"] = [cwl_out]
+            cwl.pop("$schema", None)
+            cwl.pop("$id", None)
+            pkg.pop("$schema", None)
+            pkg.pop("$id", None)
+            assert pkg == cwl
+
+            # process description should have been generated with relevant I/O
+            proc = desc["process"]
+            assert proc["id"] == p_id
+            assert proc["inputs"] == []
+            assert proc["outputs"] == [{
+                "id": "output",
+                "title": "output",
+                "schema": {"type": "string", "contentMediaType": "text/plain"},
+                "formats": [{"default": True, "mediaType": "text/plain"}]
+            }]
+
+    def test_deploy_process_CWL_DockerRequirement_executionUnit_UnitWithMediaType(self):
+        with contextlib.ExitStack() as stack:
+            stack.enter_context(mocked_wps_output(self.settings))
+            cwl = self.get_cwl_docker_python_version()
+
+            p_id = "test-docker-python-version"
+            body = {
+                "processDescription": {"process": {"id": p_id}},
+                "executionUnit": {"unit": cwl, "type": ContentType.APP_JSON},
+                "deploymentProfileName": "http://www.opengis.net/profiles/eoc/dockerizedApplication",
+            }
+            desc = self.deploy_process_make_visible_and_fetch_deployed(body, p_id, assert_io=False)
+            pkg = self.get_application_package(p_id)
+            assert desc["deploymentProfile"] == "http://www.opengis.net/profiles/eoc/dockerizedApplication"
+
+            # once parsed, CWL I/O are converted to listing form
+            # rest should remain intact with the original definition
+            cwl["inputs"] = []
+            cwl_out = cwl["outputs"]["output"]
+            cwl_out["id"] = "output"
+            cwl["outputs"] = [cwl_out]
+            cwl.pop("$schema", None)
+            cwl.pop("$id", None)
+            pkg.pop("$schema", None)
+            pkg.pop("$id", None)
+            assert pkg == cwl
+
+            # process description should have been generated with relevant I/O
+            proc = desc["process"]
+            assert proc["id"] == p_id
+            assert proc["inputs"] == []
+            assert proc["outputs"] == [{
+                "id": "output",
+                "title": "output",
+                "schema": {"type": "string", "contentMediaType": "text/plain"},
+                "formats": [{"default": True, "mediaType": "text/plain"}]
+            }]
+
     def test_deploy_process_CWL_CudaRequirement_executionUnit(self):
         with contextlib.ExitStack() as stack:
             stack.enter_context(mocked_wps_output(self.settings))

--- a/weaver/processes/utils.py
+++ b/weaver/processes/utils.py
@@ -239,7 +239,7 @@ def _check_deploy(payload):
         r_exec_unit = results.get("executionUnit", [{}])
         if p_exec_unit and p_exec_unit != r_exec_unit:
             message = "Process deployment execution unit is invalid."
-            d_exec_unit = sd.ExecutionUnitList(
+            d_exec_unit = sd.ExecutionUnitVariations(
                 schema_meta_include=False,
                 schema_include=False,
             ).deserialize(p_exec_unit)  # raises directly if caused by invalid schema
@@ -400,7 +400,11 @@ def deploy_process_from_payload(payload, container, overwrite=False):  # pylint:
             if not any(deployment_profile_name.lower().endswith(typ) for typ in allowed_profile_suffix):
                 raise HTTPBadRequest("Invalid value for parameter 'deploymentProfileName'.")
         execution_units = payload.get("executionUnit")
-        if not isinstance(execution_units, list):
+        if isinstance(execution_units, dict):
+            if list(execution_units) != ["unit"]:
+                execution_units = {"unit": execution_units}
+            execution_units = [execution_units]
+        if not isinstance(execution_units, list) or not len(execution_units) == 1:
             raise HTTPUnprocessableEntity("Invalid parameter 'executionUnit'.")
         for execution_unit in execution_units:
             if not isinstance(execution_unit, dict):

--- a/weaver/processes/utils.py
+++ b/weaver/processes/utils.py
@@ -401,7 +401,7 @@ def deploy_process_from_payload(payload, container, overwrite=False):  # pylint:
                 raise HTTPBadRequest("Invalid value for parameter 'deploymentProfileName'.")
         execution_units = payload.get("executionUnit")
         if isinstance(execution_units, dict):
-            if list(execution_units) != ["unit"]:
+            if "unit" not in execution_units:
                 execution_units = {"unit": execution_units}
             execution_units = [execution_units]
         if not isinstance(execution_units, list) or not len(execution_units) == 1:

--- a/weaver/typedefs.py
+++ b/weaver/typedefs.py
@@ -826,12 +826,17 @@ if TYPE_CHECKING:
     ProcessDescriptionListing = Union[ProcessOfferingListing, ProcessDescriptionNestedListing]
     ProcessDescription = Union[ProcessDescriptionMapping, ProcessDescriptionListing]
 
-    ExecutionUnitItem = TypedDict("ExecutionUnitItem", {
+    ExecutionUnitNested = TypedDict("ExecutionUnitNested", {
         "unit": CWL
     }, total=True)
+    ExecutionUnitItem = Union[CWL, ExecutionUnitNested, Link]
+    ExecutionUnit = Union[
+        ExecutionUnitItem,
+        List[ExecutionUnitItem],
+    ]
     ProcessDeployment = TypedDict("ProcessDeployment", {
         "processDescription": ProcessDescription,
-        "executionUnit": List[Union[ExecutionUnitItem, Link]],
+        "executionUnit": ExecutionUnit,
         "immediateDeployment": NotRequired[bool],
         "deploymentProfileName": str,
     }, total=True)


### PR DESCRIPTION
## changes

- Support alternative representations from `OGC API - Processes` schemas for ``executionUnit`` definition
  during `Process` deployment. The *unit* does not need to be nested under ``unit`` or a list anymore, and can instead
  be directly provided as `JSON` mapping. For backward compatibility, the previous list representation is still allowed
  (fixes #507).
- Support an additional ``type`` property along a ``unit`` item describing an ``executionUnit`` to specify an IANA
  Media-Type that categories the ``unit`` contents, similarly to how it could be provided for its ``href`` counterpart.
  For the moment, only `CWL`-based ``unit`` are supported, but this could allow future extensions to provide alternate
  representations of an `Application Package`.