### PR TITLE
pin sphinx-argparse<0.5.0 to fix Sphinx/RTD docs build

### DIFF
--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -5,7 +5,7 @@
 -r requirements.txt
 jinja2
 sphinx>=6,<8
-sphinx-argparse
+sphinx-argparse<0.5.0
 sphinx-autoapi>=1.7.0
 sphinx-paramlinks>=0.4.1
 # adds redoc OpenAPI directly served on readthedocs


### PR DESCRIPTION
pin `sphinx-argparse<0.5.0` to fix Sphinx/RTD docs build
relates to https://github.com/sphinx-doc/sphinx-argparse/issues/57