### PR TITLE
add `weaver.wps_client_headers_filter` setting to filter WPS provider headers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,7 +12,9 @@ Changes
 
 Changes:
 --------
-- No change.
+- Add ``weaver.wps_client_headers_filter`` setting that allows filtering of specific `WPS` request headers from the
+  incoming request to be passed down to the `WPS` client employed to interact with the `WPS` provider
+  (fixes `#600 <https://github.com/crim-ca/weaver/issues/600>`_).
 
 Fixes:
 ------

--- a/config/weaver.ini.example
+++ b/config/weaver.ini.example
@@ -113,6 +113,10 @@ weaver.wps_output_s3_bucket =
 weaver.wps_output_s3_region =
 weaver.wps_workdir =
 
+# List of comma-separated case-insensitive headers that will be removed from incoming requests before
+# passing them down to invoke an operation with the corresponding WPS provider through the WPS client.
+weaver.wps_client_headers_filter = Host,
+
 # --- Weaver WPS metadata ---
 # all attributes under "metadata:main" can be specified as 'weaver.wps_metadata_<field>'
 # (reference: https://pywps.readthedocs.io/en/master/configuration.html#metadata-main)

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -199,6 +199,16 @@ they are optional and which default value or operation is applied in each situat
   |
   | Prefix where process :term:`Job` worker should execute the :term:`Process` from.
 
+- | ``weaver.wps_client_headers_filter = <headers>``
+  | (default: ``Host,``)
+  |
+  | List of comma-separated case-insensitive headers that will be removed from incoming requests before
+  | passing them down to invoke an operation with the corresponding :term:`WPS` provider through the :term:`WPS` client.
+
+.. seealso::
+    - :func:`weaver.wps.utils.get_wps_client_filtered_headers`
+    - :func:`weaver.wps.utils.get_wps_client`
+
 - | ``weaver.wps_restapi = true|false`` [:class:`bool`-like]
   | (default: ``true``)
   |

--- a/weaver/utils.py
+++ b/weaver/utils.py
@@ -149,6 +149,8 @@ if TYPE_CHECKING:
         "headers": NotRequired[AnyHeadersContainer],
         "cookies": NotRequired[AnyCookiesContainer],
         "stream": NotRequired[bool],
+        "cache": NotRequired[bool],
+        "cache_enabled": NotRequired[bool],
     }, total=False)
     RequestCachingKeywords = Dict[str, AnyValueType]
     RequestCachingFunction = Callable[[AnyRequestMethod, str, RequestCachingKeywords], Response]
@@ -1670,7 +1672,7 @@ def invalidate_region(caching_args):
 
 
 def get_ssl_verify_option(method, url, settings, request_options=None):
-    # type: (str, str, AnySettingsContainer, Optional[SettingsType]) -> bool
+    # type: (str, str, AnySettingsContainer, Optional[RequestOptions]) -> bool
     """
     Obtains the SSL verification option considering multiple setting definitions and the provided request context.
 
@@ -1695,9 +1697,9 @@ def get_ssl_verify_option(method, url, settings, request_options=None):
 
 
 def get_no_cache_option(request_headers, **cache_options):
-    # type: (HeadersType, **bool) -> bool
+    # type: (HeadersType, **bool | RequestOptions) -> bool
     """
-    Obtains the No-Cache result from request headers and configured request options.
+    Obtains the ``No-Cache`` result from request headers and configured :term:`Request Options`.
 
     .. seealso::
         - :meth:`Request.headers`
@@ -1717,7 +1719,7 @@ def get_no_cache_option(request_headers, **cache_options):
 def get_request_options(method, url, settings):
     # type: (str, str, AnySettingsContainer) -> RequestOptions
     """
-    Obtains the *request options* corresponding to the request from the configuration file.
+    Obtains the :term:`Request Options` corresponding to the request from the configuration file.
 
     The configuration file specified is expected to be pre-loaded within setting ``weaver.request_options``.
     If no file was pre-loaded or no match is found for the request, an empty options dictionary is returned.


### PR DESCRIPTION
## Changes
- Add ``weaver.wps_client_headers_filter`` setting that allows filtering of specific `WPS` request headers from the
  incoming request to be passed down to the `WPS` client employed to interact with the `WPS` provider.

## References 

- fixes #600