### PR TITLE
add SessionAuthHandler

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -9,3 +9,4 @@ Contributors
 * David Byrns <david.byrns@crim.ca> @dbyrns
 * David Caron <david.caron@crim.ca> @davidcaron
 * Mathieu Provencher <mathieu.provencher@crim.ca> @MatProv
+* Misha Schwartz @mishaschwartz

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,8 +12,8 @@ Changes
 
 Changes:
 --------
-- Add ``weaver.cli.SessionAuthHandler`` class which uses the cookies stored in a pre-existing ``requests.Session``
-  instance to authenticate.
+- Add ``token`` optional argument to the ``weaver.cli.RequestAuthHandler`` class. If specified, the handler will use
+  this token instead of making an authentication request to obtain the token.
 
 Fixes:
 ------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,7 +12,8 @@ Changes
 
 Changes:
 --------
-- No change.
+- Add ``weaver.cli.SessionAuthHandler`` class which uses the cookies stored in a pre-existing ``requests.Session``
+  instance to authenticate.
 
 Fixes:
 ------

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -112,7 +112,6 @@ request toward the service.
     - :py:class:`weaver.cli.BasicAuthHandler`
     - :py:class:`weaver.cli.BearerAuthHandler`
     - :py:class:`weaver.cli.CookieAuthHandler`
-    - :py:class:`weaver.cli.SessionAuthHandler`
     - |requests-magpie-auth|_
 
 .. |requests-magpie-auth| replace:: ``requests_magpie.MagpieAuth``
@@ -145,9 +144,6 @@ When using the :ref:`Python Interface <client_commands>`, the desired implementa
     MAGPIE_PASSWORD = os.getenv("MAGPIE_PASSWORD")
     client.capabilities(auth=requests_magpie.MagpieAuth(MAGPIE_URL, MAGPIE_USERNAME, MAGPIE_PASSWORD))
 
-.. note::
-    The :py:class:`weaver.cli.SessionAuthHandler` is only available when using the
-    :ref:`Python Interface <client_commands>`.
 
 .. _cli_example_deploy:
 

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -112,6 +112,7 @@ request toward the service.
     - :py:class:`weaver.cli.BasicAuthHandler`
     - :py:class:`weaver.cli.BearerAuthHandler`
     - :py:class:`weaver.cli.CookieAuthHandler`
+    - :py:class:`weaver.cli.SessionAuthHandler`
     - |requests-magpie-auth|_
 
 .. |requests-magpie-auth| replace:: ``requests_magpie.MagpieAuth``
@@ -144,6 +145,9 @@ When using the :ref:`Python Interface <client_commands>`, the desired implementa
     MAGPIE_PASSWORD = os.getenv("MAGPIE_PASSWORD")
     client.capabilities(auth=requests_magpie.MagpieAuth(MAGPIE_URL, MAGPIE_USERNAME, MAGPIE_PASSWORD))
 
+.. note::
+    The :py:class:`weaver.cli.SessionAuthHandler` is only available when using the
+    :ref:`Python Interface <client_commands>`.
 
 .. _cli_example_deploy:
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -222,6 +222,24 @@ def test_auth_handler_bearer_explicit_token():
     assert resp.headers["Authorization"].startswith("Bearer") and resp.headers["Authorization"].endswith(token)
 
 
+def test_auth_handler_bearer_explicit_token_matches_request_token():
+    req_explicit_token = WebTestRequest({})
+    req_request_token = WebTestRequest({})
+    token = str(uuid.uuid4())
+    auth_explicit_token = BearerAuthHandler(token=token)
+    auth_request_token = BearerAuthHandler(identity=str(uuid.uuid4()))
+    with mock.patch(
+        "requests.Session.request",
+        side_effect=lambda *_, **__: mocked_auth_response("access_token", token)
+    ) as mock_request:
+        resp_explicit_token = auth_explicit_token(req_explicit_token)  # type: ignore
+        mock_request.assert_not_called()
+        resp_request_token = auth_request_token(req_request_token)  # type: ignore
+    assert "Authorization" in resp_explicit_token.headers and len(resp_explicit_token.headers["Authorization"])
+    assert "Authorization" in resp_request_token.headers and len(resp_request_token.headers["Authorization"])
+    assert resp_explicit_token.headers["Authorization"] == resp_request_token.headers["Authorization"]
+
+
 def test_auth_handler_cookie():
     req = WebTestRequest({})
     auth = CookieAuthHandler(identity=str(uuid.uuid4()))
@@ -273,6 +291,24 @@ def test_auth_handler_cookie_explicit_token_mapping_multi():
     assert "Cookie" in resp.headers and len(resp.headers["Cookie"])
     assert f"auth_example={token['auth_example']}" in resp.headers["Cookie"].split("; ")
     assert f"auth_example2={token['auth_example2']}" in resp.headers["Cookie"].split("; ")
+
+
+def test_auth_handler_cookie_explicit_token_matches_request_token():
+    req_explicit_token = WebTestRequest({})
+    req_request_token = WebTestRequest({})
+    token = str(uuid.uuid4())
+    auth_explicit_token = CookieAuthHandler(token=token)
+    auth_request_token = CookieAuthHandler(identity=str(uuid.uuid4()))
+    with mock.patch(
+        "requests.Session.request",
+        side_effect=lambda *_, **__: mocked_auth_response("access_token", token)
+    ) as mock_request:
+        resp_explicit_token = auth_explicit_token(req_explicit_token)  # type: ignore
+        mock_request.assert_not_called()
+        resp_request_token = auth_request_token(req_request_token)  # type: ignore
+    assert "Cookie" in resp_explicit_token.headers and len(resp_explicit_token.headers["Cookie"])
+    assert "Cookie" in resp_request_token.headers and len(resp_request_token.headers["Cookie"])
+    assert resp_explicit_token.headers["Cookie"] == resp_request_token.headers["Cookie"]
 
 
 def test_upload_file_not_found():

--- a/weaver/cli.py
+++ b/weaver/cli.py
@@ -60,7 +60,7 @@ from weaver.wps_restapi import swagger_definitions as sd
 if TYPE_CHECKING:
     from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Set, Tuple, Type, Union
 
-    from requests import Response
+    from requests import Response, PreparedRequest
 
     # avoid failing sphinx-argparse documentation
     # https://github.com/ashb/sphinx-argparse/issues/7
@@ -319,6 +319,19 @@ class CookieAuthHandler(RequestAuthHandler):
         return {"Cookie": token}
 
 
+class SessionAuthHandler(AuthBase):
+    """
+    Adds the cookies from the session to the request.
+    """
+    def __init__(self, session):
+        self.session = session
+
+    def __call__(self, request):
+        # type: (PreparedRequest) -> PreparedRequest
+        request.prepare_cookies(self.session.cookies)
+        return request
+
+
 class WeaverClient(object):
     """
     Client that handles common HTTP requests with a `Weaver` or similar :term:`OGC API - Processes` instance.
@@ -329,7 +342,7 @@ class WeaverClient(object):
     auth = None  # type: AuthHandler
 
     def __init__(self, url=None, auth=None):
-        # type: (Optional[str], Optional[AuthHandler]) -> None
+        # type: (Optional[str], Optional[AuthBase]) -> None
         """
         Initialize the client with predefined parameters.
 

--- a/weaver/cli.py
+++ b/weaver/cli.py
@@ -245,11 +245,8 @@ class RequestAuthHandler(AuthHandler, HTTPBasicAuth):
 
     def __init__(self, token=None, **kwargs):
         # type: (Any, **Any) -> None
-        if token is None:
-            self.token = token
-        else:
-            self.token = self.parse_token(token)
         AuthHandler.__init__(self, **kwargs)
+        self.token = token
 
     @property
     def auth_token_name(self):
@@ -308,13 +305,14 @@ class RequestAuthHandler(AuthHandler, HTTPBasicAuth):
     def __call__(self, request):
         # type: (AnyRequestType) -> AnyRequestType
         if self.token is None:
-            auth_token = self.token
-        else:
             auth_token = self.request_auth()
+        else:
+            auth_token = self.token
         if not auth_token:
             LOGGER.warning("Expected authorization token could not be retrieved from: [%s] in [%s]",
                            self.url, fully_qualified_name(self))
         else:
+            auth_token = self.parse_token(auth_token)
             auth_header = self.auth_header(auth_token)
             request.headers.update(auth_header)
         return request
@@ -346,7 +344,7 @@ class CookieAuthHandler(RequestAuthHandler):
 
     @staticmethod
     def parse_token(token):
-        # type: (Union[str, Mapping]) -> str
+        # type: (Union[str, Mapping[str, str]]) -> str
         """
         Convert token to a form that can be included in a request header.
 

--- a/weaver/cli.py
+++ b/weaver/cli.py
@@ -246,6 +246,7 @@ class RequestAuthHandler(AuthHandler, HTTPBasicAuth):
     def __init__(self, token=None, **kwargs):
         # type: (Any, **Any) -> None
         AuthHandler.__init__(self, **kwargs)
+        HTTPBasicAuth.__init__(self, username=kwargs.get("username"), password=kwargs.get("password"))
         self.token = token
 
     @property
@@ -328,6 +329,7 @@ class BearerAuthHandler(RequestAuthHandler):
         # type: (str) -> str
         """
         Convert token to a form that can be included in a request header.
+
         Returns the token string as is.
         """
         return token
@@ -1910,6 +1912,7 @@ def add_shared_options(parser):
             "instead."
         )
     )
+
 
 def add_listing_options(parser, item):
     # type: (argparse.ArgumentParser, str) -> None

--- a/weaver/cli.py
+++ b/weaver/cli.py
@@ -559,7 +559,7 @@ class WeaverClient(object):
                  provider_id,           # type: str
                  provider_url,          # type: str
                  url=None,              # type: Optional[str]
-                 auth=None,             # type: Optional[AuthBase]
+                 auth=None,             # type: Optional[AuthHandler]
                  headers=None,          # type: Optional[AnyHeadersContainer]
                  with_links=True,       # type: bool
                  with_headers=False,    # type: bool
@@ -600,7 +600,7 @@ class WeaverClient(object):
     def unregister(self,
                    provider_id,             # type: str
                    url=None,                # type: Optional[str]
-                   auth=None,               # type: Optional[AuthBase]
+                   auth=None,               # type: Optional[AuthHandler]
                    headers=None,            # type: Optional[AnyHeadersContainer]
                    with_links=True,         # type: bool
                    with_headers=False,      # type: bool
@@ -647,7 +647,7 @@ class WeaverClient(object):
                password=None,           # type: Optional[str]
                undeploy=False,          # type: bool
                url=None,                # type: Optional[str]
-               auth=None,               # type: Optional[AuthBase]
+               auth=None,               # type: Optional[AuthHandler]
                headers=None,            # type: Optional[AnyHeadersContainer]
                with_links=True,         # type: bool
                with_headers=False,      # type: bool
@@ -735,7 +735,7 @@ class WeaverClient(object):
     def undeploy(self,
                  process_id,            # type: str
                  url=None,              # type: Optional[str]
-                 auth=None,             # type: Optional[AuthBase]
+                 auth=None,             # type: Optional[AuthHandler]
                  headers=None,          # type: Optional[AnyHeadersContainer]
                  with_links=True,       # type: bool
                  with_headers=False,    # type: bool
@@ -770,7 +770,7 @@ class WeaverClient(object):
 
     def capabilities(self,
                      url=None,              # type: Optional[str]
-                     auth=None,             # type: Optional[AuthBase]
+                     auth=None,             # type: Optional[AuthHandler]
                      headers=None,          # type: Optional[AnyHeadersContainer]
                      with_links=True,       # type: bool
                      with_headers=False,    # type: bool
@@ -846,7 +846,7 @@ class WeaverClient(object):
                  process_id,                # type: str
                  provider_id=None,          # type: Optional[str]
                  url=None,                  # type: Optional[str]
-                 auth=None,                 # type: Optional[AuthBase]
+                 auth=None,                 # type: Optional[AuthHandler]
                  headers=None,              # type: Optional[AnyHeadersContainer]
                  schema=ProcessSchema.OGC,  # type: Optional[ProcessSchemaType]
                  with_links=True,           # type: bool
@@ -904,7 +904,7 @@ class WeaverClient(object):
                 process_id,                 # type: str
                 provider_id=None,           # type: Optional[str]
                 url=None,                   # type: Optional[str]
-                auth=None,                  # type: Optional[AuthBase]
+                auth=None,                  # type: Optional[AuthHandler]
                 headers=None,               # type: Optional[AnyHeadersContainer]
                 with_links=True,            # type: bool
                 with_headers=False,         # type: bool
@@ -1080,7 +1080,7 @@ class WeaverClient(object):
                 interval=None,          # type: Optional[int]
                 subscribers=None,       # type: Optional[JobSubscribers]
                 url=None,               # type: Optional[str]
-                auth=None,              # type: Optional[AuthBase]
+                auth=None,              # type: Optional[AuthHandler]
                 headers=None,           # type: Optional[AnyHeadersContainer]
                 with_links=True,        # type: bool
                 with_headers=False,     # type: bool
@@ -1218,7 +1218,7 @@ class WeaverClient(object):
                content_type=None,       # type: Optional[str]
                content_encoding=None,   # type: Optional[ContentEncoding]
                url=None,                # type: Optional[str]
-               auth=None,               # type: Optional[AuthBase]
+               auth=None,               # type: Optional[AuthHandler]
                headers=None,            # type: Optional[AnyHeadersContainer]
                with_links=True,         # type: bool
                with_headers=False,      # type: bool
@@ -1309,7 +1309,7 @@ class WeaverClient(object):
 
     def jobs(self,
              url=None,              # type: Optional[str]
-             auth=None,             # type: Optional[AuthBase]
+             auth=None,             # type: Optional[AuthHandler]
              headers=None,          # type: Optional[AnyHeadersContainer]
              with_links=True,       # type: bool
              with_headers=False,    # type: bool
@@ -1391,7 +1391,7 @@ class WeaverClient(object):
     def status(self,
                job_reference,           # type: str
                url=None,                # type: Optional[str]
-               auth=None,               # type: Optional[AuthBase]
+               auth=None,               # type: Optional[AuthHandler]
                headers=None,            # type: Optional[AnyHeadersContainer]
                with_links=True,         # type: bool
                with_headers=False,      # type: bool
@@ -1431,7 +1431,7 @@ class WeaverClient(object):
                   x_path,                   # type: str
                   job_reference,            # type: str
                   url=None,                 # type: Optional[str]
-                  auth=None,                # type: Optional[AuthBase]
+                  auth=None,                # type: Optional[AuthHandler]
                   headers=None,             # type: Optional[AnyHeadersContainer]
                   with_links=True,          # type: bool
                   with_headers=False,       # type: bool
@@ -1492,7 +1492,7 @@ class WeaverClient(object):
                 interval=None,                      # type: Optional[int]
                 wait_for_status=Status.SUCCEEDED,   # type: str
                 url=None,                           # type: Optional[str]
-                auth=None,                          # type: Optional[AuthBase]
+                auth=None,                          # type: Optional[AuthHandler]
                 headers=None,                       # type: Optional[AnyHeadersContainer]
                 with_links=True,                    # type: bool
                 with_headers=False,                 # type: bool
@@ -1558,7 +1558,7 @@ class WeaverClient(object):
         return OperationResult(False, msg)
 
     def _download_references(self, outputs, out_links, out_dir, job_id, auth=None):
-        # type: (ExecutionResults, AnyHeadersContainer, str, str, Optional[AuthBase]) -> ExecutionResults
+        # type: (ExecutionResults, AnyHeadersContainer, str, str, Optional[AuthHandler]) -> ExecutionResults
         """
         Download file references from results response contents and link headers.
 
@@ -1628,7 +1628,7 @@ class WeaverClient(object):
                 out_dir=None,           # type: Optional[str]
                 download=False,         # type: bool
                 url=None,               # type: Optional[str]
-                auth=None,              # type: Optional[AuthBase]
+                auth=None,              # type: Optional[AuthHandler]
                 headers=None,           # type: Optional[AnyHeadersContainer]
                 with_links=True,        # type: bool
                 with_headers=False,     # type: bool
@@ -1688,7 +1688,7 @@ class WeaverClient(object):
     def dismiss(self,
                 job_reference,          # type: str
                 url=None,               # type: Optional[str]
-                auth=None,              # type: Optional[AuthBase]
+                auth=None,              # type: Optional[AuthHandler]
                 headers=None,           # type: Optional[AnyHeadersContainer]
                 with_links=True,        # type: bool
                 with_headers=False,     # type: bool

--- a/weaver/cli.py
+++ b/weaver/cli.py
@@ -559,7 +559,7 @@ class WeaverClient(object):
                  provider_id,           # type: str
                  provider_url,          # type: str
                  url=None,              # type: Optional[str]
-                 auth=None,             # type: Optional[AuthHandler]
+                 auth=None,             # type: Optional[AuthBase]
                  headers=None,          # type: Optional[AnyHeadersContainer]
                  with_links=True,       # type: bool
                  with_headers=False,    # type: bool
@@ -600,7 +600,7 @@ class WeaverClient(object):
     def unregister(self,
                    provider_id,             # type: str
                    url=None,                # type: Optional[str]
-                   auth=None,               # type: Optional[AuthHandler]
+                   auth=None,               # type: Optional[AuthBase]
                    headers=None,            # type: Optional[AnyHeadersContainer]
                    with_links=True,         # type: bool
                    with_headers=False,      # type: bool
@@ -647,7 +647,7 @@ class WeaverClient(object):
                password=None,           # type: Optional[str]
                undeploy=False,          # type: bool
                url=None,                # type: Optional[str]
-               auth=None,               # type: Optional[AuthHandler]
+               auth=None,               # type: Optional[AuthBase]
                headers=None,            # type: Optional[AnyHeadersContainer]
                with_links=True,         # type: bool
                with_headers=False,      # type: bool
@@ -735,7 +735,7 @@ class WeaverClient(object):
     def undeploy(self,
                  process_id,            # type: str
                  url=None,              # type: Optional[str]
-                 auth=None,             # type: Optional[AuthHandler]
+                 auth=None,             # type: Optional[AuthBase]
                  headers=None,          # type: Optional[AnyHeadersContainer]
                  with_links=True,       # type: bool
                  with_headers=False,    # type: bool
@@ -770,7 +770,7 @@ class WeaverClient(object):
 
     def capabilities(self,
                      url=None,              # type: Optional[str]
-                     auth=None,             # type: Optional[AuthHandler]
+                     auth=None,             # type: Optional[AuthBase]
                      headers=None,          # type: Optional[AnyHeadersContainer]
                      with_links=True,       # type: bool
                      with_headers=False,    # type: bool
@@ -846,7 +846,7 @@ class WeaverClient(object):
                  process_id,                # type: str
                  provider_id=None,          # type: Optional[str]
                  url=None,                  # type: Optional[str]
-                 auth=None,                 # type: Optional[AuthHandler]
+                 auth=None,                 # type: Optional[AuthBase]
                  headers=None,              # type: Optional[AnyHeadersContainer]
                  schema=ProcessSchema.OGC,  # type: Optional[ProcessSchemaType]
                  with_links=True,           # type: bool
@@ -904,7 +904,7 @@ class WeaverClient(object):
                 process_id,                 # type: str
                 provider_id=None,           # type: Optional[str]
                 url=None,                   # type: Optional[str]
-                auth=None,                  # type: Optional[AuthHandler]
+                auth=None,                  # type: Optional[AuthBase]
                 headers=None,               # type: Optional[AnyHeadersContainer]
                 with_links=True,            # type: bool
                 with_headers=False,         # type: bool
@@ -1080,7 +1080,7 @@ class WeaverClient(object):
                 interval=None,          # type: Optional[int]
                 subscribers=None,       # type: Optional[JobSubscribers]
                 url=None,               # type: Optional[str]
-                auth=None,              # type: Optional[AuthHandler]
+                auth=None,              # type: Optional[AuthBase]
                 headers=None,           # type: Optional[AnyHeadersContainer]
                 with_links=True,        # type: bool
                 with_headers=False,     # type: bool
@@ -1218,7 +1218,7 @@ class WeaverClient(object):
                content_type=None,       # type: Optional[str]
                content_encoding=None,   # type: Optional[ContentEncoding]
                url=None,                # type: Optional[str]
-               auth=None,               # type: Optional[AuthHandler]
+               auth=None,               # type: Optional[AuthBase]
                headers=None,            # type: Optional[AnyHeadersContainer]
                with_links=True,         # type: bool
                with_headers=False,      # type: bool
@@ -1309,7 +1309,7 @@ class WeaverClient(object):
 
     def jobs(self,
              url=None,              # type: Optional[str]
-             auth=None,             # type: Optional[AuthHandler]
+             auth=None,             # type: Optional[AuthBase]
              headers=None,          # type: Optional[AnyHeadersContainer]
              with_links=True,       # type: bool
              with_headers=False,    # type: bool
@@ -1391,7 +1391,7 @@ class WeaverClient(object):
     def status(self,
                job_reference,           # type: str
                url=None,                # type: Optional[str]
-               auth=None,               # type: Optional[AuthHandler]
+               auth=None,               # type: Optional[AuthBase]
                headers=None,            # type: Optional[AnyHeadersContainer]
                with_links=True,         # type: bool
                with_headers=False,      # type: bool
@@ -1431,7 +1431,7 @@ class WeaverClient(object):
                   x_path,                   # type: str
                   job_reference,            # type: str
                   url=None,                 # type: Optional[str]
-                  auth=None,                # type: Optional[AuthHandler]
+                  auth=None,                # type: Optional[AuthBase]
                   headers=None,             # type: Optional[AnyHeadersContainer]
                   with_links=True,          # type: bool
                   with_headers=False,       # type: bool
@@ -1492,7 +1492,7 @@ class WeaverClient(object):
                 interval=None,                      # type: Optional[int]
                 wait_for_status=Status.SUCCEEDED,   # type: str
                 url=None,                           # type: Optional[str]
-                auth=None,                          # type: Optional[AuthHandler]
+                auth=None,                          # type: Optional[AuthBase]
                 headers=None,                       # type: Optional[AnyHeadersContainer]
                 with_links=True,                    # type: bool
                 with_headers=False,                 # type: bool
@@ -1558,7 +1558,7 @@ class WeaverClient(object):
         return OperationResult(False, msg)
 
     def _download_references(self, outputs, out_links, out_dir, job_id, auth=None):
-        # type: (ExecutionResults, AnyHeadersContainer, str, str, Optional[AuthHandler]) -> ExecutionResults
+        # type: (ExecutionResults, AnyHeadersContainer, str, str, Optional[AuthBase]) -> ExecutionResults
         """
         Download file references from results response contents and link headers.
 
@@ -1628,7 +1628,7 @@ class WeaverClient(object):
                 out_dir=None,           # type: Optional[str]
                 download=False,         # type: bool
                 url=None,               # type: Optional[str]
-                auth=None,              # type: Optional[AuthHandler]
+                auth=None,              # type: Optional[AuthBase]
                 headers=None,           # type: Optional[AnyHeadersContainer]
                 with_links=True,        # type: bool
                 with_headers=False,     # type: bool
@@ -1688,7 +1688,7 @@ class WeaverClient(object):
     def dismiss(self,
                 job_reference,          # type: str
                 url=None,               # type: Optional[str]
-                auth=None,              # type: Optional[AuthHandler]
+                auth=None,              # type: Optional[AuthBase]
                 headers=None,           # type: Optional[AnyHeadersContainer]
                 with_links=True,        # type: bool
                 with_headers=False,     # type: bool

--- a/weaver/cli.py
+++ b/weaver/cli.py
@@ -58,7 +58,7 @@ from weaver.utils import (
 from weaver.wps_restapi import swagger_definitions as sd
 
 if TYPE_CHECKING:
-    from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Set, Tuple, Type, Union, Mapping
+    from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Sequence, Set, Tuple, Type, Union
 
     from requests import Response
 

--- a/weaver/cli.py
+++ b/weaver/cli.py
@@ -249,6 +249,13 @@ class RequestAuthHandler(AuthHandler, HTTPBasicAuth):
         HTTPBasicAuth.__init__(self, username=kwargs.get("username"), password=kwargs.get("password"))
         self.token = token
 
+    # Update __init__'s signature to include keyword arguments from AuthHandler's __init__. This is required because
+    # the CLI entrypoint inspects the auth class' signature in order to figure out which arguments to pass to it.
+    _signature_AuthHandler = inspect.signature(AuthHandler.__init__)
+    __init__.__signature__ = _signature_AuthHandler.replace(
+        parameters=(*_signature_AuthHandler.parameters.values(), inspect.signature(__init__).parameters["token"])
+    )
+
     @property
     def auth_token_name(self):
         # type: () -> str
@@ -2954,7 +2961,6 @@ def main(*args):
     except Exception as exc:
         msg = "Operation failed due to exception."
         err = fully_qualified_name(exc)
-        result = OperationResult(False, message=msg, body={"message": msg, "cause": str(exc), "error": err})
     if result.success:
         LOGGER.info("%s successful. %s\n", oper.title(), result.message)
         print(result.text)  # use print in case logger disabled or level error/warn

--- a/weaver/cli.py
+++ b/weaver/cli.py
@@ -58,9 +58,9 @@ from weaver.utils import (
 from weaver.wps_restapi import swagger_definitions as sd
 
 if TYPE_CHECKING:
-    from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Set, Tuple, Type, Union
+    from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Set, Tuple, Type, Union, Mapping
 
-    from requests import Response, PreparedRequest
+    from requests import Response
 
     # avoid failing sphinx-argparse documentation
     # https://github.com/ashb/sphinx-argparse/issues/7
@@ -242,6 +242,15 @@ class RequestAuthHandler(AuthHandler, HTTPBasicAuth):
     """
     Base class to send a request in order to retrieve an authorization token.
     """
+
+    def __init__(self, token=None, **kwargs):
+        # type: (Any, **Any) -> None
+        if token is None:
+            self.token = token
+        else:
+            self.token = self.parse_token(token)
+        AuthHandler.__init__(self, **kwargs)
+
     @property
     def auth_token_name(self):
         # type: () -> str
@@ -257,6 +266,15 @@ class RequestAuthHandler(AuthHandler, HTTPBasicAuth):
         # type: (str) -> AnyHeadersContainer
         """
         Obtain the header definition with the provided authorization token.
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    @abc.abstractmethod
+    def parse_token(token):
+        # type: (Any) -> str
+        """
+        Convert token to a form that can be included in a request header.
         """
         raise NotImplementedError
 
@@ -289,7 +307,10 @@ class RequestAuthHandler(AuthHandler, HTTPBasicAuth):
 
     def __call__(self, request):
         # type: (AnyRequestType) -> AnyRequestType
-        auth_token = self.request_auth()
+        if self.token is None:
+            auth_token = self.token
+        else:
+            auth_token = self.request_auth()
         if not auth_token:
             LOGGER.warning("Expected authorization token could not be retrieved from: [%s] in [%s]",
                            self.url, fully_qualified_name(self))
@@ -304,6 +325,15 @@ class BearerAuthHandler(RequestAuthHandler):
     Adds the ``Authorization`` header formed of the authentication bearer token from the underlying request.
     """
 
+    @staticmethod
+    def parse_token(token):
+        # type: (str) -> str
+        """
+        Convert token to a form that can be included in a request header.
+        Returns the token string as is.
+        """
+        return token
+
     def auth_header(self, token):
         # type: (str) -> AnyHeadersContainer
         return {"Authorization": f"Bearer {token}"}
@@ -311,25 +341,27 @@ class BearerAuthHandler(RequestAuthHandler):
 
 class CookieAuthHandler(RequestAuthHandler):
     """
-    Adds the ``Authorization`` header formed of the authentication bearer token from the underlying request.
+    Adds the ``Cookie`` header formed from the authentication bearer token from the underlying request.
     """
+
+    @staticmethod
+    def parse_token(token):
+        # type: (Union[str, Mapping]) -> str
+        """
+        Convert token to a form that can be included in a request header.
+
+        Returns the token string as is if it is a string. Otherwise, if the token is a mapping, where keys are cookie
+        names and values are cookie values, convert the cookie representation to a string that can be accepted as the
+        value of the "Cookie" header.
+        """
+        if isinstance(token, str):
+            return token
+        cookie_dict = CaseInsensitiveDict(token)
+        return "; ".join(f"{key}={val}" for key, val in cookie_dict.items())
 
     def auth_header(self, token):
         # type: (str) -> AnyHeadersContainer
         return {"Cookie": token}
-
-
-class SessionAuthHandler(AuthBase):
-    """
-    Adds the cookies from the session to the request.
-    """
-    def __init__(self, session):
-        self.session = session
-
-    def __call__(self, request):
-        # type: (PreparedRequest) -> PreparedRequest
-        request.prepare_cookies(self.session.cookies)
-        return request
 
 
 class WeaverClient(object):
@@ -342,7 +374,7 @@ class WeaverClient(object):
     auth = None  # type: AuthHandler
 
     def __init__(self, url=None, auth=None):
-        # type: (Optional[str], Optional[AuthBase]) -> None
+        # type: (Optional[str], Optional[AuthHandler]) -> None
         """
         Initialize the client with predefined parameters.
 
@@ -1872,7 +1904,14 @@ def add_shared_options(parser):
             "Surrounding spaces are trimmed."
         )
     )
-
+    auth_grp.add_argument(
+        "-aT", "--auth-token", dest="auth_token", metavar="TOKEN",
+        help=(
+            "Token to be added directly to the request headers. If this is specified, the authenticator will not make "
+            "an additional authentication request in order to obtain a token. The token specified here will be used "
+            "instead."
+        )
+    )
 
 def add_listing_options(parser, item):
     # type: (argparse.ArgumentParser, str) -> None
@@ -1907,6 +1946,7 @@ def parse_auth(kwargs):
     auth_url = kwargs.pop("auth_url", None)
     auth_method = kwargs.pop("auth_method", None)
     auth_headers = kwargs.pop("auth_headers", {})
+    auth_token = kwargs.pop("auth_token", None)
     if not (auth_handler and issubclass(auth_handler, (AuthHandler, AuthBase))):
         return None
     auth_handler_name = fully_qualified_name(auth_handler)
@@ -1918,6 +1958,7 @@ def parse_auth(kwargs):
         ("url", auth_url),
         ("method", auth_method),
         ("headers", CaseInsensitiveDict(auth_headers)),
+        ("token", auth_token)
     ]
     if len(auth_sign.parameters) == 0:
         auth_handler = auth_handler()


### PR DESCRIPTION
Add `weaver.cli.SessionAuthHandler` class which uses the cookies stored in a pre-existing `requests.Session` instance to authenticate.


Alternative to #597 as discussed in https://github.com/crim-ca/weaver/pull/597#discussion_r1480537709

Closes #597