### PR TITLE
add tests and fixes to validate builtin processes core script

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,11 +12,14 @@ Changes
 
 Changes:
 --------
-- No change.
+- Add more tests to validate core code paths of ``builtin`` `Process` ``jsonarray2netcdf``, ``metalink2netcdf`` and
+  ``file_index_selector`` with validation of happy path and error handling conditions.
 
 Fixes:
 ------
-- No change.
+- Fix invalid parsing of `XML` Metalink files in ``metalink2netcdf``. Metalink V3 and V4 will now properly consider the
+  namespace and specific content structure to extract the NetCDF URL reference, and the `Process` will validate that the
+  extracted reference respects the NetCDF extension.
 
 .. _changes_4.34.0:
 

--- a/weaver/processes/builtin/jsonarray2netcdf.py
+++ b/weaver/processes/builtin/jsonarray2netcdf.py
@@ -41,7 +41,7 @@ def j2n(json_reference, output_dir):
     LOGGER.debug("Process '%s' output directory: [%s].", PACKAGE_NAME, output_dir)
     try:
         if not os.path.isdir(output_dir):
-            raise ValueError(f"Output dir [{output_dir}] does not exist.")
+            raise ValueError(f"Output directory [{output_dir}] does not exist.")
         with TemporaryDirectory(prefix=f"wps_process_{PACKAGE_NAME}_") as tmp_dir:
             LOGGER.debug("Fetching JSON file: [%s]", json_reference)
             json_path = fetch_file(json_reference, tmp_dir, timeout=10, retry=3)
@@ -56,7 +56,7 @@ def j2n(json_reference, output_dir):
                 LOGGER.debug("Fetching NetCDF reference from JSON file: [%s]", file_url)
                 fetched_nc = fetch_file(file_url, output_dir, timeout=10, retry=3)
                 LOGGER.debug("Fetched NetCDF output location: [%s]", fetched_nc)
-    except Exception as exc:
+    except Exception as exc:  # pragma: no cover
         LOGGER.error("Process '%s' raised an exception: [%s]", PACKAGE_NAME, exc)
         raise
     LOGGER.info("Process '%s' execution completed.", PACKAGE_NAME)
@@ -66,13 +66,13 @@ def main(*args):
     # type: (*str) -> None
     LOGGER.info("Parsing inputs of '%s' process.", PACKAGE_NAME)
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("-i", metavar="json", type=str,
+    parser.add_argument("-i", metavar="json", type=str, required=True,
                         help="JSON file to be parsed for NetCDF file names.")
     parser.add_argument("-o", metavar="outdir", default=CUR_DIR,
                         help="Output directory of the retrieved NetCDF files extracted by name from the JSON file.")
-    ns = parser.parse_args(*args)
+    ns = parser.parse_args(args)
     sys.exit(j2n(ns.i, ns.o))
 
 
 if __name__ == "__main__":
-    main()
+    main(*sys.argv[1:])

--- a/weaver/processes/builtin/metalink2netcdf.cwl
+++ b/weaver/processes/builtin/metalink2netcdf.cwl
@@ -11,6 +11,7 @@ inputs:
      position: 1
      prefix: "-i"
  index:
+   doc: Index of the MetaLink file to extract. This index is 1-based.
    type: int
    inputBinding:
      position: 2

--- a/weaver/processes/builtin/metalink2netcdf.py
+++ b/weaver/processes/builtin/metalink2netcdf.py
@@ -18,6 +18,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(CUR_DIR))))
 # pylint: disable=C0413,wrong-import-order
 from weaver import xml_util  # isort:skip # noqa: E402
 from weaver.utils import fetch_file  # isort:skip # noqa: E402
+from weaver.processes.builtin.utils import is_netcdf_url  # isort:skip # noqa: E402
 
 PACKAGE_NAME = os.path.split(os.path.splitext(__file__)[0])[-1]
 
@@ -27,7 +28,7 @@ LOGGER.addHandler(logging.StreamHandler(sys.stdout))
 LOGGER.setLevel(logging.INFO)
 
 # process details
-__version__ = "1.2"
+__version__ = "1.3"
 __title__ = "Metalink to NetCDF"
 __abstract__ = __doc__  # NOTE: '__doc__' is fetched directly, this is mostly to be informative
 
@@ -48,29 +49,41 @@ def m2n(metalink_reference, index, output_dir):
             LOGGER.debug("Reading Metalink file: [%s]", metalink_path)
             xml_data = xml_util.parse(metalink_path)
             LOGGER.debug("Parsing Metalink file references.")
-            nc_file_url = xml_data.xpath(f"string(//metalink/file[{index}]/metaurl)")
+            meta_ns = xml_data.getroot().nsmap[None]  # metalink URN namespace, pass explicitly otherwise xpath fails
+            meta_version = xml_data.xpath("/m:metalink[1]", namespaces={"m": meta_ns})
+            if (
+                (meta_version and meta_version[0].get("version") == "4.0") or
+                os.path.splitext(metalink_path)[-1] == ".meta4"
+            ):
+                ns_xpath = f"/m:metalink/m:file[{index}]/m:metaurl"
+            else:
+                ns_xpath = f"/m:metalink/m:files/m:file[{index}]/m:resources[1]/m:url"
+            nc_file_url = str(xml_data.xpath(f"string({ns_xpath})", namespaces={"m": meta_ns}))
+            if not is_netcdf_url(nc_file_url):
+                raise ValueError(f"Resolved file URL [{nc_file_url}] is not a valid NetCDF reference.")
             LOGGER.debug("Fetching NetCDF reference from Metalink file: [%s]", metalink_reference)
             LOGGER.debug("NetCDF file URL : %s", nc_file_url)
             fetch_file(nc_file_url, output_dir)
     except Exception as exc:
         # log only debug for tracking, re-raise and actual error wil be logged by top process monitor
-        LOGGER.debug("Process '%s' raised an exception: [%s]", PACKAGE_NAME, exc)
+        LOGGER.error("Process '%s' raised an unhandled exception: [%s]", PACKAGE_NAME, exc)
         raise
     LOGGER.info("Process '%s' execution completed.", PACKAGE_NAME)
 
 
-def main():
+def main(*args):
+    # type: (*str) -> None
     LOGGER.info("Parsing inputs of '%s' process.", PACKAGE_NAME)
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("-i", metavar="metalink", type=str,
+    parser.add_argument("-i", metavar="metalink", type=str, required=True,
                         help="Metalink file to be parsed for NetCDF file names.")
-    parser.add_argument("-n", metavar="index", type=int,
+    parser.add_argument("-n", metavar="index", type=int, required=True,
                         help="Index of the specific NetCDF file to extract. First element's index is 1.")
     parser.add_argument("-o", metavar="outdir", default=CUR_DIR,
                         help="Output directory of the retrieved NetCDF files extracted by name from the Metalink file.")
-    args = parser.parse_args()
+    args = parser.parse_args(args)
     sys.exit(m2n(args.i, args.n, args.o))
 
 
 if __name__ == "__main__":
-    main()
+    main(*sys.argv[1:])

--- a/weaver/xml_util.py
+++ b/weaver/xml_util.py
@@ -45,7 +45,8 @@ Element = lxml_etree.Element
 ParseError = lxml_etree.ParseError
 
 # define this type here so that code can use it for actual logic without repeating 'noqa'
-XML = lxml_etree._ElementTree  # noqa
+XML = lxml_etree._Element  # noqa
+XMLTree = lxml_etree._ElementTree  # noqa
 
 # save a local reference to method employed by OWSLib directly called
 _lxml_fromstring = lxml_etree.fromstring
@@ -59,7 +60,7 @@ def fromstring(text, parser=XML_PARSER):
 
 
 def parse(source, parser=XML_PARSER):
-    # type: (Union[str, BufferedReader], lxml_etree.XMLParser) -> XML
+    # type: (Union[str, BufferedReader], lxml_etree.XMLParser) -> XMLTree
     return lxml_etree.parse(source, parser=parser)  # nosec: B410
 
 

--- a/weaver/xml_util.py
+++ b/weaver/xml_util.py
@@ -45,7 +45,7 @@ Element = lxml_etree.Element
 ParseError = lxml_etree.ParseError
 
 # define this type here so that code can use it for actual logic without repeating 'noqa'
-XML = lxml_etree._Element  # noqa
+XML = lxml_etree._ElementTree  # noqa
 
 # save a local reference to method employed by OWSLib directly called
 _lxml_fromstring = lxml_etree.fromstring


### PR DESCRIPTION
## Changes
- Add more tests to validate core code paths of ``builtin`` `Process` ``jsonarray2netcdf``, ``metalink2netcdf`` and
  ``file_index_selector`` with validation of happy path and error handling conditions.

## Fixes
- Fix invalid parsing of `XML` Metalink files in ``metalink2netcdf``. Metalink V3 and V4 will now properly consider the
  namespace and specific content structure to extract the NetCDF URL reference, and the `Process` will validate that the
  extracted reference respects the NetCDF extension.