### PR TITLE
resolve OAS array with enum for OAP input directly specified

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -65,6 +65,8 @@ Changes:
 
 Fixes:
 ------
+- Fix `CWL` conversion from a `OGC API - Processes` definition specifying an `I/O` with ``schema`` explicitly
+  indicating a ``type: array`` and nested ``enum``, even if ``minOccurs: 1`` is omitted or explicitly set.
 - Fix definition of `CWL` ``schema.org`` namespaced fields (i.e.: ``s:author`` and ``s:dateCreated``) causing
   schema deserialization error when validation the submitted request body against typical examples provided in
   `CWL Metadata and Authorship <https://www.commonwl.org/user_guide/topics/metadata-and-authorship.html>`_.

--- a/docs/source/package.rst
+++ b/docs/source/package.rst
@@ -554,18 +554,18 @@ Inputs/Outputs ID
 -----------------------
 
 Inputs and outputs (:term:`I/O`) ``id`` from the :term:`CWL` context will be respectively matched against corresponding
-``id`` or ``identifier`` field from I/O of :term:`WPS` context. In the :term:`CWL` definition, all of the allowed I/O
-structures are supported, whether they are specified using an array list with explicit definitions, using "shortcut"
-variant (i.e.: ``<type>[]``), or using key-value pairs (see |cwl-io-map|_ for more details). Regardless of array or
-mapping format, :term:`CWL` requires that all I/O have unique ``id``.
-On the :term:`WPS` side, either a mapping or list of I/O are also expected with unique ``id``.
+``id`` or ``identifier`` field from :term:`I/O` of :term:`WPS` context. In the :term:`CWL` definition, all of the
+allowed :term:`I/O` structures are supported, whether they are specified using an array list with explicit definitions,
+using "shortcut" variant (i.e.: ``<type>[]``), or using key-value pairs (see |cwl-io-map|_ for more details).
+Regardless of array or mapping format, :term:`CWL` requires that all :term:`I/O` have unique ``id``.
+On the :term:`WPS` side, either a mapping or list of :term:`I/O` are also expected with unique ``id``.
 
 .. versionchanged:: 4.0
-    Previous versions only supported :term:`WPS` I/O using the listing format. Both can be used interchangeably in
-    both :term:`CWL` and :term:`WPS` contexts as of this version.
+    Previous versions only supported :term:`WPS` :term:`I/O` using the listing format.
+    Both can be used interchangeably in both :term:`CWL` and :term:`WPS` contexts as of this version.
 
-To summarize, the following :term:`CWL` and :term:`WPS` I/O definitions are all equivalent and will result into the
-same process definition after deployment. For simplification purpose, below examples omit all but mandatory fields
+To summarize, the following :term:`CWL` and :term:`WPS` :term:`I/O` definitions are all equivalent and will result into
+the same process definition after deployment. For simplification purpose, below examples omit all but mandatory fields
 (only of the ``inputs`` and ``outputs`` portion of the full deployment body) to produce the same result.
 Other fields are discussed afterward in specific sections.
 
@@ -616,11 +616,13 @@ the :ref:`Deploy <proc_op_deploy>` request body with any of the following variat
 .. warning::
     `Weaver` assumes that its main purpose is to eventually execute an :term:`Application Package` and will therefore
     prioritize specification in :term:`CWL` over :term:`WPS` to infer types. Because of this, any unmatched ``id`` from
-    the :term:`WPS` context against provided :term:`CWL` ``id``\s of the same I/O section **will be dropped**, as they
-    ultimately would have no purpose during :term:`CWL` execution.
+    the :term:`WPS` context against provided :term:`CWL` ``id``\s of the same :term:`I/O` section **will be dropped**,
+    as they ultimately would have no purpose during :term:`CWL` execution.
 
     This does not apply in the case of referenced :ref:`proc_wps_12` processes since no :term:`CWL` is available in the
-    first place.
+    first place. Similarly, when deploying a :ref:`Remote OGC API - Processes <proc_ogc_api>` by :term:`URL` reference,
+    it is expected that only the :term:`OAS` context (see :ref:`oas_io_schema`) with ``schema`` are provided. Therefore,
+    these definitions could overrule the :term:`CWL` resolution that would normally occur.
 
 .. _cwl-io-types:
 
@@ -650,7 +652,10 @@ The simplification of types can happen when converting in any direction
 It all depends on which definitions that were provided are the more specific. For example, a :term:`WPS` ``dateTime``
 will be simplified to a generic :term:`CWL` ``string``, and into an :term:`OAS` ``string`` with ``format: "date-time"``.
 In this example, it would be important to provide the :term:`WPS` or :term:`OAS` definitions if the *date-time* portion
-was critical, since it could not be inferred only from :term:`CWL` ``string``.
+was critical, since it could not be inferred only from :term:`CWL` ``string`` (since it doesn't define this concept).
+
+.. seealso::
+    Further details for the :term:`OAS` context are provided in :ref:`oas_io_schema`.
 
 Further details regarding handling methods or important considerations for
 specific types will be presented in :ref:`cwl-type` and :ref:`cwl-dir` sections.
@@ -740,10 +745,10 @@ In the :term:`WPS` context, three data types exist, namely ``Literal``, ``Boundi
 
 As presented in previous examples, :term:`I/O` in the :term:`WPS` context does not require an explicit indication of
 which data type from one of ``Literal``, ``BoundingBox`` and ``Complex`` to apply. Instead, :term:`WPS` type can be
-inferred using the matched API schema of the I/O. For instance, ``Complex`` I/O (e.g.: file reference) requires the
-``formats`` field to distinguish it from a plain ``string``. Therefore, specifying either ``format`` in :term:`CWL`
-or ``formats`` in :term:`WPS` immediately provides all needed information for `Weaver` to understand that this I/O is
-expected to be a file reference.
+inferred using the matched API schema of the :term:`I/O`. For instance, ``Complex`` :term:`I/O`
+(e.g.: :ref:`File Reference <file_ref_types>`) requires the ``formats`` field to distinguish it from a plain ``string``.
+Therefore, specifying either ``format`` in :term:`CWL` or ``formats`` in :term:`WPS` immediately provides all needed
+information for `Weaver` to understand that this :term:`I/O` is expected to be a file reference.
 
 .. code-block:: json
     :caption: WPS Complex Data Type
@@ -884,7 +889,7 @@ Following is an example where input definitions are equivalent in both :term:`CW
 
     +-----------------------------------------------+-----------------------------------------------------------------+
     | .. code-block:: json                          | .. code-block:: json                                            |
-    |    :caption: WPS Format with MIME-type        |    :caption: CWL Format with Namespace                          |
+    |    :caption: :term:`WPS` Format with MIME-type|    :caption: :term:`CWL` Format with Namespace                  |
     |    :linenos:                                  |    :linenos:                                                    |
     |                                               |                                                                 |
     |    {                                          |    {                                                            |
@@ -982,18 +987,18 @@ the following two variants are equivalent and completely interchangeable.
     :widths: 50,50
 
     +---------------------------------------------------+-----------------------------------------------+
-    | .. code-block:: json                              | .. code-block:: json                          |
-    |    :caption: WPS AllowedValues Input              |    :caption: CWL Enum Values                  |
-    |    :linenos:                                      |    :linenos:                                  |
-    |                                                   |                                               |
-    |    {                                              |    {                                          |
-    |      "id": "input",                               |      "id": "input",                           |
-    |      "literalDataDomains": [                      |      "type": {                                |
-    |        {"allowedValues": ["value-1", "value-2"]}  |        "type": "enum",                        |
-    |      ]                                            |        "symbols": ["value-1", "value-2"]      |
-    |    }                                              |      }                                        |
-    |                                                   |    }                                          |
-    +---------------------------------------------------+-----------------------------------------------+
+   | .. code-block:: json                              | .. code-block:: json                          |
+   |    :caption: :term:`WPS` AllowedValues Input      |    :caption: :term:`CWL` Enum Values          |
+   |    :linenos:                                      |    :linenos:                                  |
+   |                                                   |                                               |
+   |    {                                              |    {                                          |
+   |      "id": "input",                               |      "id": "input",                           |
+   |      "literalDataDomains": [                      |      "type": {                                |
+   |        {"allowedValues": ["value-1", "value-2"]}  |        "type": "enum",                        |
+   |      ]                                            |        "symbols": ["value-1", "value-2"]      |
+   |    }                                              |      }                                        |
+   |                                                   |    }                                          |
+   +---------------------------------------------------+-----------------------------------------------+
 
 `Weaver` will ensure to propagate such definitions bidirectionally in order to update the :term:`CWL` or :term:`WPS`
 correspondingly with the provided information in the other context if missing. The primitive type to apply to a missing
@@ -1026,8 +1031,8 @@ than :term:`CWL` because all details are contained within the same two parameter
 preferable to provide the ``minOccurs`` and ``maxOccurs`` in the :term:`WPS` context, and let `Weaver` infer the
 ``array`` and/or ``"null"`` type requirements automatically. Also, because of all implied parameters in this situation
 to specify the similar details, it is important to avoid providing contradicting specifications as `Weaver` will have
-trouble guessing the intended result when merging specifications. If unambiguous guess can be made, :term:`CWL` will be
-employed as the overruling definition to resolve erroneous mismatches (as for any other corresponding fields).
+trouble guessing the intended result when merging specifications. If an ambiguous guess is made, :term:`CWL` will
+be employed as the overruling definition to resolve erroneous mismatches (as for any other corresponding fields).
 
 .. warning::
     Parameters ``minOccurs`` and ``maxOccurs`` are not permitted for outputs in the :term:`WPS` context. Native
@@ -1048,20 +1053,20 @@ of *multiple* and *optional* information.
     :align: center
     :widths: 50,50
 
-    +---------------------------------------------------+-----------------------------------------------------------+
-    | .. code-block:: json                              | .. code-block:: json                                      |
-    |    :caption: WPS Multi-Value Input (required)     |    :caption: CWL Multi-Value Input (required)             |
-    |    :linenos:                                      |    :linenos:                                              |
-    |                                                   |                                                           |
-    |    {                                              |    {                                                      |
-    |      "id": "input-multi-required",                |      "id": "input-multi-required",                        |
-    |      "format": "application/json",                |      "format": "iana:application/json",                   |
-    |      "minOccurs": 1,                              |      "type": {                                            |
-    |      "maxOccurs": "unbounded"                     |        "type": "array", "items": "File"                   |
-    |    }                                              |      }                                                    |
-    |                                                   |    }                                                      |
-    |                                                   |                                                           |
-    +---------------------------------------------------+-----------------------------------------------------------+
+    +-------------------------------------------------------+-------------------------------------------------------+
+    | .. code-block:: json                                  | .. code-block:: json                                  |
+    |    :caption: :term:`WPS` Multi-Value Input (required) |    :caption: :term:`CWL` Multi-Value Input (required) |
+    |    :linenos:                                          |    :linenos:                                          |
+    |                                                       |                                                       |
+    |    {                                                  |    {                                                  |
+    |      "id": "input-multi-required",                    |      "id": "input-multi-required",                    |
+    |      "format": "application/json",                    |      "format": "iana:application/json",               |
+    |      "minOccurs": 2,                                  |      "type": {                                        |
+    |      "maxOccurs": "unbounded"                         |        "type": "array", "items": "File"               |
+    |    }                                                  |      }                                                |
+    |                                                       |    }                                                  |
+    |                                                       |                                                       |
+    +-------------------------------------------------------+-------------------------------------------------------+
 
 
 It can be noted from the examples that ``minOccurs`` and ``maxOccurs`` can be either an ``integer`` or a ``string``
@@ -1102,27 +1107,27 @@ parameters presented later in this section. Some definitions are also not comple
     :align: center
     :widths: 33,34,33
 
-    +-------------------------------+------------------------------+-----------------------------+
-    | .. code-block:: json          | .. code-block:: json         | .. code-block:: json        |
-    |    :caption: WPS Input        |    :caption: OAS Input       |    :caption: CWL Input      |
-    |    :linenos:                  |    :linenos:                 |    :linenos:                |
-    |                               |                              |                             |
-    |    {                          |    {                         |    {                        |
-    |      "id": "input",           |      "id": "input",          |      "id": "input",         |
-    |      "literalDataDomains": [  |      "schema": {             |      "type": {              |
-    |        {                      |        "type": "array",      |        "type": "array",     |
-    |           "allowedValues": [  |        "items": {            |        "items": {           |
-    |             "value-1",        |          "type": "string",   |          "type": "enum",    |
-    |             "value-2"         |          "enum": [           |          "symbols": [       |
-    |           ]                   |            "value-1",        |            "value-1",       |
-    |        }                      |            "value-2"         |            "value-2"        |
-    |      ],                       |          ]                   |          ]                  |
-    |      "minOccurs": 2,          |        },                    |        }                    |
-    |      "maxOccurs": 4           |        "minItems": 2,        |      }                      |
-    |    }                          |        "maxItems": 4         |    }                        |
-    |                               |      }                       |                             |
-    |                               |    }                         |                             |
-    +-------------------------------+------------------------------+-----------------------------+
+    +--------------------------------+--------------------------------+--------------------------------+
+    | .. code-block:: json           | .. code-block:: json           | .. code-block:: json           |
+    |    :caption: :term:`WPS` Input |    :caption: :term:`OAS` Input |    :caption: :term:`CWL` Input |
+    |    :linenos:                   |    :linenos:                   |    :linenos:                   |
+    |                                |                                |                                |
+    |    {                           |    {                           |    {                           |
+    |      "id": "input",            |      "id": "input",            |      "id": "input",            |
+    |      "literalDataDomains": [   |      "schema": {               |      "type": {                 |
+    |        {                       |        "type": "array",        |        "type": "array",        |
+    |           "allowedValues": [   |        "items": {              |        "items": {              |
+    |             "value-1",         |          "type": "string",     |          "type": "enum",       |
+    |             "value-2"          |          "enum": [             |          "symbols": [          |
+    |           ]                    |            "value-1",          |            "value-1",          |
+    |        }                       |            "value-2"           |            "value-2"           |
+    |      ],                        |          ]                     |          ]                     |
+    |      "minOccurs": 2,           |        },                      |        }                       |
+    |      "maxOccurs": 4            |        "minItems": 2,          |      }                         |
+    |    }                           |        "maxItems": 4           |    }                           |
+    |                                |      }                         |                                |
+    |                                |    }                           |                                |
+    +--------------------------------+--------------------------------+--------------------------------+
 
 .. seealso::
     An example with extensive variations of supported :term:`I/O` definitions with :term:`OAS` is
@@ -1136,13 +1141,103 @@ As per all previous parameters in :term:`CWL` and :term:`WPS` contexts, details 
 complementary and `Weaver` will attempt to infer, combine and convert between the various representations as best
 as possible according to the level of details provided.
 
-Furthermore, `Weaver` will *extend* (as needed) any provided ``schema`` during
+Furthermore, `Weaver` will *extend* (as needed) any provided ``schema`` and the resulting :term:`CWL` ``type`` during
 :ref:`Process Deployment <proc_op_deploy>` if it can identify that the specific :term:`OAS` definition is inconsistent
-with other parameters. For example, if ``minOccurs``/``maxOccurs`` were provided by indicating that the :term:`I/O` must
-have exactly between [2-4] elements, but only a single :term:`OAS` object was defined under ``schema``, that :term:`OAS`
-definition would be converted to the corresponding array, as single values are not permitted in this case. Similarly, if
-the range of items was instead [1-4], the :term:`OAS` definition would be adjusted with ``oneOf`` keyword, allowing both
+with other parameters. It will also consider any supplementary details provided across all contexts (:term:`CWL`,
+:term:`WPS` and :term:`OAS`) to resolve the definitions in the other unspecified contexts.
+
+For example (as shown below), if ``minOccurs``/``maxOccurs`` are provided to indicate that the :term:`I/O` must
+have exactly between [2-4] elements, but only a single :term:`OAS` object is defined under ``schema``, that :term:`OAS`
+definition would be converted internally (since single values would not make sense in this case), to generate the
+corresponding array representation for the final :term:`CWL` ``type``. If the amount of allowed items was
+instead in the [1-4] range, the :term:`OAS` definition would be adjusted with a ``oneOf`` keyword, allowing both
 single value and array representation of those values, when submitted for :ref:`Process Execution <proc_op_execute>`.
+The :term:`CWL` ``type`` would also be adjusted automatically to represent the same single/multi-value flexibility.
+Finally, if ``minOccurs=0`` is detected along the :term:`OAS` definition, `Weaver` will consider that this :term:`I/O`
+is optional (see also :ref:`cwl-array-null-values`), and will update the :term:`CWL` representation accordingly
+with the ``"null"`` type.
+
+.. table::
+    :class: table-code
+    :name: table-io-oas2cwl-single
+    :align: center
+    :widths: 50,50
+
+    +
+    | Submitted :term:`OAS` :term:`I/O` | Resolved :term:`CWL` :term:`I/O` |
+    +------------------------------+-----------------------------+
+    | .. code-block:: json         | .. code-block:: json        |
+    |    :caption: OAS Input       |    :caption: CWL Input      |
+    |    :linenos:                 |    :linenos:                |
+    |                              |                             |
+    |    {                         |    {                        |
+    |      "id": "input",          |      "id": "input",         |
+    |      "schema": {             |      "type": {              |
+    |        "type": "string",     |        "type": "enum",      |
+    |        "enum": [             |        "symbols": [         |
+    |          "value-1",          |          "value-1",         |
+    |          "value-2"           |          "value-2"          |
+    |        ]                     |        ]                    |
+    |      },                      |      }                      |
+    |      "minOccurs": 2,         |    }                        |
+    |      "maxOccurs": 4          |                             |
+    |    }                         |                             |
+    |                              |                             |
+    |                              |                             |
+    |                              |                             |
+    +------------------------------+-----------------------------+
+
+.. table::
+    :class: table-code
+    :name: table-io-oas2cwl-single-or-multi
+    :align: center
+    :widths: 50,50
+
+    +
+    | Submitted :term:`OAS` :term:`I/O` | Resolved :term:`CWL` :term:`I/O` |
+    +------------------------------+-----------------------------+
+    | .. code-block:: json         | .. code-block:: json        |
+    |    :caption: OAS Input       |    :caption: CWL Input      |
+    |    :linenos:                 |    :linenos:                |
+    |                              |                             |
+    |    {                         |    {                        |
+    |      "id": "input",          |      "id": "input",         |
+    |      "schema": {             |      "type": {              |
+    |        "type": "array",      |        "type": "array",     |
+    |        "items": {            |        "items": {           |
+    |          "type": "string",   |          "type": "enum",    |
+    |          "enum": [           |          "symbols": [       |
+    |            "value-1",        |            "value-1",       |
+    |            "value-2"         |            "value-2"        |
+    |          ]                   |          ]                  |
+    |        },                    |        }                    |
+    |        "minItems": 2,        |      }                      |
+    |        "maxItems": 4         |    }                        |
+    |      }                       |                             |
+    |    }                         |                             |
+    +------------------------------+-----------------------------+
+
+.. table::
+    :class: table-code
+    :name: table-io-oas2cwl-single-nullable
+    :align: center
+    :widths: 50,50
+
+    +
+    | Submitted :term:`OAS` :term:`I/O` | Resolved :term:`CWL` :term:`I/O` |
+    +------------------------------+-----------------------------+
+
+.. _warn-single-occurs-multi:
+.. versionchanged:: 6.0
+
+    One known ambiguous resolution can happen when deploying a :term:`OGC API - Processes` that explicitly
+    defines an :term:`I/O` ``schema`` with a ``type: array`` specification.
+    By default, :term:`OGC API - Processes` and :term:`WPS` contexts consider that omitting ``minOccurs``/``maxOccurs``
+    is equivalent to setting both of them to ``1``.
+    However, given that an ``array`` implies multiple values, the resolution is in itself ambiguous.
+    In such case, `Weaver` will assume that users intend their :term:`I/O` to be an array, and will silently ignore
+    the ambiguity to generate a :term:`CWL` and :term:`WPS` representation as if ``minOccurs>1`` was specified.
+
 
 Below is a summary of fields that are equivalent or considered to identify similar specifications
 (corresponding fields are aligned in the table).
@@ -1215,7 +1310,7 @@ automatically expended using the ``oneOf`` structure with other missing componen
 
     +-----------------------------------------------------------+---------------------------------------------------+
     | .. code-block:: json                                      | .. code-block:: json                              |
-    |   :caption: JSON Complex Input with schema reference      |   :caption: Generic JSON Complex Input            |
+    |   :caption: :term:`JSON` Complex Input with Reference     |   :caption: Generic :term:`JSON` Complex Input    |
     |                                                           |                                                   |
     |    {                                                      |    {                                              |
     |      "id:" "input",                                       |      "id:" "input",                               |

--- a/docs/source/package.rst
+++ b/docs/source/package.rst
@@ -986,7 +986,7 @@ the following two variants are equivalent and completely interchangeable.
     :align: center
     :widths: 50,50
 
-    +---------------------------------------------------+-----------------------------------------------+
+   +---------------------------------------------------+-----------------------------------------------+
    | .. code-block:: json                              | .. code-block:: json                          |
    |    :caption: :term:`WPS` AllowedValues Input      |    :caption: :term:`CWL` Enum Values          |
    |    :linenos:                                      |    :linenos:                                  |
@@ -1156,10 +1156,9 @@ have exactly between [2-4] elements, but only a single :term:`OAS` object instan
 that :term:`OAS` definition will be converted internally (since single values would not make sense in this case),
 to generate the corresponding array representation for the final :term:`CWL` ``type``.
 
-.. table::
+.. table:: Mutil-Value Array inferred from Occurrences
     :class: table-code
     :name: table-io-oas2cwl-multi
-    :caption: Mutil-Value Array inferred from Occurrences
     :align: center
     :widths: 50,50
 
@@ -1190,10 +1189,9 @@ to conveniently allow submitting a :ref:`Process Execution <proc_op_execute>` wi
 an array of this value representation.
 The :term:`CWL` ``type`` would also be adjusted automatically to represent the same single/multi-value flexibility.
 
-.. table::
+.. table:: Single/Mutil-Value Array inferred from Occurrences
     :class: table-code
     :name: table-io-oas2cwl-single-or-multi
-    :caption: Single/Mutil-Value Array inferred from Occurrences
     :align: center
     :widths: 50,50
 
@@ -1233,10 +1231,9 @@ representation accordingly with the ``"null"`` type, as shown below.
 .. seealso::
     :ref:`cwl-array-null-values`
 
-.. table::
+.. table:: Nullable Single/Multi-Value Array inferred from Occurrences
     :class: table-code
     :name: table-io-oas2cwl-single-or-multi-nullable
-    :caption: Nullable Single/Multi-Value Array inferred from Occurrences
     :align: center
     :widths: 50,50
 
@@ -1294,10 +1291,9 @@ definition, as shown below.
     (since it was specified explicitly in the submitted ``schema``), and will silently ignore the ambiguity
     to generate a :term:`CWL` and :term:`WPS` representation as if ``minOccurs>1`` was specified.
 
-.. table::
+.. table:: Multi-Value Array inferred from Occurrences
     :class: table-code
     :name: table-io-oas2cwl-array
-    :caption: Multi-Value Array inferred from Occurrences
     :align: center
     :widths: 50,50
 
@@ -1324,10 +1320,9 @@ definition, as shown below.
 As one might expect, mixing ``minOccurs=0`` in combination with the ``type: array`` within the ``schema``
 will also generate the relevant representation by combining it with ``"null"`` for the :term:`CWL` type definition.
 
-.. table::
+.. table:: Nullable Multi-Value Array inferred from Occurrences
     :class: table-code
     :name: table-io-oas2cwl-array-nullable
-    :caption: Nullable Multi-Value Array inferred from Occurrences
     :align: center
     :widths: 50,50
 
@@ -1368,10 +1363,9 @@ Note that all :term:`OAS` elements are always nested under the ``schema`` field 
 located where appropriate as per :term:`OpenAPI` specification. Other :term:`OAS` fields are still permitted, but
 are not explicitly handled to search for corresponding definitions in :term:`WPS` and :term:`CWL` contexts.
 
-.. table::
+.. table:: Summary of :term:`I/O` Context Mappings
     :align: center
     :name: table-io-summary-context-mapping
-    :caption: Summary of :term:`I/O` Context Mappings
 
     +-------------------------------------+---------------------------------------+------------------------------------+
     | Parameters in :term:`WPS` Context   | Parameters in :term:`OAS` Context     | Parameters in :term:`CWL` Context  |
@@ -1438,7 +1432,7 @@ submitting the :term:`I/O` definition.
     |   :caption: :term:`JSON` Complex Input with Reference     |
     |                                                           |
     |    {                                                      |
-    |      "id:" "input",                                       |
+    |      "id": "input",                                       |
     |      "schema": {                                          |
     |        "oneOf": [                                         |
     |          {                                                |
@@ -1463,7 +1457,7 @@ submitting the :term:`I/O` definition.
     |   :caption: Generic :term:`JSON` Complex Input    |
     |                                                   |
     |    {                                              |
-    |      "id:" "input",                               |
+    |      "id": "input",                               |
     |      "schema": {                                  |
     |        "oneOf": [                                 |
     |          {                                        |
@@ -1514,8 +1508,8 @@ purposes.
    by reference.
 
 2. Using a generic ``{"type": "string", "format": "uri"}`` :term:`OAS` schema does not convey the :term:`Media-Types`
-   requirements as well as inferring them "link-to" ``{"type": "string", "contentMediaType: <format>}``. It is therefore
-   better to omit them entirely as they do not add any :term:`I/O` descriptive value.
+   requirements as well as inferring them from a ``{"type": "string", "contentMediaType: <media-type>}`` representation.
+   It is therefore better to omit them entirely as they do not add any :term:`I/O` descriptive value.
 
 3. Because the above string-formatted ``uri`` are left out from definitions, it can instead be used explicitly in an
    :term:`I/O` specification to indicate to `Weaver` that the :term:`Process` uses a ``Literal`` URI string, that must
@@ -1539,7 +1533,7 @@ schema can be added as well, as presented in :ref:`oas_json_types` section.
     |    :caption: Single Format Complex Input  |    :caption: Multiple Supported Format Complex Input  |
     |                                           |                                                       |
     |    {                                      |    {                                                  |
-    |      "id:" "input",                       |      "id:" "input",                                   |
+    |      "id": "input",                       |      "id": "input",                                   |
     |      "schema": {                          |      "schema": {                                      |
     |        "type": "string",                  |        "oneOf": [                                     |
     |        "contentMediaType": "image/png",   |          {                                            |

--- a/tests/processes/test_convert.py
+++ b/tests/processes/test_convert.py
@@ -532,6 +532,84 @@ def test_any2cwl_io_from_oas():
                 "inputBinding": {"valueFrom": _get_cwl_js_value_from([1, 2, 3], allow_unique=True, allow_array=True)},
             },
         ),
+        (
+            IO_INPUT,
+            {
+                "id": "test",
+                "schema": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": ["a", "b", "c"]
+                    }
+                }
+            },
+            {
+                "id": "test",
+                # note: "type" as array of single mapping with "type: array" would also be valid ([] around the {})
+                "type": {
+                    "type": "array",
+                    "items": {
+                        "type": "enum",
+                        "symbols": ["a", "b", "c"],
+                    },
+                }
+            }
+        ),
+        (
+            IO_INPUT,
+            {
+                "id": "test",
+                "minOccurs": 0,
+                "schema": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": ["a", "b", "c"]
+                    }
+                }
+            },
+            {
+                "id": "test",
+                "type": [
+                    "null",
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "enum",
+                            "symbols": ["a", "b", "c"],
+                        },
+                    }
+                ]
+            }
+        ),
+        (
+            IO_INPUT,
+            {
+                "id": "test",
+                "minOccurs": 0,
+                "schema": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": ["a", "b", "c"]
+                    }
+                }
+            },
+            {
+                "id": "test",
+                "type": [
+                    "null",
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "enum",
+                            "symbols": ["a", "b", "c"],
+                        },
+                    }
+                ]
+            }
+        )
     ]
 )
 def test_any2cwl_io_enum_convert(io_select, test_io, expect):

--- a/tests/processes/test_convert.py
+++ b/tests/processes/test_convert.py
@@ -533,14 +533,99 @@ def test_any2cwl_io_from_oas():
             },
         ),
         (
+            # documentation example
             IO_INPUT,
             {
                 "id": "test",
                 "schema": {
+                    "type": "string",
+                    "enum": ["value-1", "value-2"]
+                },
+                "minOccurs": 2,
+                "maxOccurs": 4,
+            },
+            {
+                "id": "test",
+                "type": {
+                    "type": "array",
+                    "items": {
+                        "type": "enum",
+                        "symbols": ["value-1", "value-2"],
+                    },
+                }
+            }
+        ),
+        (
+            # documentation example
+            IO_INPUT,
+            {
+                "id": "test",
+                "schema": {
+                    "type": "string",
+                    "enum": ["value-1", "value-2"]
+                },
+                "minOccurs": 1,
+                "maxOccurs": 4,
+            },
+            {
+                "id": "test",
+                "type": [
+                    {
+                        "type": "enum",
+                        "symbols": ["value-1", "value-2"],
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "enum",
+                            "symbols": ["value-1", "value-2"],
+                        },
+                    }
+                ]
+            }
+        ),
+        (
+            # documentation example
+            IO_INPUT,
+            {
+                "id": "test",
+                "schema": {
+                    "type": "string",
+                    "enum": ["value-1", "value-2"]
+                },
+                "minOccurs": 0,
+                "maxOccurs": 4,
+            },
+            {
+                "id": "test",
+                "type": [
+                    "null",
+                    {
+                        "type": "enum",
+                        "symbols": ["value-1", "value-2"],
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "enum",
+                            "symbols": ["value-1", "value-2"],
+                        },
+                    }
+                ]
+            }
+        ),
+        (
+            # documentation example
+            IO_INPUT,
+            {
+                "id": "test",
+                "schema": {
+                    # explicitly array, MUST force CWL to be an array as well
+                    # doesn't matter that default min/max occurs = 1
                     "type": "array",
                     "items": {
                         "type": "string",
-                        "enum": ["a", "b", "c"]
+                        "enum": ["value-1", "value-2"]
                     }
                 }
             },
@@ -551,21 +636,47 @@ def test_any2cwl_io_from_oas():
                     "type": "array",
                     "items": {
                         "type": "enum",
-                        "symbols": ["a", "b", "c"],
+                        "symbols": ["value-1", "value-2"],
                     },
                 }
             }
         ),
         (
+            # documentation example
             IO_INPUT,
             {
                 "id": "test",
-                "minOccurs": 0,
+                "minOccurs": 1,  # same as previous, but explicitly specified rather than default
                 "schema": {
                     "type": "array",
                     "items": {
                         "type": "string",
-                        "enum": ["a", "b", "c"]
+                        "enum": ["value-1", "value-2"]
+                    }
+                }
+            },
+            {
+                "id": "test",
+                "type": {
+                    "type": "array",
+                    "items": {
+                        "type": "enum",
+                        "symbols": ["value-1", "value-2"],
+                    },
+                }
+            }
+        ),
+        (
+            # documentation example
+            IO_INPUT,
+            {
+                "id": "test",
+                "minOccurs": 0,  # because optional, array must be combined with "null"
+                "schema": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": ["value-1", "value-2"]
                     }
                 }
             },
@@ -577,22 +688,24 @@ def test_any2cwl_io_from_oas():
                         "type": "array",
                         "items": {
                             "type": "enum",
-                            "symbols": ["a", "b", "c"],
+                            "symbols": ["value-1", "value-2"],
                         },
                     }
                 ]
             }
         ),
         (
+            # documentation example
             IO_INPUT,
             {
                 "id": "test",
-                "minOccurs": 0,
+                "minOccurs": 0,  # same as previous
+                "maxOccurs": 4,  # explicitly specified should not change anything
                 "schema": {
                     "type": "array",
                     "items": {
                         "type": "string",
-                        "enum": ["a", "b", "c"]
+                        "enum": ["value-1", "value-2"]
                     }
                 }
             },
@@ -604,7 +717,7 @@ def test_any2cwl_io_from_oas():
                         "type": "array",
                         "items": {
                             "type": "enum",
-                            "symbols": ["a", "b", "c"],
+                            "symbols": ["value-1", "value-2"],
                         },
                     }
                 ]

--- a/weaver/processes/convert.py
+++ b/weaver/processes/convert.py
@@ -928,17 +928,38 @@ def any2cwl_io(wps_io, io_select):
     # convert OAS format to JSON first to simplify following comparisons
     wps_io_type = get_field(wps_io, "type", search_variations=True)
     wps_io_schema = get_field(wps_io, "schema", search_variations=False)
+
+    # check for min/max occurs before 'schema' conversion because they
+    # can be employed with either the WPS or the OGC API representations
+    wps_min_occ = get_field(wps_io, "min_occurs", search_variations=True)
+    wps_max_occ = get_field(wps_io, "max_occurs", search_variations=True)
+
+    schema_array = False
     if wps_io_type is null and isinstance(wps_io_schema, dict):
         wps_io = oas2json_io(wps_io_schema)
         wps_io_cat = get_field(wps_io, "type", search_variations=False)
         wps_io_type = get_field(wps_io, "data_type", search_variations=False)
+        schema_array = get_field(wps_io_schema, "type", search_variations=False) == "array"
+
+        # re-check for min/max occurs in case some details where inferred from the 'schema'
+        if wps_min_occ is null:
+            wps_min_occ = get_field(wps_io, "min_occurs", search_variations=True, default=1)
+        if wps_max_occ is null:
+            wps_max_occ = get_field(wps_io, "max_occurs", search_variations=True)
 
     wps_default = get_field(wps_io, "default", search_variations=True)
-    wps_min_occ = get_field(wps_io, "min_occurs", search_variations=True, default=1)
-    wps_max_occ = get_field(wps_io, "max_occurs", search_variations=True)
     is_min_null = wps_min_occ in [0, "0"]
     allow_unique = wps_min_occ in [0, "0", 1, "1"]
     allow_array = wps_max_occ != null and (wps_max_occ == "unbounded" or wps_max_occ > 1)
+
+    # If the OGC API 'schema' of the I/O explicitly requested for an array,
+    # min occurrence of 1 should be interpreted as needing at least 1 value *in the array*.
+    # This reflects the typical expectation since omitting the occurrence means 1 by default,
+    # but an implementation that desires a direct value wouldn't usually indicate 'type: array'.
+    # (relates to https://github.com/opengeospatial/ogcapi-processes/issues/414)
+    if schema_array:
+        allow_unique = False
+        allow_array = True
 
     if wps_io_cat not in list(WPS_COMPLEX_TYPES):
         cwl_io_type = any2cwl_literal_datatype(wps_io_type)
@@ -946,6 +967,7 @@ def any2cwl_io(wps_io, io_select):
             LOGGER.warning("Could not identify a CWL literal data type with [%s].", wps_io_type)
         wps_allow = get_field(wps_io, "allowed_values", search_variations=True)
         if isinstance(wps_allow, list) and len(wps_allow) > 0:
+
             cwl_io_enum = _convert_cwl_io_enum(cwl_io_type, wps_allow, io_select, allow_unique, allow_array)
             cwl_io.update(cwl_io_enum)
         else:
@@ -971,7 +993,7 @@ def any2cwl_io(wps_io, io_select):
                 "items": cwl_io["type"]
             }
             # if single value still allowed, or explicitly multi-value array if min greater than one
-            if wps_min_occ > 1:
+            if wps_min_occ > 1 or not allow_unique:
                 cwl_io["type"] = cwl_array
             else:
                 cwl_io["type"] = [cwl_io["type"], cwl_array]

--- a/weaver/processes/convert.py
+++ b/weaver/processes/convert.py
@@ -947,6 +947,9 @@ def any2cwl_io(wps_io, io_select):
         if wps_max_occ is null:
             wps_max_occ = get_field(wps_io, "max_occurs", search_variations=True)
 
+    if wps_min_occ is null:
+        wps_min_occ = 1
+
     wps_default = get_field(wps_io, "default", search_variations=True)
     is_min_null = wps_min_occ in [0, "0"]
     allow_unique = wps_min_occ in [0, "0", 1, "1"]


### PR DESCRIPTION
Given an input using: 

```json
{
  "id": "test",
  "schema": {
      "type": "array",
      "items": {
          "type": "string",
          "enum": ["value-1", "value-2"]
      }
  }
}
```

Automatically convert it in CWL as: 
```json
{
    "id": "test",
    "type": {
        "type": "array",
        "items": {
            "type": "enum",
            "symbols": ["value-1", "value-2"],
        },
    }
}
```

Previously, the definition was erroneously converted to the nested CWL enum by itself (without array representation). 
