### PR TITLE
fix incompatibilities between extra requirements `celery[mongodb]` and `pymongo[srv]>=4.8.0`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,9 @@ Fixes:
   disallow ``additionalProperties`` that cannot be mapped to a particular child `JSON` schema definition.
 - Fix ``VariableSchemaNode`` resolution to allow mapping against multiple ``variable`` sub-nodes representing
   different nested `JSON` schema nodes permitted under the ``additionalProperties`` mapping.
+- Pin ``pymongo>=4.3`` and remove ``celery[mongodb]`` extra requirement to avoid incompatible resolution
+  of ``pymongo[srv]>=4.8.0`` (relates to `celery/celery#9254 <https://github.com/celery/celery/issues/9254>`_
+  and `MongoDB PYTHON-4756 <https://jira.mongodb.org/browse/PYTHON-4756>`_).
 
 .. _changes_5.8.0:
 

--- a/docker/Dockerfile-base
+++ b/docker/Dockerfile-base
@@ -20,6 +20,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates \
         netbase \
         gcc \
+        g++ \
         git \
         nodejs \
     && pip install --no-cache-dir --upgrade -r requirements-sys.txt \
@@ -27,6 +28,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && pip install --no-cache-dir -e ${APP_DIR} \
     && apt-get remove -y \
         gcc \
+        g++ \
         git \
     && rm -rf /var/lib/apt/lists/*
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ boto3-stubs[s3]
 # https://github.com/celery/billiard/issues/313
 billiard>2; sys_platform != "win32"  # avoid issue with use_2to3
 billiard>3.2,<3.4; sys_platform == "win32"
-# FIXME: pymongo>=4 breaks with kombu corresponding to pinned Celery
+# pymongo>=4 breaks for some kombu combinations corresponding to pinned Celery
 # - https://github.com/crim-ca/weaver/issues/386
 # - https://github.com/celery/kombu/pull/1536
 # - https://github.com/celery/celery/pull/7834
@@ -19,7 +19,14 @@ billiard>3.2,<3.4; sys_platform == "win32"
 #   celery's CLI interface changed
 #   https://github.com/celery/celery/blob/master/docs/whatsnew-5.2.rst#upgrading-from-celery-4x
 celery[mongodb]<4; sys_platform == "win32"  # rq.filter: <4  # pyup: ignore
-celery[mongodb]>=5.2.2,<6; sys_platform != "win32"
+# Remove extra '[mongodb]' from 'celery' to avoid 'pymongo[srv]' extra requirement.
+# (https://github.com/celery/celery/blob/main/requirements/extras/mongodb.txt)
+# This breaks in 'pymongo>=4.8.0' since 'srv' is removed.
+# - https://jira.mongodb.org/browse/PYTHON-4756
+# - https://github.com/celery/celery/issues/9254
+# Note that 'srv' does not add anything since 'pymongo==4.3.0' (https://jira.mongodb.org/browse/PYTHON-3423).
+# Therefore, use plain 'celery', and rely on our 'pymongo' dependency.
+celery>=5.2.2,<6; sys_platform != "win32"
 cffi
 colander<2
 # FIXME: patch fix of the cornice service prefixed route path resolution (https://github.com/Cornices/cornice/pull/584)
@@ -77,11 +84,11 @@ psutil
 # - extra 'backend-native' uses shapely for Python objects
 # - support FES, CQL(TEXT,JSON), CQL2(TEXT,JSON), ECQL, JFE
 pygeofilter[fes,backend-native]
-# FIXME: pymongo>=4 breaks with kombu corresponding to pinned Celery
+# pymongo>=4 breaks for some kombu combinations corresponding to pinned Celery
 # - https://github.com/crim-ca/weaver/issues/386
 # - https://github.com/celery/kombu/pull/1536
 # - https://github.com/celery/celery/pull/7834
-pymongo>=4  # either (pymongo>=4, kombu>=5.3.0b2) or (pymongo<4, celery<5.2)
+pymongo>=4.3  # either (pymongo>=4, kombu>=5.3.0b2) or (pymongo<4, celery<5.2)
 pyramid>=1.7.3
 pyramid_beaker>=0.8
 # see https://github.com/sontek/pyramid_celery/pull/102 to fix Python 3.12 support and other improvements


### PR DESCRIPTION
- relates to https://github.com/celery/celery/issues/9254
- relates to https://jira.mongodb.org/browse/PYTHON-4756