### PR TITLE
add CI python pip cache

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,9 +92,10 @@ jobs:
       - name: Setup Python
         # skip python setup if running with docker
         if: ${{ matrix.test-case != 'test-docker' }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: "${{ matrix.python-version }}"
+          cache: 'pip'
       - name: Parse Python Version
         id: python-semver
         run: |


### PR DESCRIPTION
Add the `pip` CI cache option to avoid redownload of assets. 
If the target version for a package to install hits the cache, it will reduce the CI time. 
Since we leave many packages unpinned to get latest updates, it will not hit in many cases, but this is what we want. 