### PR TITLE
allow `sphinx-argparse!=0.5.0` for latest fix 

### DIFF
--- a/docs/source/references.rst
+++ b/docs/source/references.rst
@@ -97,7 +97,7 @@
 .. |filter-jfe| replace:: JSON Filter Expressions
 .. _filter-jfe: https://github.com/tschaub/ogcapi-features/tree/json-array-expression/extensions/cql/jfe
 .. |geotiff-cog| replace:: Cloud Optimized GeoTIFF (COG)
-.. _geotiff-cog: https://www.cogeo.org/
+.. _geotiff-cog: http://www.cogeo.org/
 .. |metalink| replace:: Metalink
 .. _metalink: https://tools.ietf.org/html/rfc5854
 .. |geojson| replace:: GeoJSON

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -5,7 +5,7 @@
 -r requirements.txt
 jinja2
 sphinx>=6,<8
-sphinx-argparse<0.5.0
+sphinx-argparse!=0.5.0
 sphinx-autoapi>=1.7.0
 sphinx-paramlinks>=0.4.1
 # adds redoc OpenAPI directly served on readthedocs


### PR DESCRIPTION
- relates to https://github.com/sphinx-doc/sphinx-argparse/issues/57