### PR TITLE
fix invalid reference in CI causing skip duplicate output to be misinterpreted 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
     continue-on-error: true
     runs-on: ubuntu-latest
     outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip && ! contains(github.ref, 'refs/tags') }}
+      should_skip: ${{ steps.skip_duplicate.outputs.should_skip && ! contains(github.ref, 'refs/tags') }}
     steps:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@master
@@ -30,10 +30,8 @@ jobs:
 
   # see: https://github.com/actions/setup-python
   tests:
-    # FIXME: https://github.com/fkirc/skip-duplicate-actions/issues/90
-    #   disable for now because the tests never run... somehow similar config works in Magpie...
-    # needs: skip_duplicate
-    # if: ${{ needs.skip_duplicate.outputs.should_skip != 'true' }}
+    needs: skip_duplicate
+    if: ${{ needs.skip_duplicate.outputs.should_skip != 'true' }}
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.allow-failure }}
     env:


### PR DESCRIPTION
fix invalid reference in CI causing skip duplicate output to be misinterpreted (relates to https://github.com/fkirc/skip-duplicate-actions/issues/90)