### PR TITLE
pass session object to client

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,7 +12,8 @@ Changes
 
 Changes:
 --------
-- No change.
+- Add option to make requests with ``WeaverClient`` using a ``requests.Session`` instance. This allows requests to be
+  made with the session cookies that may already be attached to this ``requests.Session`` instance.
 
 Fixes:
 ------

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -145,6 +145,24 @@ When using the :ref:`Python Interface <client_commands>`, the desired implementa
     client.capabilities(auth=requests_magpie.MagpieAuth(MAGPIE_URL, MAGPIE_USERNAME, MAGPIE_PASSWORD))
 
 
+If using the :ref:`Python Interface <client_commands>`, you can also pass a `requests.Session` instance as an argument
+during initialization of the :py:class:`weaver.cli.WeaverClient` or as argument to individual methods when calling the
+respective operation.
+
+This is useful when you have previously authenticated and the session cookies are stored in a `requests.Session`
+instance.
+
+.. code-block:: python
+
+    # This example uses Magpie as a login example but this can be used for any authentication mechanism
+    # that returns a session cookie.
+    MAGPIE_URL = os.getenv("MAGPIE_URL")
+    MAGPIE_USERNAME = os.getenv("MAGPIE_USERNAME")
+    MAGPIE_PASSWORD = os.getenv("MAGPIE_PASSWORD")
+    s = requests.Session()
+    s.post(f"{MAGPIE_URL}/signin", data={"user_name": MAGPIE_USERNAME, "password": MAGPIE_PASSWORD, "provider_name": "ziggurat"})
+    client.capabilities(session=s)
+
 .. _cli_example_deploy:
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,6 +14,7 @@ from urllib.parse import quote
 
 import mock
 import pytest
+import requests
 import yaml
 from webtest import TestRequest as WebTestRequest  # avoid pytest collect warning
 

--- a/weaver/cli.py
+++ b/weaver/cli.py
@@ -328,8 +328,8 @@ class WeaverClient(object):
     monitor_interval = 5    # interval between monitor pooling job status requests
     auth = None  # type: AuthHandler
 
-    def __init__(self, url=None, auth=None):
-        # type: (Optional[str], Optional[AuthHandler]) -> None
+    def __init__(self, url=None, auth=None, session=None):
+        # type: (Optional[str], Optional[AuthHandler], Optional[Session]) -> None
         """
         Initialize the client with predefined parameters.
 
@@ -346,6 +346,7 @@ class WeaverClient(object):
             self._url = None
             LOGGER.warning("No URL provided. All operations must provide it directly or through another parameter!")
         self.auth = auth
+        self.session = session
         self._headers = {"Accept": ContentType.APP_JSON, "Content-Type": ContentType.APP_JSON}
         self._settings = {
             "weaver.request_options": {}
@@ -362,6 +363,8 @@ class WeaverClient(object):
                  ):                     # type: (...) -> AnyResponseType
         if self.auth is not None and kwargs.get("auth") is None:
             kwargs["auth"] = self.auth
+        if self.session is not None and kwargs.get("session") is None:
+            kwargs["session"] = self.session
 
         if not headers and x_headers:
             headers = x_headers


### PR DESCRIPTION
Add option to make requests with `WeaverClient` using a `requests.Session` instance. 

This allows requests to be made with the session cookies that may already be attached to this ``requests.Session`` instance.

Useful as an alternative to authenticating with an `auth` argument when a user has already authenticated and they have access to the session cookie. This is mostly so that we can take advantage of this feature with weaver https://github.com/bird-house/birdhouse-deploy/pull/407