### PR TITLE
Fix URL resolutions in various places

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -65,6 +65,7 @@ Changes:
 
 Fixes:
 ------
+- Fix ``url`` parameter to override the `CLI` internal ``url`` when passed explicitly to the invoked operation.
 - Fix ``href`` detection when provided directly as mapping within the ``executionUnit`` of the deployment body.
 - Fix definition of `CWL` ``schema.org`` namespaced fields (i.e.: ``s:author`` and ``s:dateCreated``) causing
   schema deserialization error when validation the submitted request body against typical examples provided in

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -65,6 +65,7 @@ Changes:
 
 Fixes:
 ------
+- Fix ``href`` detection when provided directly as mapping within the ``executionUnit`` of the deployment body.
 - Fix definition of `CWL` ``schema.org`` namespaced fields (i.e.: ``s:author`` and ``s:dateCreated``) causing
   schema deserialization error when validation the submitted request body against typical examples provided in
   `CWL Metadata and Authorship <https://www.commonwl.org/user_guide/topics/metadata-and-authorship.html>`_.

--- a/docs/source/processes.rst
+++ b/docs/source/processes.rst
@@ -414,13 +414,15 @@ Deployment of a new process is accomplished through the ``POST {WEAVER_URL}/proc
 The request body requires mainly two components:
 
 - | ``processDescription``:
-  | Defines the process identifier, metadata, inputs, outputs, and some execution specifications. This mostly
-    corresponds to information that is provided by traditional :term:`WPS` definition.
+  | Defines the :term:`Process` identifier, metadata, inputs, outputs, and some execution specifications.
+    This mostly corresponds to information that is provided by traditional :term:`WPS`
+    or :term:`OGC API - Processes` definitions.
 - | ``executionUnit``:
-  | Defines the core details of the `Application Package`_. This corresponds to the explicit :term:`CWL` definition
-    that indicates how to execute the given application.
+  | Defines the core details of the |app_pkg|_. This corresponds to the explicit :term:`CWL` definition
+    or other :ref:`proc_types` references that indicates how to execute the underlying application.
 
-.. _Application Package: docs/source/package.rst
+.. |app_pkg| replace:: Application Package
+.. _app_pkg: docs/source/package.rst
 
 Upon deploy request, `Weaver` will either respond with a successful result, or with the appropriate error message,
 whether caused by conflicting ID, invalid definitions or other parsing issues. A successful process deployment will

--- a/tests/functional/test_wps_package.py
+++ b/tests/functional/test_wps_package.py
@@ -4655,11 +4655,11 @@ class WpsPackageAppTestResultResponses(WpsConfigBase, ResourcesUtil):
             },
         }
 
-    @pytest.mark.oap_part1
     @parameterized.expand([
         ContentType.MULTIPART_ANY,
         ContentType.MULTIPART_MIXED,
     ])
+    @pytest.mark.oap_part1
     def test_execute_multi_output_multipart_accept(self, multipart_header):
         """
         Requesting ``multipart`` explicitly should return it instead of default :term:`JSON` ``document`` response.

--- a/tests/wps_restapi/test_jobs.py
+++ b/tests/wps_restapi/test_jobs.py
@@ -339,8 +339,6 @@ class WpsRestApiJobsTest(JobUtils):
                 for job in grouped_jobs["jobs"]:
                     self.check_job_format(job)
 
-    @pytest.mark.html
-    @pytest.mark.oap_part1
     @parameterized.expand([
         ({}, ),  # detail omitted should apply it for HTML, unlike JSON that returns the simplified listing by default
         ({"detail": None}, ),
@@ -353,6 +351,8 @@ class WpsRestApiJobsTest(JobUtils):
         ({"detail": "False"}, ),
         ({"detail": "no"}, ),
     ])
+    @pytest.mark.html
+    @pytest.mark.oap_part1
     def test_get_jobs_detail_html_enforced(self, params):
         """
         Using :term:`HTML`, ``detail`` response is always enforced to allow rendering, regardless of the parameter.
@@ -779,7 +779,6 @@ class WpsRestApiJobsTest(JobUtils):
         assert resp.status_code == 404
         assert resp.content_type == ContentType.APP_JSON
 
-    @pytest.mark.oap_part1
     @parameterized.expand([
         get_path_kvp(
             sd.jobs_service.path,
@@ -818,6 +817,7 @@ class WpsRestApiJobsTest(JobUtils):
             service="provider-2",
         ),
     ])
+    @pytest.mark.oap_part1
     def test_get_jobs_process_or_service_mismatch_in_path_or_query(self, path):
         # type: (str) -> None
         """
@@ -1820,13 +1820,13 @@ class WpsRestApiJobsTest(JobUtils):
         assert resp.status_code == 200
         assert resp.json["outputs"] == {"test": {"value": "data"}}
 
-    @pytest.mark.oap_part4
     @pytest.mark.xfail(reason="CWL PROV not implemented (https://github.com/crim-ca/weaver/issues/673)")
+    @pytest.mark.oap_part4
     def test_job_run_response(self):
         raise NotImplementedError  # FIXME (https://github.com/crim-ca/weaver/issues/673)
 
-    @pytest.mark.oap_part4
     @parameterized.expand([Status.ACCEPTED, Status.RUNNING, Status.FAILED, Status.SUCCEEDED])
+    @pytest.mark.oap_part4
     def test_job_update_locked(self, status):
         new_job = self.make_job(
             task_id=self.fully_qualified_test_name(), process=self.process_public.identifier, service=None,

--- a/weaver/cli.py
+++ b/weaver/cli.py
@@ -470,7 +470,9 @@ class WeaverClient(object):
         # type: (Optional[str]) -> str
         if not self._url and not url:
             raise ValueError("No URL available. Client was not created with an URL and operation did not receive one.")
-        return self._url or self._parse_url(url)
+        if url:
+            return self._parse_url(url)
+        return self._url
 
     @staticmethod
     def _parse_url(url):

--- a/weaver/processes/builtin/collection_processor.cwl
+++ b/weaver/processes/builtin/collection_processor.cwl
@@ -1,7 +1,6 @@
 #! /usr/bin/env cwl-runner
 cwlVersion: v1.0
 class: CommandLineTool
-id: collection_processor
 label: Collection Processor
 doc: |
   Retrieves relevant data or files resolved from a collection reference using its metadata, queries and desired outputs.

--- a/weaver/processes/utils.py
+++ b/weaver/processes/utils.py
@@ -467,7 +467,7 @@ def deploy_process_from_payload(payload, container, overwrite=False):  # pylint:
                 raise HTTPBadRequest("Invalid value for parameter 'deploymentProfileName'.")
         execution_units = payload.get("executionUnit")
         if isinstance(execution_units, dict):
-            if "unit" not in execution_units:
+            if "unit" not in execution_units and "href" not in execution_units:
                 execution_units = {"unit": execution_units}
             execution_units = [execution_units]
         if not isinstance(execution_units, list) or not len(execution_units) == 1:


### PR DESCRIPTION
- fix detection of `executionUnit` `href` using mapping representation 
- patch pytest markers with parametrized
- allow CLI override of `url` parameter on each operation