### PR TITLE
temporary pin `requests!=2.32` to avoid issue with `docker-py`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,7 +16,13 @@ Changes:
 
 Fixes:
 ------
-- No change.
+- Pin ``requests!=2.32`` to avoid issue with ``docker-py`` custom adapter not (yet) supporting it
+  (relates to `psf/requests#6710 <https://github.com/psf/requests/pull/6710>`_
+  and `docker/docker-py#3257 <https://github.com/docker/docker-py/pull/3257>`_).
+  Pinning ``requests>=2.32.2`` *should* be applied when possible (when ``docker-py`` is released) to address
+  `CVE-2024-35195 <https://nvd.nist.gov/vuln/detail/CVE-2024-35195>`_. However, the corresponding ``verify=False``
+  option affected by this CVE is not recommended for use in `Weaver`, and should be avoided entirely anyway.
+  Could affect *requests options* if the corresponding ``verify: false`` configuration was employed.
 
 .. _changes_5.3.0:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -82,7 +82,11 @@ pytz
 pywps==4.6.0
 pyyaml>=5.2
 rdflib>=5  # pyup: ignore
-requests
+# FIXME: temporary workaround
+# 'requests=2.32' needed for CVE-2024-35195
+# (https://github.com/psf/requests/releases/tag/v2.32.0, https://github.com/psf/requests/pull/6710)
+# however, https://github.com/docker/docker-py/pull/3257 not yet released, 'docker-py' broken by 'requests=2.32' change
+requests!=2.32
 requests_file
 ruamel.yaml>=0.16
 # force use of later mistune (https://github.com/common-workflow-language/schema_salad/pull/619#issuecomment-1346025607)


### PR DESCRIPTION
relates to https://github.com/docker/docker-py/pull/3257, https://github.com/psf/requests/pull/6710, https://github.com/crim-ca/weaver/pull/651, https://github.com/crim-ca/weaver/pull/650

`docker-py` uses a custom adapter that does not override the new method used by `requests=2.32`

The `docker-py` PR is merged, but not released yet. 
Need to wait for a release to pin it.
