### PR TITLE
make CWL format check against IANA media-type URI more resilient against temporary/sporadic SSL handshake error

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,8 @@ Fixes:
 ------
 - Fix invalid resolution of ``weaver.formats.ContentEncoding.open_parameters``.
 - Fix minor resolution combinations or redundant checks for multiple ``weaver.formats`` utilities.
+- FIx `CWL` ``format`` resolution check against `IANA` media-types if the reference ontology happens to be
+  temporarily/sporadically unresponsive to SSL handshake check, allowing temporary HTTP resolution of media-type.
 
 .. _changes_5.7.0:
 

--- a/weaver/formats.py
+++ b/weaver/formats.py
@@ -839,7 +839,7 @@ def get_cwl_file_format(media_type, make_reference=False, must_exist=True, allow
             # allow temporary HTTP resolution given IANA is a well-known URI
             # however, ensure the cause is in fact related to SSL, and still a resolvable referenced
             http_err = str(exc.args[0]).lower()
-            http_url = "http://" + _media_type_url.split("://", 1)[-1]
+            http_url = f"http://{_media_type_url.split('://', 1)[-1]}"
             if (
                 _media_type_url.startswith(IANA_NAMESPACE_URL) and
                 any(err in http_err for err in ["ssl", "handshake"]) and


### PR DESCRIPTION
Recent (2024-09-93) PRs (#705, #706, etc.) have shown flaky CI testing results due to inconsistent SSL handshake errors from IANA. Avoid this extra validation to fail our pipelines, as they can generally be considered a safe URI location for this specific case.