### PR TITLE
bump `safety>=3.4.0` to fix issue with marshmallow sub-dependency 

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -39,7 +39,7 @@ pylint>=3,<4
 pylint_quotes @ git+https://github.com/marekhanus/pylint-quotes.git@0.3.0a2
 pylint-per-file-ignores
 responses
-safety
+safety>=3.4.0
 stopit
 typing_extensions
 WebTest


### PR DESCRIPTION
- relates to https://github.com/pyupio/safety/issues/711
