### PR TITLE
update skip-duplicate CI with `cancel_others`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           concurrent_skipping: "same_content_newer"
           skip_after_successful_duplicate: "true"
+          cancel_others: "true"
           do_not_skip: '["workflow_dispatch", "schedule", "release"]'
 
   # see: https://github.com/actions/setup-python


### PR DESCRIPTION
If new commits are pushed to a PR with executing workflow runs on previous commits, they will be cancelled to prioritize more promptly the most recent updates.