### PR TITLE
fix browser WPS XML response content-type resolution

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,7 +16,9 @@ Changes:
 
 Fixes:
 ------
-- No change.
+- Fix default `XML` format resolution for `WPS` endpoint when no ``Accept`` header or ``format``/``f`` query parameter
+  is provided and that the request is submitted from a Web Browser, which involves additional control logic to select
+  the applicable ``Content-Type`` for the response.
 
 .. _changes_4.36.0:
 

--- a/tests/functional/test_wps_app.py
+++ b/tests/functional/test_wps_app.py
@@ -134,6 +134,22 @@ class WpsAppTest(unittest.TestCase):
         assert resp.content_type in ContentType.ANY_XML
         resp.mustcontain("<ows:ExceptionText>Unknown process")
 
+    def test_describeprocess_no_format_default_api_client(self):
+        template = "service=wps&request=describeprocess&version=1.0.0&identifier={}"
+        params = template.format(HelloWPS.identifier)
+        resp = self.app.get(self.make_url(params), headers={"User-Agent": "Robot"})
+        assert resp.status_code == 200
+        assert resp.content_type in ContentType.ANY_XML
+        resp.mustcontain("</wps:ProcessDescriptions>")
+
+    def test_describeprocess_no_format_default_web_browser(self):
+        template = "service=wps&request=describeprocess&version=1.0.0&identifier={}"
+        params = template.format(HelloWPS.identifier)
+        resp = self.app.get(self.make_url(params), headers={"User-Agent": "Mozilla/Test"})
+        assert resp.status_code == 200
+        assert resp.content_type in ContentType.ANY_XML
+        resp.mustcontain("</wps:ProcessDescriptions>")
+
     def test_execute_allowed_demo(self):
         template = "service=wps&request=execute&version=1.0.0&identifier={}&datainputs=name=tux"
         params = template.format(HelloWPS.identifier)

--- a/weaver/wps/service.py
+++ b/weaver/wps/service.py
@@ -162,7 +162,7 @@ class WorkerService(ServiceWPS):
         """
         req = wps_request.http_request
         req = extend_instance(req, PyramidRequest)  # apply query 'params' method
-        accept_type = guess_target_format(req, default=None)
+        accept_type = guess_target_format(req, default=ContentType.APP_XML)
         if accept_type == ContentType.APP_JSON:
             url = get_weaver_url(self.settings)
             proc = wps_request.identifiers


### PR DESCRIPTION
Fixes

- Fix default `XML` format resolution for `WPS` endpoint when no ``Accept`` header or ``format``/``f`` query parameter
  is provided and that the request is submitted from a Web Browser, which involves additional control logic to select
  the applicable ``Content-Type`` for the response.


Browser WPS XML response auto-redirected to JSON caused an unresolved process description when submitted from the browser.