### PR TITLE
handle WPS endpoint identifiers with `processID:revision`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,7 @@ Fixes:
   (fixes `#799 <https://github.com/crim-ca/weaver/issues/799>`_).
 - Fix ``jobControlOptions`` not respected in cases where resolution occurs against a restricted set of capabilities
   for a given `Process` when the submitted `Job` requests an invalid combination by execution ``mode`` body parameter.
+- Fix ``remote`` and ``local`` tags incorrectly applied to `Job` definition.
 
 .. _changes_6.3.0:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,8 @@ Fixes:
 - Fix resolution of `Process` revisions when queried by multiple ID and/or version combinations on the `WPS` endpoint.
 - Fix resolution of `Process` revisions by ``{processID}:{version}`` for execution by `OGC API - Processes` endpoint
   (fixes `#799 <https://github.com/crim-ca/weaver/issues/799>`_).
+- Fix ``jobControlOptions`` not respected in cases where resolution occurs against a restricted set of capabilities
+  for a given `Process` when the submitted `Job` requests an invalid combination by execution ``mode`` body parameter.
 
 .. _changes_6.3.0:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,7 +19,10 @@ Changes:
 
 Fixes:
 ------
-- No change.
+- Fix resolution of `Process` revisions by ``{processID}:{version}`` when queried on the `WPS` endpoint.
+- Fix resolution of `Process` revisions when queried by multiple ID and/or version combinations on the `WPS` endpoint.
+- Fix resolution of `Process` revisions by ``{processID}:{version}`` for execution by `OGC API - Processes` endpoint
+  (fixes `#799 <https://github.com/crim-ca/weaver/issues/799>`_).
 
 .. _changes_6.3.0:
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -75,6 +75,7 @@ markers =
 	oap_part3: mark test as 'OGC API - Processes - Part 3: Workflows and Chaining' functionalities
 	oap_part4: mark test as 'OGC API - Processes - Part 4: Job Management' functionalities
 	openeo: mark test as evaluating 'openEO' functionalities
+	wps: mark test as evaluating the 'WPS' endpoint directly
 filterwarnings = 
 	ignore:No file specified for WPS-1 providers registration:RuntimeWarning
 	ignore:.*configuration setting.*weaver\.cwl_processes_dir.*:RuntimeWarning

--- a/tests/functional/test_wps_app.py
+++ b/tests/functional/test_wps_app.py
@@ -22,7 +22,7 @@ from weaver.visibility import Visibility
 if TYPE_CHECKING:
     from typing import List
 
-    from weaver.typedefs import JSON
+    from weaver.typedefs import AnyUUID, AnyVersion, JSON
 
 
 @pytest.mark.wps
@@ -231,8 +231,8 @@ class WpsAppTestWithProcessRevisions(WpsConfigBase, ResourcesUtil):
         "weaver.wps_metadata_identification_title": "Weaver WPS Test Server",
         "weaver.wps_metadata_provider_name": "WpsAppTest"
     }
-    process_ids = None
-    process_revisions = None
+    process_ids = []        # type: List[AnyUUID]
+    process_revisions = []  # type: List[List[AnyVersion]]
 
     @classmethod
     def setUpClass(cls):

--- a/tests/functional/test_wps_app.py
+++ b/tests/functional/test_wps_app.py
@@ -14,6 +14,7 @@ from tests.utils import mocked_execute_celery
 from weaver import xml_util
 from weaver.execute import ExecuteControlOption
 from weaver.formats import ContentType
+from weaver.owsexceptions import OWSInvalidParameterValue
 from weaver.processes.wps_default import HelloWPS
 from weaver.processes.wps_testing import WpsTestProcess
 from weaver.visibility import Visibility
@@ -140,6 +141,24 @@ class WpsAppTest(WpsConfigBase):
         assert resp.content_type in ContentType.ANY_XML
         resp.mustcontain("</wps:ProcessDescriptions>")
 
+    def test_describeprocess_invalid_id_bad_request_xml(self):
+        bad_id = "$ohNoYouDont!"
+        params = f"service=wps&request=describeprocess&version=1.0.0&identifier={bad_id}"
+        resp = self.app.get(self.make_url(params), expect_errors=True)
+        assert resp.status_code == 400
+        assert resp.content_type in ContentType.ANY_XML
+        resp.mustcontain("</ExceptionReport>")
+        resp.mustcontain(f"[\"{bad_id}\"]")
+
+    def test_describeprocess_invalid_id_bad_request_json(self):
+        bad_id = "$ohNoYouDont!"
+        params = f"service=wps&request=describeprocess&version=1.0.0&identifier={bad_id}"
+        resp = self.app.get(self.make_url(params), expect_errors=True, headers={"Accept": ContentType.APP_JSON})
+        assert resp.status_code == 400
+        assert resp.content_type in ContentType.APP_JSON
+        assert resp.json["code"] == OWSInvalidParameterValue.code
+        assert resp.json["value"] == [bad_id]
+
     def test_execute_allowed_demo(self):
         template = "service=wps&request=execute&version=1.0.0&identifier={}&datainputs=name=tux"
         params = template.format(HelloWPS.identifier)
@@ -212,13 +231,20 @@ class WpsAppTestWithProcessRevisions(WpsConfigBase, ResourcesUtil):
         "weaver.wps_metadata_identification_title": "Weaver WPS Test Server",
         "weaver.wps_metadata_provider_name": "WpsAppTest"
     }
-    process_id = None
+    process_ids = None
+    process_revisions = None
 
     @classmethod
     def setUpClass(cls):
         super(WpsAppTestWithProcessRevisions, cls).setUpClass()
-        cls.process_id = cls.fully_qualified_test_name(cls)
-        cls.process_revisions = cls.deploy_process_revisions(cls, cls.process_id)
+        cls.process_ids = [
+            cls.fully_qualified_test_name(cls, name=idx)
+            for idx in [1, 2]
+        ]
+        cls.process_revisions = [
+            cls.deploy_process_revisions(cls, proc_id)
+            for proc_id in cls.process_ids
+        ]
 
     def deploy_process_revisions(self, process_id):
         # type: (str) -> List[str]
@@ -258,8 +284,8 @@ class WpsAppTestWithProcessRevisions(WpsConfigBase, ResourcesUtil):
     ])
     def test_describe_process_single_revision(self, process_revision):
         headers = {"Accept": ContentType.APP_XML}
-        proc_id = f"{self.process_id}:{process_revision}" if process_revision else self.process_id
-        proc_ver = process_revision if process_revision else self.process_revisions[-1]
+        proc_id = f"{self.process_ids[0]}:{process_revision}" if process_revision else self.process_ids[0]
+        proc_ver = process_revision if process_revision else self.process_revisions[0][-1]
         params = {
             "service": "WPS",
             "request": "DescribeProcess",
@@ -274,18 +300,23 @@ class WpsAppTestWithProcessRevisions(WpsConfigBase, ResourcesUtil):
         resp.mustcontain(f"<ows:Identifier>{proc_id}</ows:Identifier>")  # ID as requested to match search criteria
 
     @parameterized.expand([
-        (["1.2.3", "1.2.5"], ),
-        (["1.3.2", "1.3.4", "2.0.0"], ),
-        (["1.2.5", "", "2.0.0"], ),
+        # list of process ID index and revision to describe
+        # they must be nested in tuples to be passed as single argument
+        ([(0, "1.2.3"), (1, "1.2.5")], ),
+        # ensure "same tag" is not mixed between distinct process ID
+        ([(0, "1.3.2"), (1, "1.3.2"), (0, "1.3.4"), (1, "2.0.0")], ),
+        # ensure optional tag returns both variants as pseudo-duplicates when the corresponding revision is also given
+        # ("" == "2.0.0"), this is not the same as 'test_describe_process_multi_revision_duplicates' use case
+        ([(0, "1.2.5"), (0, ""), (0, "2.0.0"), (0, ""), (1, "2.0.0")], ),
     ])
     def test_describe_process_multi_revision_filter(self, process_revisions):
         headers = {"Accept": ContentType.APP_XML}
         proc_ids = [
-            f"{self.process_id}:{rev}" if rev else self.process_id
-            for rev in process_revisions
+            f"{self.process_ids[idx]}:{rev}" if rev else self.process_ids[idx]
+            for idx, rev in process_revisions
         ]
         proc_vers = [
-            rev if rev else self.process_revisions[-1]
+            rev if rev else self.process_revisions[0][-1]
             for rev in process_revisions
         ]
         params = {
@@ -302,9 +333,35 @@ class WpsAppTestWithProcessRevisions(WpsConfigBase, ResourcesUtil):
             resp.mustcontain(f"ProcessDescription wps:processVersion=\"{proc_ver}\"")  # reported regardless of ID:rev
             resp.mustcontain(f"<ows:Identifier>{proc_id}</ows:Identifier>")  # ID as requested to match search criteria
 
-        unrequested_versions = set(self.process_revisions) - set(proc_vers)
+        unrequested_versions = set(self.process_revisions[0]) - set(proc_vers)
         for proc_ver in unrequested_versions:
             assert f"ProcessDescription wps:processVersion=\"{proc_ver}\"" not in resp.text, "filter did not work"
+
+        # number of identifiers must match the requested IDs/revisions that exist,
+        # even if they represent the same process after optional-latest revision resolution
+        # to ensure that PyWPS can resolve them against the specified query string ID values
+        # (PyWPS does not have special 'revision' logic, it considers them distinct processes without relationships)
+        assert resp.text.count("<ows:Identifier>") == len(process_revisions)
+
+    def test_describe_process_multi_revision_duplicates(self):
+        headers = {"Accept": ContentType.APP_XML}
+        prov_rev = self.process_revisions[0][0]
+        proc_id_rev = f"{self.process_ids[0]}:{prov_rev}"
+        params = {
+            "service": "WPS",
+            "request": "DescribeProcess",
+            "version": "1.0.0",
+            # redundant IDs specified twice, which are not the latest (real duplicates)
+            "identifier": f"{proc_id_rev},{proc_id_rev}",
+        }
+        resp = self.app.get(self.wps_path, params=params, headers=headers)
+        assert resp.status_code == 200
+        assert resp.content_type in ContentType.ANY_XML
+        resp.mustcontain("</wps:ProcessDescriptions>")
+        resp.mustcontain(f"ProcessDescription wps:processVersion=\"{prov_rev}\"")
+        assert resp.text.count(f"<ows:Identifier>{proc_id_rev}</ows:Identifier>") == 1, (
+            "Duplicate literal process 'ID:revision' should not result in duplicate entries in listing."
+        )
 
     @parameterized.expand([
         # 1st revision is an older version that must be specified to invoke it specifically
@@ -313,12 +370,13 @@ class WpsAppTestWithProcessRevisions(WpsConfigBase, ResourcesUtil):
     ])
     def test_execute_single_revision(self, process_revision):
         headers = {"Accept": ContentType.APP_XML}
-        proc_id = f"{self.process_id}:{process_revision}" if process_revision else self.process_id
+        proc_id = f"{self.process_ids[0]}:{process_revision}" if process_revision else self.process_ids[0]
         params = {
             "service": "WPS",
-            "request": "ExecuteProcess",
+            "request": "Execute",
             "version": "1.0.0",
             "identifier": proc_id,
+            "dataInputs": "message=test",
         }
         with contextlib.ExitStack() as stack_exec:
             for mock_exec in mocked_execute_celery():

--- a/tests/functional/utils.py
+++ b/tests/functional/utils.py
@@ -533,8 +533,8 @@ class WpsConfigBase(GenericUtils):
         assert resp.status_code == 200, f"Error job info:\n{resp.text}"
         return resp.json
 
-    def get_outputs(self, status_url):
-        path = get_path_kvp(f"{status_url}/outputs", schema=JobInputsOutputsSchema.OLD)
+    def get_outputs(self, status_url, schema=JobInputsOutputsSchema.OLD):
+        path = get_path_kvp(f"{status_url}/outputs", schema=schema)
         resp = self.app.get(path, headers=dict(self.json_headers))
         body = resp.json
         pretty = json.dumps(body, indent=2, ensure_ascii=False)

--- a/tests/wps_restapi/test_processes.py
+++ b/tests/wps_restapi/test_processes.py
@@ -149,6 +149,7 @@ class WpsRestApiProcessesTest(WpsConfigBase):
             self.process_public,
             processDescriptionURL=f"{weaver_api_url}/processes/{self.process_public.identifier}",
             processEndpointWPS1=weaver_wps_url,
+            jobControlOptions=ExecuteControlOption.values(),
         )
         self.process_store.save_process(public_process)
         self.process_store.save_process(self.process_private)
@@ -223,7 +224,7 @@ class WpsRestApiProcessesTest(WpsConfigBase):
             assert "version" in process and isinstance(process["version"], str)
             assert "keywords" in process and isinstance(process["keywords"], list)
             assert "metadata" in process and isinstance(process["metadata"], list)
-            assert len(process["jobControlOptions"]) == 1
+            assert len(process["jobControlOptions"]) == 2
             assert ExecuteControlOption.ASYNC in process["jobControlOptions"]
 
         processes_id = [p["id"] for p in resp.json["processes"]]
@@ -432,7 +433,7 @@ class WpsRestApiProcessesTest(WpsConfigBase):
         body = resp.json
         assert len(body["processes"]) == proc_total
         proc_result = [(proc["id"], proc["version"]) for proc in body["processes"]]
-        proc_expect = [(proc_id, "0.0.0") for proc_id in proc_no_revs]
+        proc_expect = [(proc_id, self.process_public.version) for proc_id in proc_no_revs]
         proc_expect += [(tag, ver) for tag, ver in zip(proc1_tags, proc1_versions)]
         proc_expect += [(tag, ver) for tag, ver in zip(proc2_tags, proc2_versions)]
         assert proc_result == sorted(proc_expect)
@@ -2449,7 +2450,7 @@ class WpsRestApiProcessesTest(WpsConfigBase):
         rev = "1.1.0"
         proc = self.process_public.identifier
         path = f"/processes/{proc}"
-        data = {"version": rev, "title": "updated", "jobControlOptions": [ExecuteControlOption.SYNC]}
+        data = {"version": rev, "title": "updated", "jobControlOptions": [ExecuteControlOption.ASYNC]}
         resp = self.app.patch_json(path, params=data, headers=self.json_headers)
         assert resp.status_code == 200
 

--- a/weaver/execute.py
+++ b/weaver/execute.py
@@ -81,6 +81,13 @@ class ExecuteControlOption(Constants):
         """
         return [ExecuteControlOption.ASYNC, ExecuteControlOption.SYNC]
 
+    @classmethod
+    def from_mode(cls, mode):
+        # type: (Optional[AnyExecuteMode]) -> Optional[ExecuteControlOption]
+        mode = ExecuteMode.get(mode)
+        ctrl = cls.get(f"{mode}-execute")
+        return ctrl
+
 
 class ExecuteReturnPreference(Constants):
     MINIMAL = "minimal"                 # type: ExecuteReturnPreferenceMinimalType

--- a/weaver/processes/execution.py
+++ b/weaver/processes/execution.py
@@ -905,10 +905,11 @@ def submit_job_handler(payload,             # type: ProcessExecution
     # non-local is only a reference, no actual process object to validate
     provider_id = provider.id if isinstance(provider, Service) else provider
     process_id = None
-    if process and is_local and not isinstance(process, Process):
+    if process and not isinstance(process, Process):
         process_id = process
-        proc_store = db.get_store(StoreProcesses)
-        process = proc_store.fetch_by_id(process)
+        if is_local:
+            proc_store = db.get_store(StoreProcesses)
+            process = proc_store.fetch_by_id(process)
     if process and is_local:
         validate_process_io(process, json_body)
         validate_process_id(process, json_body)
@@ -917,7 +918,8 @@ def submit_job_handler(payload,             # type: ProcessExecution
             "Skipping validation of execution parameters for remote process [%s] on provider [%s]",
             process, provider_id
         )
-    process_id = process_id or process.id  # pass down the specified or resolved reference (possibly with revision tag)
+    # pass down the specified or resolved reference (possibly with revision tag)
+    process_id = process_id or process.id
 
     headers = headers or {}
     if is_local:

--- a/weaver/processes/execution.py
+++ b/weaver/processes/execution.py
@@ -842,7 +842,7 @@ def submit_job(request, reference, tags=None, process_id=None):
         visibility = reference.visibility
         is_workflow = reference.type == ProcessType.WORKFLOW
         is_local = True
-        tags += "local"
+        tags.append("local")
         support_lang = AcceptLanguage.offers()
         accepts_lang = request.accept_language  # type: AnyAcceptLanguageHeader
         matched_lang = accepts_lang.lookup(support_lang, default="") or None
@@ -865,7 +865,7 @@ def submit_job(request, reference, tags=None, process_id=None):
         visibility = Visibility.PUBLIC
         is_workflow = False
         is_local = False
-        tags += "remote"
+        tags.append("remote")
     else:  # pragma: no cover
         LOGGER.error("Expected process/service, got: %s", type(reference))
         raise TypeError("Invalid process or service reference to execute job.")

--- a/weaver/store/base.py
+++ b/weaver/store/base.py
@@ -123,8 +123,8 @@ class StoreProcesses(StoreInterface):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def fetch_by_id(self, process_id, visibility=None):
-        # type: (AnyProcessRef, Optional[AnyVisibility]) -> Process
+    def fetch_by_id(self, process_id, visibility=None, revision=False):
+        # type: (AnyProcessRef, Optional[AnyVisibility], bool) -> Process
         raise NotImplementedError
 
     @abc.abstractmethod

--- a/weaver/store/base.py
+++ b/weaver/store/base.py
@@ -118,6 +118,7 @@ class StoreProcesses(StoreInterface):
                        total=False,         # type: bool
                        revisions=False,     # type: bool
                        process=None,        # type: Optional[str]
+                       identifiers=None,    # type: Optional[List[str]]
                        ):                   # type: (...) -> Union[List[Process], Tuple[List[Process], int]]
         raise NotImplementedError
 

--- a/weaver/store/mongodb.py
+++ b/weaver/store/mongodb.py
@@ -594,7 +594,7 @@ class MongodbProcessStore(StoreProcesses, MongodbStore, ListingMixin):
                     {"$match": {"identifier": proc_id, "version": proc_rev}},
                     # After resolutions, align any 'latest' process that indicates the explicit revision.
                     # The only case that must be patched is when the version is explicitly indicated in query,
-                    # although not explicit set in the DB document since it corresponds to the latest revision.
+                    # although not explicitly set in the DB document since it corresponds to the latest revision.
                     {"$set": {"identifier": {"$cond": {
                         "if": {"$regexMatch": {"input": "$identifier", "regex": r"^.*(?!:[0-9]+[^:]*)$"}},
                         "then": {"$concat": ["$identifier", ":", "$version"]},

--- a/weaver/wps/service.py
+++ b/weaver/wps/service.py
@@ -2,7 +2,7 @@ import logging
 import os
 from configparser import ConfigParser
 from typing import TYPE_CHECKING
-from urllib.parse import urlparse
+from urllib.parse import urlparse, unquote
 
 from owslib.wps import WPSExecution
 from pyramid.httpexceptions import HTTPBadRequest, HTTPSeeOther
@@ -414,7 +414,8 @@ def get_pywps_service(environ=None, is_worker=False):
         # resolve pre-filtered list of process(es), and whether they require any explicit revision tag
         # do this dynamically in advance since a lot of processes could require listing + conversion
         # avoid unnecessary resolution of processes that will not be employed otherwise
-        proc_ids = parse_kvp(environ.get("QUERY_STRING") or "", pair_sep="&").get("identifier") or None
+        query = unquote(environ.get("QUERY_STRING") or "")
+        proc_ids = parse_kvp(query, pair_sep="&").get("identifier") or None
 
         # call pywps application with processes filtered according to the adapter's definition
         process_store = get_db(registry).get_store(StoreProcesses)  # type: StoreProcesses

--- a/weaver/wps_restapi/jobs/jobs.py
+++ b/weaver/wps_restapi/jobs/jobs.py
@@ -260,7 +260,6 @@ def create_job(request):
         ref = get_service(request, provider_id=prov_id)
     else:
         ref = get_process(process_id=proc_id)
-        proc_id = None  # ensure ref is used, process ID needed only for provider
     return submit_job(request, ref, process_id=proc_id, tags=["wps-rest", "ogc-api"])
 
 

--- a/weaver/wps_restapi/jobs/utils.py
+++ b/weaver/wps_restapi/jobs/utils.py
@@ -96,6 +96,7 @@ if TYPE_CHECKING:
         ExecutionResultValue,
         HeadersTupleType,
         HeadersType,
+        HTTPValid,
         JobValueFormat,
         JSON,
         PyramidRequest,
@@ -1118,6 +1119,12 @@ def get_job_results_multipart(job, results, *, headers, settings):
     resp = HTTPOk(detail=f"Multipart Response for {job}", headers=resp_headers)
     resp.body = res_multi.read()
     return resp
+
+
+@overload
+def get_job_submission_response(body, headers):
+    # type: (JSON, AnyHeadersContainer) -> HTTPValid
+    ...
 
 
 def get_job_submission_response(


### PR DESCRIPTION
## Description

- handle WPS endpoint identifiers with `processID:revision` to allow describe/execution using older versions 
- fixes #799

## To Do

- Add tests 
  - [x] single `processID` when it is the latest revision
  - [x] single `processID:revision` when it is the latest
  - [x] single `processID:revision` when it is an older revision
  - [x] multi `processID:revision,processID:revision,processID` with mixture of latest/older revisions