### PR TITLE
fix packaging/setuptools versions

### DIFF
--- a/requirements-sys.txt
+++ b/requirements-sys.txt
@@ -1,2 +1,3 @@
 pip>=22.0.4  # pyup: ignore
 setuptools>=71.0.3
+packaging>=22.0


### PR DESCRIPTION
fix invalid setup arguments encountered when versions missmtach between `setuptools` and `packaging`