### PR TITLE
update conformance links, schema references, and align reqs with OGC locations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ Changes
 
 Changes:
 --------
+- Add ``alternate`` references, as ``Link`` header and within the `JSON` content ``links`` property when applicable, in
+  the returned `Process` description response to refer between the `XML` and the corresponding `JSON` representations.
 - Support alternative representations from `OGC API - Processes` schemas for ``executionUnit`` definition
   during `Process` deployment. The *unit* does not need to be nested under ``unit`` or a list anymore, and can instead
   be directly provided as `JSON` mapping. For backward compatibility, the previous list representation is still allowed
@@ -39,6 +41,8 @@ Changes:
 
 Fixes:
 ------
+- Fix inconsistent or missing schema references to updated `OGC` schema locations, and align their based URL locations
+  for corresponding ``/conformance`` endpoint reporting.
 - Fix auto-insertion of ``$schema`` and ``$id`` URI references into `JSON` schema and their data content representation.
   When in `OpenAPI` context, schemas now correctly report their ``$id`` as the reference schema they represent (usually
   from external `OGC` schema references), and ``$schema`` as the `JSON` meta-schema. When representing `JSON` data

--- a/weaver/datatype.py
+++ b/weaver/datatype.py
@@ -2403,6 +2403,8 @@ class Process(Base):
         proc_self = f"{proc_list}/{self.tag}" if self.version else proc_desc
         links = [
             {"href": proc_self, "rel": "self", "title": "Current process description."},
+            {"href": f"{proc_desc}?f=xml", "rel": "alternate",
+             "title": "Alternate process description.", "type": ContentType.APP_XML},
             {"href": proc_desc, "rel": "process-meta", "title": "Process definition."},
             {"href": proc_exec, "rel": "http://www.opengis.net/def/rel/ogc/1.0/execute",
              "title": "Process execution endpoint for job submission."},

--- a/weaver/wps_restapi/api.py
+++ b/weaver/wps_restapi/api.py
@@ -322,8 +322,7 @@ def get_conformance(category):
         f"{ogcapi_proc_part2}/req/deploy-replace-undeploy/undeploy/response",
         f"{ogcapi_proc_part2}/req/deploy-replace-undeploy/ogcapppkg",
         # FIXME: below partially, for full Part 3, would need $graph support
-        # (see https://github.com/crim-ca/weaver/issues/56) 
-        # and below 'f"{ogcapi_proc_apppkg}/conf/app-pck/cwl"'
+        # (see https://github.com/crim-ca/weaver/issues/56 and below '/conf/app-pck/cwl')
         f"{ogcapi_proc_part3}/req/cwl-workflows",
         f"{ogcapi_proc_part3}/conf/cwl-workflows",
         # FIXME: support part 3: workflows (https://github.com/crim-ca/weaver/issues/412)

--- a/weaver/wps_restapi/api.py
+++ b/weaver/wps_restapi/api.py
@@ -64,9 +64,10 @@ def get_conformance(category):
 
     ows_wps1 = "http://schemas.opengis.net/wps/1.0.0"
     ows_wps2 = "http://www.opengis.net/spec/WPS/2.0"
-    ogcapi_common = "http://www.opengis.net/spec/ogcapi-common-2/1.0"
+    ogcapi_common = "http://www.opengis.net/spec/ogcapi-common-1/1.0"
     ogcapi_proc_core = "http://www.opengis.net/spec/ogcapi-processes-1/1.0"
     ogcapi_proc_part2 = "http://www.opengis.net/spec/ogcapi-processes-2/1.0"
+    ogcapi_proc_part3 = "http://www.opengis.net/spec/ogcapi-processes-3/0.0"
     ogcapi_proc_apppkg = "http://www.opengis.net/spec/eoap-bp/1.0"
     # FIXME: https://github.com/crim-ca/weaver/issues/412
     # ogcapi_proc_part3 = "http://www.opengis.net/spec/ogcapi-processes-3/1.0"
@@ -320,14 +321,37 @@ def get_conformance(category):
         f"{ogcapi_proc_part2}/req/deploy-replace-undeploy/undeploy/delete-op",
         f"{ogcapi_proc_part2}/req/deploy-replace-undeploy/undeploy/response",
         f"{ogcapi_proc_part2}/req/deploy-replace-undeploy/ogcapppkg",
-        # FIXME: support part 3: workflows (?)
-        #   https://github.com/crim-ca/weaver/issues/412
-        # ogcapi_proc_part3 + "/req/workflows",
-        # ogcapi_proc_part3 + "/req/workflows/collection/body",
-        # ogcapi_proc_part3 + "/req/workflows/collection/content-type",
-        # ogcapi_proc_part3 + "/req/workflows/collection/post-op",
-        # ogcapi_proc_part3 + "/req/workflows/collection/response-body",
-        # ogcapi_proc_part3 + "/req/workflows/collection/response",
+        # FIXME: below partially, for full Part 3, would need $graph support
+        # (see https://github.com/crim-ca/weaver/issues/56) 
+        # and below 'f"{ogcapi_proc_apppkg}/conf/app-pck/cwl"'
+        f"{ogcapi_proc_part3}/req/cwl-workflows",
+        f"{ogcapi_proc_part3}/conf/cwl-workflows",
+        # FIXME: support part 3: workflows (https://github.com/crim-ca/weaver/issues/412)
+        # f"{ogcapi_proc_part3}/conf/nested-processes",
+        # f"{ogcapi_proc_part3}/conf/remote-core-processes",
+        # f"{ogcapi_proc_part3}/conf/collection-input",
+        # f"{ogcapi_proc_part3}/conf/remote-collections",
+        # f"{ogcapi_proc_part3}/conf/input-fields-modifiers",
+        # f"{ogcapi_proc_part3}/conf/output-fields-modifiers",
+        # f"{ogcapi_proc_part3}/conf/deployable-workflows",
+        # f"{ogcapi_proc_part3}/conf/collection-output",
+        # f"{ogcapi_proc_part3}/req/collection-input",
+        # f"{ogcapi_proc_part3}/req/collection-output",
+        # f"{ogcapi_proc_part3}/req/deployable-workflows",
+        # f"{ogcapi_proc_part3}/req/input-fields-modifiers",
+        # f"{ogcapi_proc_part3}/req/output-fields-modifiers",
+        # f"{ogcapi_proc_part3}/req/nested-processes",
+        # f"{ogcapi_proc_part3}/req/remote-collections",
+        # f"{ogcapi_proc_part3}/req/remote-core-processes",
+        # f"{ogcapi_proc_part3}/req/workflows",
+        # f"{ogcapi_proc_part3}/req/workflows/collection/body",
+        # f"{ogcapi_proc_part3}/req/workflows/collection/content-type",
+        # f"{ogcapi_proc_part3}/req/workflows/collection/post-op",
+        # f"{ogcapi_proc_part3}/req/workflows/collection/response-body",
+        # f"{ogcapi_proc_part3}/req/workflows/collection/response",
+        # FIXME: support openEO processes (https://github.com/crim-ca/weaver/issues/564)
+        # f"{ogcapi_proc_part3}/conf/openeo-workflows",
+        # f"{ogcapi_proc_part3}/req/openeo-workflows",
         # FIXME: https://github.com/crim-ca/weaver/issues/156  (billing/quotation)
         # https://github.com/opengeospatial/ogcapi-processes/tree/master/extensions/billing
         # https://github.com/opengeospatial/ogcapi-processes/tree/master/extensions/quotation
@@ -343,21 +367,21 @@ def get_conformance(category):
         f"{ogcapi_proc_apppkg}/conf/app-stage-in",
         f"{ogcapi_proc_apppkg}/req/app-stage-in",
         # FIXME: Support for STAC metadata (https://github.com/crim-ca/weaver/issues/103)
-        # ogcapi_proc_apppkg + "/conf/app/stac-input",
-        # ogcapi_proc_apppkg + "/req/app/stac-input",
+        # f"{ogcapi_proc_apppkg}/conf/app/stac-input",
+        # f"{ogcapi_proc_apppkg}/req/app/stac-input",
         f"{ogcapi_proc_apppkg}/conf/app-stage-out",
         f"{ogcapi_proc_apppkg}/req/app-stage-out",
-        # ogcapi_proc_apppkg + "/req/app/stac-out",
-        # ogcapi_proc_apppkg + "/conf/app/stac-out",
-        # ogcapi_proc_apppkg + "/rec/app/stac-out-metadata",
-        # ogcapi_proc_apppkg + "/rec/conf/stac-out-metadata",
+        # f"{ogcapi_proc_apppkg}/req/app/stac-out",
+        # f"{ogcapi_proc_apppkg}/conf/app/stac-out",
+        # f"{ogcapi_proc_apppkg}/rec/app/stac-out-metadata",
+        # f"{ogcapi_proc_apppkg}/rec/conf/stac-out-metadata",
         f"{ogcapi_proc_apppkg}/conf/app-pck",
         f"{ogcapi_proc_apppkg}/req/app-pck",
         # FIXME: Support embedded step definition in CWL (https://github.com/crim-ca/weaver/issues/56)
         #   Allow definition of a '$graph' with list of Workflow + >=1 CommandLineTool all together
         #   see: https://docs.ogc.org/bp/20-089r1.html#toc28
-        # ogcapi_proc_apppkg + "/conf/app-pck/cwl",
-        # ogcapi_proc_apppkg + "/req/app-pck/cwl",
+        # f"{ogcapi_proc_apppkg}/conf/app-pck/cwl",
+        # f"{ogcapi_proc_apppkg}/req/app-pck/cwl",
         f"{ogcapi_proc_apppkg}/req/app-pck/clt",
         f"{ogcapi_proc_apppkg}/req/app-pck/wf",
         f"{ogcapi_proc_apppkg}/req/app-pck/wf-inputs",
@@ -367,11 +391,11 @@ def get_conformance(category):
         f"{ogcapi_proc_apppkg}/req/app-pck-stage-in",
         # FIXME: Support for STAC metadata (https://github.com/crim-ca/weaver/issues/103)
         #   not sure about requirement: "staging of EO products SHALL be of type 'Directory'."
-        # ogcapi_proc_apppkg + "/req/app-pck-stage-in/clt-stac",
-        # ogcapi_proc_apppkg + "/req/app-pck-stage-in/wf-stac",
+        # f"{ogcapi_proc_apppkg}/req/app-pck-stage-in/clt-stac",
+        # f"{ogcapi_proc_apppkg}/req/app-pck-stage-in/wf-stac",
         f"{ogcapi_proc_apppkg}/conf/app-pck-stage-out",
         f"{ogcapi_proc_apppkg}/req/app-pck-stage-out",
-        # ogcapi_proc_apppkg + "/req/app-pck-stage-out/output-stac"
+        # f"{ogcapi_proc_apppkg}/req/app-pck-stage-out/output-stac"
         f"{ogcapi_proc_apppkg}/conf/plt",
         f"{ogcapi_proc_apppkg}/req/plt",
         f"{ogcapi_proc_apppkg}/req/plt/api",
@@ -380,11 +404,11 @@ def get_conformance(category):
         f"{ogcapi_proc_apppkg}/conf/plt-stage-in",
         f"{ogcapi_proc_apppkg}/req/plt-stage-in",
         # FIXME: Support for STAC metadata (https://github.com/crim-ca/weaver/issues/103)
-        # ogcapi_proc_apppkg + "/req/plt-stage-in/input-stac",
-        # ogcapi_proc_apppkg + "/req/plt-stage-in/stac-stage",
+        # f"{ogcapi_proc_apppkg}/req/plt-stage-in/input-stac",
+        # f"{ogcapi_proc_apppkg}/req/plt-stage-in/stac-stage",
         f"{ogcapi_proc_apppkg}/conf/plt-stage-out",
         f"{ogcapi_proc_apppkg}/req/plt-stage-out",
-        # ogcapi_proc_apppkg + "/req/plt-stage-out/stac-stage",
+        # f"{ogcapi_proc_apppkg}/req/plt-stage-out/stac-stage",
     ]
     if category not in [None, ConformanceCategory.ALL]:
         cat = f"/{category}/"

--- a/weaver/wps_restapi/swagger_definitions.py
+++ b/weaver/wps_restapi/swagger_definitions.py
@@ -167,8 +167,8 @@ OGC_API_PROC_PART1_SCHEMAS = f"{OGC_API_PROC_PART1_BASE}/openapi/schemas"
 OGC_API_PROC_PART1_RESPONSES = f"{OGC_API_PROC_PART1_BASE}/openapi/responses"
 OGC_API_PROC_PART1_PARAMETERS = f"{OGC_API_PROC_PART1_BASE}/openapi/parameters"
 OGC_API_PROC_PART1_EXAMPLES = f"{OGC_API_PROC_PART1_BASE}/examples"
-OGC_WPS_1_BASE = f"{OGC_API_SCHEMAS_URL}/wps/1.0.0"
-OGC_WPS_2_BASE = f"{OGC_API_SCHEMAS_URL}/wps/2.0"
+OGC_WPS_1_SCHEMAS = f"{OGC_API_SCHEMAS_URL}/wps/1.0.0"
+OGC_WPS_2_SCHEMAS = f"{OGC_API_SCHEMAS_URL}/wps/2.0"
 
 WEAVER_SCHEMA_VERSION = "master"
 WEAVER_SCHEMA_URL = f"https://raw.githubusercontent.com/crim-ca/weaver/{WEAVER_SCHEMA_VERSION}/weaver/schemas"
@@ -2194,14 +2194,14 @@ class WPSOperationGetNoContent(ExtendedMappingSchema):
 
 
 class WPSOperationPost(ExtendedMappingSchema):
-    _schema = "http://schemas.opengis.net/wps/1.0.0/common/RequestBaseType.xsd"
+    _schema = f"{OGC_WPS_1_SCHEMAS}/common/RequestBaseType.xsd"
     accepted_versions = OWSAcceptVersions(missing=drop, default="1.0.0")
     language = OWSLanguageAttribute(missing=drop)
     service = OWSService()
 
 
 class WPSGetCapabilitiesPost(WPSOperationPost, WPSNamespace):
-    _schema = "http://schemas.opengis.net/wps/1.0.0/wpsGetCapabilities_request.xsd"
+    _schema = f"{OGC_WPS_1_SCHEMAS}/wpsGetCapabilities_request.xsd"
     name = "GetCapabilities"
     title = "GetCapabilities"
 
@@ -2243,7 +2243,7 @@ class OWSMetadata(ExtendedSequenceSchema, OWSNamespace):
 
 
 class WPSDescribeProcessPost(WPSOperationPost, WPSNamespace):
-    _schema = "http://schemas.opengis.net/wps/1.0.0/wpsDescribeProcess_request.xsd"
+    _schema = f"{OGC_WPS_1_SCHEMAS}/wpsDescribeProcess_request.xsd"
     name = "DescribeProcess"
     title = "DescribeProcess"
     identifier = OWSIdentifierList(
@@ -2260,7 +2260,7 @@ class WPSExecuteDataInputs(ExtendedMappingSchema, WPSNamespace):
 
 
 class WPSExecutePost(WPSOperationPost, WPSNamespace):
-    _schema = "http://schemas.opengis.net/wps/1.0.0/wpsExecute_request.xsd"
+    _schema = f"{OGC_WPS_1_SCHEMAS}/wpsExecute_request.xsd"
     name = "Execute"
     title = "Execute"
     identifier = OWSIdentifier(description="Identifier of the process to execute with data inputs.")
@@ -2368,7 +2368,7 @@ class OWSServiceProvider(ExtendedMappingSchema, OWSNamespace):
 
 
 class WPSDescriptionType(ExtendedMappingSchema, OWSNamespace):
-    _schema = "http://schemas.opengis.net/wps/1.0.0/common/DescriptionType.xsd"
+    _schema = f"{OGC_WPS_1_SCHEMAS}/common/DescriptionType.xsd"
     name = "DescriptionType"
     _title = OWSTitle(description="Title of the service.", example="Weaver")
     abstract = OWSAbstract(description="Detail about the service.", example="Weaver WPS example schema.", missing=drop)
@@ -2462,14 +2462,14 @@ class WPSLanguageSpecification(ExtendedMappingSchema, WPSNamespace):
 
 
 class WPSResponseBaseType(PermissiveMappingSchema, WPSNamespace):
-    _schema = "http://schemas.opengis.net/wps/1.0.0/common/ResponseBaseType.xsd"
+    _schema = f"{OGC_WPS_1_SCHEMAS}/common/ResponseBaseType.xsd"
     service = WPSServiceAttribute()
     version = WPSVersionAttribute()
     lang = WPSLanguageAttribute()
 
 
 class WPSProcessVersion(ExtendedSchemaNode, WPSNamespace):
-    _schema = "http://schemas.opengis.net/wps/1.0.0/common/ProcessVersion.xsd"
+    _schema = f"{OGC_WPS_1_SCHEMAS}/common/ProcessVersion.xsd"
     schema_type = String
     description = "Release version of this Process."
     name = "processVersion"
@@ -2591,7 +2591,7 @@ class ProcessOutputs(ExtendedSequenceSchema, WPSNamespace):
 
 
 class WPSGetCapabilities(WPSResponseBaseType):
-    _schema = "http://schemas.opengis.net/wps/1.0.0/wpsGetCapabilities_response.xsd"
+    _schema = f"{OGC_WPS_1_SCHEMAS}/wpsGetCapabilities_response.xsd"
     name = "Capabilities"
     title = "Capabilities"  # not to be confused by 'GetCapabilities' used for request
     svc = OWSServiceIdentification()
@@ -2618,7 +2618,7 @@ class WPSProcessDescriptionList(ExtendedSequenceSchema, WPSNamespace):
 
 
 class WPSDescribeProcess(WPSResponseBaseType):
-    _schema = "http://schemas.opengis.net/wps/1.0.0/wpsDescribeProcess_response.xsd"
+    _schema = f"{OGC_WPS_1_SCHEMAS}/wpsDescribeProcess_response.xsd"
     name = "DescribeProcess"
     title = "DescribeProcess"
     process = WPSProcessDescriptionList()
@@ -2733,7 +2733,7 @@ class WPSProcessOutputs(ExtendedSequenceSchema, WPSNamespace):
 
 
 class WPSExecuteResponse(WPSResponseBaseType, WPSProcessVersion):
-    _schema = "http://schemas.opengis.net/wps/1.0.0/wpsExecute_response.xsd"
+    _schema = f"{OGC_WPS_1_SCHEMAS}/wpsExecute_response.xsd"
     name = "ExecuteResponse"
     title = "ExecuteResponse"  # not to be confused by 'Execute' used for request
     location = WPSStatusLocationAttribute()
@@ -3163,7 +3163,7 @@ class ProcessSummary(
     """
     Summary process definition.
     """
-    _schema = f"{OGC_API_SCHEMA_CORE}/processSummary.yaml"
+    _schema = f"{OGC_API_PROC_PART1_SCHEMAS}/processSummary.yaml"
     _sort_first = PROCESS_DESCRIPTION_FIELD_FIRST
     _sort_after = PROCESS_DESCRIPTION_FIELD_AFTER
 
@@ -5184,7 +5184,7 @@ class VersionsSchema(ExtendedMappingSchema):
 
 class ConformanceList(ExtendedSequenceSchema):
     conformance = URL(description="Conformance specification link.",
-                      example="http://www.opengis.net/spec/WPS/2.0/req/service/binding/rest-json/core")
+                      example="http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/core")
 
 
 class ConformanceSchema(ExtendedMappingSchema):


### PR DESCRIPTION
## Chanages 

- Add ``alternate`` references, as ``Link`` header and within the `JSON` content ``links`` property when applicable, in
  the returned `Process` description response to refer between the `XML` and the corresponding `JSON` representations.

## Fixes

- Fix inconsistent or missing schema references to updated `OGC` schema locations, and align their based URL locations
  for corresponding ``/conformance`` endpoint reporting.