### PR TITLE
setup zenodo and add citations

### DIFF
--- a/.github/workflows/zenodo.yml
+++ b/.github/workflows/zenodo.yml
@@ -1,0 +1,67 @@
+name: Zenodo Release
+
+on:
+  push:
+    branches: [master]
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+    if: ${{ success() && contains(github.ref, 'refs/tags') }}
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: "0"
+    - name: Download Archive
+      env:
+        tarball: ${{ github.event.release.tarball_url }}
+        zipball: ${{ github.event.release.zipball_url }}
+      # Add the suffix to the name of the file so type is recognized when
+      # downloading from Zenodo .tar.gz for tarball and .zip for zipball.
+      # Archiving the zipball will cause Zenodo to show a preview of the contents while using tarball will not.
+      run: |
+        name=$(basename ${zipball}).zip
+        curl -L $zipball > $name
+        echo "archive=${name}" >> $GITHUB_ENV
+
+    - name: Run Zenodo Publish
+      id: deploy_zenodo
+      uses: rseng/zenodo-release@main
+      with:
+        token: ${{ secrets.ZENODO_TOKEN }}
+        version: ${{ github.ref_name }}
+        zenodo_json: .zenodo.json
+        html_url: ${{ github.server_url }}/${{ github.repository }}/tree/${{ github.ref_name }}  # GitHub tag link
+        archive: ${{ env.archive }}
+
+        # DOI for all versions. Leaving this blank (the default) will create
+        # a new DOI on every release. Use a DOI that represents all versions will
+        # create a new version for this existing DOI.
+        # Newer versions have their own DOIs, but they're also linked to this DOI
+        # as a different version. When using this, use the DOI for all versions.
+        doi: '10.5281/zenodo.14210717'
+
+    - name: View Outputs
+      env:
+        doi: ${{ steps.deploy_zenodo.outputs.doi }}
+        conceptdoi: ${{ steps.deploy_zenodo.outputs.conceptdoi }}
+        conceptbadge: ${{ steps.deploy_zenodo.outputs.conceptbadge }}
+        badge: ${{ steps.deploy_zenodo.outputs.badge }}
+        bucket: ${{ steps.deploy_zenodo.outputs.bucket }}
+        latest: ${{ steps.deploy_zenodo.outputs.latest }}
+        latest_html: ${{ steps.deploy_zenodo.outputs.latest_html }}
+        record: ${{ steps.deploy_zenodo.outputs.record }}
+        record_html: ${{ steps.deploy_zenodo.outputs.record_html }}
+      run: |
+        echo "doi ${doi}"
+        echo "conceptdoi ${conceptdoi}"
+        echo "conceptbadge ${conceptbadge}"
+        echo "badge ${badge}"
+        echo "bucket ${bucket}"
+        echo "latest ${latest}"
+        echo "latest html ${latest_html}"
+        echo "record ${record}"
+        echo "record html ${record_html}"

--- a/.github/workflows/zenodo.yml
+++ b/.github/workflows/zenodo.yml
@@ -25,17 +25,24 @@ jobs:
       run: |
         name=$(basename ${zipball}).zip
         curl -L $zipball > $name
-        echo "archive=${name}" >> $GITHUB_ENV
+        echo "ZENODO_ARCHIVE=${name}" >> $GITHUB_ENV
+
+    - name: Generate Changelog
+      id: zenodo_metadata
+      run: |
+        make generate-changes-html VERSION=${{ github.ref_name }}
+        echo "ZENODO_DESCRIPTION=$(cat reports/CHANGES_${{ github.ref_name }}.html | tr -d '\n')" >> $GITHUB_ENV
 
     - name: Run Zenodo Publish
       id: deploy_zenodo
-      uses: rseng/zenodo-release@main
+      uses: fmigneault/zenodo-release@main
       with:
         token: ${{ secrets.ZENODO_TOKEN }}
         version: ${{ github.ref_name }}
         zenodo_json: .zenodo.json
         html_url: ${{ github.server_url }}/${{ github.repository }}/tree/${{ github.ref_name }}  # GitHub tag link
-        archive: ${{ env.archive }}
+        archive: ${{ env.ZENODO_ARCHIVE }}
+        description: ${{ env.ZENODO_DESCRIPTION }}
 
         # DOI for all versions. Leaving this blank (the default) will create
         # a new DOI on every release. Use a DOI that represents all versions will

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,93 @@
+{
+  "upload_type": "software",
+  "title": "crim-ca/weaver:5.9.0",
+  "description": "Weaver: Workflow Execution Management Service (EMS); Application, Deployment and Execution Service (ADES); OGC API - Processes; WPS; CWL Application Package",
+  "version": "5.9.0",
+  "creators": [
+    {
+      "name": "Charette-Migneault, Francis",
+      "orcid": "0000-0003-4862-3349",
+      "affiliation": "Computer Research Institute of Montréal"
+    }
+  ],
+  "contributors": [
+    {
+      "name": "Computer Research Institute of Montréal",
+      "type": "HostingInstitution"
+    },
+    {
+      "name": "Charette-Migneault, Francis",
+      "orcid": "0000-0003-4862-3349",
+      "affiliation": "Computer Research Institute of Montréal",
+      "type": "ProjectLeader"
+    },
+    {
+      "name": "Azeli, Nazim",
+      "affiliation": "Computer Research Institute of Montréal",
+      "type": "ProjectMember"
+    }
+  ],
+  "communities": [
+    {
+      "identifier": "crim"
+    },
+    {
+      "identifier": "birdhouse"
+    }
+  ],
+  "related_identifiers": [
+    {
+      "identifier": "10.5281/zenodo.14210717",
+      "relation": "isPartOf",
+      "scheme": "doi"
+    },
+    {
+      "identifier": "https://github.com/crim-ca/weaver",
+      "scheme": "url",
+      "relation": "isMetadataFor",
+      "resource_type": "software"
+    },
+    {
+      "identifier": "https://osf.io/d3esv/",
+      "scheme": "url",
+      "relation": "isVariantFormOf",
+      "resource_type": "OSF Record"
+    },
+    {
+      "identifier": "https://pavics-weaver.readthedocs.io/",
+      "scheme": "url",
+      "relation": "isDocumentedBy",
+      "resource_type": "ReadTheDocs"
+    }
+  ],
+  "custom": {
+    "code:codeRepository": "https://github.com/crim-ca/weaver",
+    "code:programmingLanguage": [
+      {
+        "id": "python",
+        "title": {"en": "Python"}
+      }
+    ],
+    "code:developmentStatus": [
+      {
+        "id": "active",
+        "title": {"en": "Active"}
+      }
+    ]
+  },
+  "language": "eng",
+  "keywords": [
+    "bird-house",
+    "WPS",
+    "Web Processing Service",
+    "OGC",
+    "OGC API - Processes",
+    "CWL",
+    "Common Workflow Language",
+    "Workflow",
+    "Remote Execution",
+    "Web API"
+  ],
+  "access_right": "open",
+  "license": "Apache 2.0"
+}

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -22,9 +22,44 @@
       "type": "ProjectLeader"
     },
     {
+      "name": "Byrns, David",
+      "affiliation": "Computer Research Institute of Montréal"
+    },
+    {
+      "name": "Caron, David",
+      "affiliation": "Computer Research Institute of Montréal"
+    },
+    {
+      "name": "Pelletier, Francis",
+      "affiliation": "Computer Research Institute of Montréal"
+    },
+    {
+      "name": "Gagnon-Grenier, Félix",
+      "affiliation": "Computer Research Institute of Montréal"
+    },
+    {
       "name": "Azeli, Nazim",
-      "affiliation": "Computer Research Institute of Montréal",
-      "type": "ProjectMember"
+      "affiliation": "Computer Research Institute of Montréal"
+    },
+    {
+      "name": "Perron, Louis-David",
+      "affiliation": "Computer Research Institute of Montréal"
+    },
+    {
+      "name": "Cummings, Charles-William",
+      "affiliation": "Computer Research Institute of Montréal"
+    },
+    {
+      "name": "Trapsida, Nadir",
+      "affiliation": "Computer Research Institute of Montréal"
+    },
+    {
+      "name": "Lacoursière, Éric",
+      "affiliation": "Computer Research Institute of Montréal"
+    },
+    {
+      "name": "Schwartz, Misha",
+      "affiliation": "University of Toronto"
     }
   ],
   "communities": [
@@ -77,17 +112,17 @@
   },
   "language": "eng",
   "keywords": [
-    "bird-house",
-    "WPS",
-    "Web Processing Service",
     "OGC",
     "OGC API - Processes",
     "CWL",
     "Common Workflow Language",
+    "WPS",
+    "Web Processing Service",
     "Workflow",
     "Remote Execution",
-    "Web API"
+    "Web API",
+    "bird-house"
   ],
   "access_right": "open",
-  "license": "Apache 2.0"
+  "license": "Apache-2.0"
 }

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -806,7 +806,7 @@ Fixes:
 - Fix ``http`` directory download to match implemented `AWS S3` directory download in ``weaver.utils.fetch_directory``,
   so both types replicate the input directory's top level folder, which is necessary when downloading
   multiple directories for the same input source.
-- Fix deprecation warnings from :mod:`webob` and :mod:`owslib`.
+- Fix deprecation warnings from ``webob`` and ``owslib``.
 - Fix filtered warnings for expected cases during tests.
 - Fix a problem with ``convert_input_values_schema`` under the `OGC` schema, that caused the conversion to malfunction
   when the function built lists for repeated input IDs of more than two elements.
@@ -1662,7 +1662,8 @@ Changes:
   Range duration parameters are limited to single values each
   (relates to `opengeospatial/ogcapi-processes#261 <https://github.com/opengeospatial/ogcapi-processes/issues/261>`_).
 - Require minimally ``pymongo==3.12.0`` and corresponding `MongoDB` ``5.0`` instance to process new filtering queries
-  of ``minDuration`` and ``maxDuration``. Please refer to :ref:`database_migration`
+  of ``minDuration`` and ``maxDuration``. Please refer
+  to `Database Migration <https://pavics-weaver.readthedocs.io/en/latest/installation.html#database-migration>`_
   and `MongoDB official documentation <https://docs.mongodb.com/manual>`_ for migration methods.
 - Refactor ``Job`` search method to facilitate its extension in the event of future filter parameters.
 - Support contextual WPS output location using ``X-WPS-Output-Context`` header to store ``Job`` results.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,110 @@
+cff-version: 1.2.0
+title: "crim-ca/weaver:5.9.0"
+message: |
+  Weaver: Workflow Execution Management Service (EMS);
+  Application, Deployment and Execution Service (ADES);
+  OGC API - Processes; WPS; CWL Application Package
+version: "5.9.0"
+
+authors:
+  - name: &crim -|
+      Computer Research Institute of Montréal
+    city: "Montréal"
+    region: "Québec"
+    alias: CRIM
+    website: "https://www.crim.ca/"
+    email: "info@crim.ca"
+    tel: "1 (514) 840-1234"
+    country: CA
+    post-code: "H3N 1M3"
+    address: "101 – 405, avenue Ogilvy"
+  - &fmigneault
+    given-names: "Francis"
+    family-names: "Charette-Migneault"
+    alias: fmigneault
+    email: "francis.charette-migneault@crim.ca"
+    orcid: "https://orcid.org/0000-0003-4862-3349"
+    affiliation: *crim
+  - given-names: David
+    family-names: Byrns
+    alias: dbyrns
+    affiliation: *crim
+  - given-names: David
+    family-names: Caron
+    alias: davidcaron
+    affiliation: *crim
+  - given-names: Francis
+    family-names: Pelletier
+    alias: f-PLT
+    affiliation: *crim
+  - given-names: Félix
+    family-names: Gagnon-Grenier
+    alias: Zvax
+    affiliation: *crim
+  - given-names: Nazim
+    family-names: Azeli
+    alias: Nazim-crim
+    affiliation: *crim
+  - given-names: Louis-David
+    family-names: Perron
+    alias: perronld
+    affiliation: *crim
+  - given-names: Charles-William
+    family-names: Cummings
+    alias: cwcummings
+    affiliation: *crim
+  - given-names: Nadir
+    family-names: Trapsida
+    alias: trapsidanadir
+    affiliation: *crim
+  - given-names: Éric
+    family-names: Lacoursière
+    alias: elacoursiere-crim
+    affiliation: *crim
+  - given-names: Misha
+    family-names: Schwartz
+    alias: mishaschwartz
+    affiliation: "University of Toronto"
+
+contact:
+  - *fmigneault
+
+doi: "10.5281/zenodo.14210717"
+identifiers:
+  - type: doi
+    value: "10.5281/zenodo.14210717"
+    description: "Zenodo DOI"
+  - type: url
+    value: "https://github.com/crim-ca/weaver"
+    description: "Source code repository."
+  - type: url
+    value: "https://osf.io/d3esv/"
+    description: "OSF Record"
+
+references:
+  - title: Weaver Documentation
+    authors:
+      - *fmigneault
+    contact:
+      - *fmigneault
+    url: "https://pavics-weaver.readthedocs.io/"
+    type: manual
+
+type: "software"
+url: "https://github.com/crim-ca/weaver"
+repository-code: "https://github.com/crim-ca/weaver"
+
+keywords:
+  - "OGC"
+  - "OGC API - Processes"
+  - "CWL"
+  - "Common Workflow Language"
+  - "WPS"
+  - "Web Processing Service"
+  - "Workflow"
+  - "Remote Execution"
+  - "Web API"
+  - "bird-house"
+
+license: "Apache-2.0"
+license-url: "https://github.com/crim-ca/weaver/blob/master/LICENSE.txt"

--- a/README.rst
+++ b/README.rst
@@ -45,6 +45,8 @@ for each process.
       - | |py_ver| |deps| |pyup|
     * - license
       - | |license| |license_scan|
+    * - citation
+      - | |citation-zenodo| |citation-cff|
     * - build status
       - | |readthedocs| |docker_build_mode| |docker_build_status|
     * - tests status
@@ -113,6 +115,14 @@ for each process.
 .. |license_scan| image:: https://app.fossa.com/api/projects/git%2Bgithub.com%2Fcrim-ca%2Fweaver.svg?type=shield&issueType=license
     :target: https://app.fossa.com/projects/git%2Bgithub.com%2Fcrim-ca%2Fweaver?ref=badge_shield&issueType=license
     :alt: FOSSA Status
+
+.. |citation-zenodo| image:: https://zenodo.org/badge/DOI/10.5281/zenodo.14210718.svg
+    :alt: Zenodo DOI
+    :target: https://zenodo.org/doi/10.5281/zenodo.14210718
+
+.. |citation-cff| image:: https://img.shields.io/badge/citation-cff-blue
+    :alt: CFF
+    :target: https://github.com/crim-ca/weaver/blob/master/CITATION.cff
 
 .. end-badges
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,10 @@ replace = {new_version}
 search = {current_version}
 replace = {new_version}
 
+[bumpversion:file:CITATION.cff]
+search = {current_version}
+replace = {new_version}
+
 [bumpversion:file:weaver/__meta__.py]
 search = {current_version}
 replace = {new_version}

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,10 @@ replace =
 search = {current_version}
 replace = {new_version}
 
+[bumpversion:file:.zenodo.json]
+search = {current_version}
+replace = {new_version}
+
 [bumpversion:file:weaver/__meta__.py]
 search = {current_version}
 replace = {new_version}


### PR DESCRIPTION
Using the https://github.com/rseng/zenodo-release GitHub Action to purposely avoid using Zenodo's official integration that requires ornaization-level admin access to webhooks.

Add CITATIONS.cff and Zenodo metadata representations for convenience.

- based on changes in https://github.com/rseng/zenodo-release/pull/16