### PR TITLE
temporarily ignore broken links from OGC Draft reports 

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -456,6 +456,8 @@ linkcheck_ignore = [
     "http[s]*://web.archive.org/.*",
     # sporadic timeouts
     "https://2024julyesipmeeting.sched.com/",
+    # FIXME: OGC Drafts broken (https://github.com/opengeospatial/ogcapi-processes/issues/490)
+    "https://docs.ogc.org/DRAFTS/.*",
 ]
 linkcheck_anchors_ignore = [
     "xml-object",  # https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md


### PR DESCRIPTION
OGC Draft reports generation has been broken for a few weeks, and it is impossible to develop anything efficiently in the meantime since CI linkchecks breaks all the time. Patch-ignore it temporarily to allow other relevant checks to be evaluated.

- relates to https://github.com/opengeospatial/ogcapi-processes/issues/490
