### PR TITLE
use retries to handle sporadic errors on CI docker still booting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -889,21 +889,20 @@ docker-push: docker-push-base docker-push-manager docker-push-worker  ## push al
 # if compose up succeeds, query weaver to get frontpage response
 DOCKER_COMPOSE_CMD ?= docker compose
 DOCKER_TEST_COMPOSES := -f "$(APP_ROOT)/tests/smoke/docker-compose.smoke-test.yml"
-DOCKER_TEST_CURL_RETRY_COUNT ?= 5
+DOCKER_TEST_CURL_RETRY_COUNT ?= 10
 DOCKER_TEST_CURL_RETRY_DELAY ?= 5
-DOCKER_TEST_CURL_RETRY_MAX_TIME ?= 60
 DOCKER_TEST_EXEC_ARGS ?=
 .PHONY: docker-test
 docker-test: docker-build stop	## execute smoke test of the built images (validate that they boots and reply)
 	@echo "Smoke test of built application docker images"
 	$(DOCKER_COMPOSE_CMD) $(DOCKER_TEST_COMPOSES) up -d
 	@echo "Pinging Weaver API entrypoint to validate response..."
-	@curl \
-			--retry $(DOCKER_TEST_CURL_RETRY_COUNT) \
-			--retry-delay $(DOCKER_TEST_CURL_RETRY_DELAY) \
-			--retry-max-time $(DOCKER_TEST_CURL_RETRY_MAX_TIME) \
+	@wget \
+			-O - \
+			--tries $(DOCKER_TEST_CURL_RETRY_COUNT) \
+			--wait $(DOCKER_TEST_CURL_RETRY_DELAY) \
 			--retry-connrefused \
-			localhost:4001 | \
+			"http://localhost:4001" | \
 		grep "Weaver Information" || \
 		( $(DOCKER_COMPOSE_CMD) $(DOCKER_TEST_COMPOSES) logs weaver worker || true && \
 		  $(DOCKER_COMPOSE_CMD) $(DOCKER_TEST_COMPOSES) stop; exit 1 )


### PR DESCRIPTION
Error does not seem to be replicable locally, but happens sporadically during GitHub CI. 
Sometimes, retrying the execution simply works. 

The same script has been running for years, but recently started breaking on random occasion. 
Attempt to handle the case where the docker might not yet have finished booting with the previously used 10s delay, by dynamically retrying the request a few times. 

Only `test-docker` case is relevant here (doing a few runs for sanity check):
- using `curl` retries:
	- https://github.com/crim-ca/weaver/actions/runs/14719312168/job/41309827916?pr=818 ❌ 
	- https://github.com/crim-ca/weaver/actions/runs/14719312168/job/41310174866?pr=818 ❌ 
	- https://github.com/crim-ca/weaver/actions/runs/14719312168/job/41310344216?pr=818 ❌ 

Even using `--retry-connrefused` does not work (https://github.com/crim-ca/weaver/pull/818/commits/367b6bd2b6ae675c8bd9bdbcd7d973d79a920c68). 
Have to use `--retry-all-errors`, but this option is not available on all OS versions.

```
Pinging Weaver API entrypoint to validate response...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (56) Recv failure: Connection reset by peer
```

Alternative:

- switch to `wget`
	- https://github.com/crim-ca/weaver/actions/runs/14719831894/job/41311340944?pr=818 ✅
	- https://github.com/crim-ca/weaver/actions/runs/14719831540/job/41311338095?pr=818 ✅

Example of errors (and finally resolution): 

```
Pinging Weaver API entrypoint to validate response...
--2025-04-28 23:24:41--  http://localhost:4001/
Resolving localhost (localhost)... ::1, 127.0.0.1
Connecting to localhost (localhost)|::1|:4001... connected.
HTTP request sent, awaiting response... Read error (Connection reset by peer) in headers.
Retrying.

--2025-04-28 23:24:42--  (try: 2)  http://localhost:4001/
Connecting to localhost (localhost)|::1|:4001... connected.
HTTP request sent, awaiting response... Read error (Connection reset by peer) in headers.
Retrying.

--2025-04-28 23:24:44--  (try: 3)  http://localhost:4001/
Connecting to localhost (localhost)|::1|:4001... connected.
HTTP request sent, awaiting response... Read error (Connection reset by peer) in headers.
Retrying.

--2025-04-28 23:24:47--  (try: 4)  http://localhost:4001/
Connecting to localhost (localhost)|::1|:4001... connected.
HTTP request sent, awaiting response... Read error (Connection reset by peer) in headers.
Retrying.

--2025-04-28 23:24:51--  (try: 5)  http://localhost:4001/
Connecting to localhost (localhost)|::1|:4001... connected.
HTTP request sent, awaiting response... 200 OK
Length: 4942 (4.8K) [application/json]
Saving to: ‘STDOUT’
```