### PR TITLE
unpin owslib to allow latest minor/patch revisions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -61,7 +61,7 @@ numpy>=1.21.6; python_version == "3.7"  # pyup: ignore
 numpy>=1.22.2; python_version >= "3.8"
 # esgf-compute-api (cwt) needs oauthlib but doesn't add it in their requirements
 oauthlib
-owslib==0.28.1
+owslib>=0.28.1,<0.30
 psutil
 # FIXME: pymongo>=4 breaks with kombu corresponding to pinned Celery
 # - https://github.com/crim-ca/weaver/issues/386

--- a/requirements.txt
+++ b/requirements.txt
@@ -61,7 +61,7 @@ numpy>=1.21.6; python_version == "3.7"  # pyup: ignore
 numpy>=1.22.2; python_version >= "3.8"
 # esgf-compute-api (cwt) needs oauthlib but doesn't add it in their requirements
 oauthlib
-owslib>=0.28.1,<0.30
+owslib>=0.28.1,!=0.29,<=0.30
 psutil
 # FIXME: pymongo>=4 breaks with kombu corresponding to pinned Celery
 # - https://github.com/crim-ca/weaver/issues/386


### PR DESCRIPTION
fixed in https://github.com/geopython/OWSLib/pull/894 (in `0.30.dev0`)
pending next release for validating `>=0.30` using pinned `owslib>=0.28.1,!=0.29,<=0.30`