### PR TITLE
Support `f=xml` and `profile=wps` queries for job status

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,7 +24,7 @@ Changes:
 
 Fixes:
 ------
-- No change.
+- Add missing ``f`` and ``format`` query parameters for `Job` status endpoints in `OpenAPI` schema.
 
 .. _changes_6.5.0:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,15 @@ Changes
 
 Changes:
 --------
+- Add ``f=xml`` support for `Job` status endpoints to directly retrieve the corresponding `WPS` `XML` status content.
+- Add ``schema=wps`` and ``profile=wps`` query parameter support for `Job` status endpoints.
+  If used by themselves, these query parameter values will return the same `WPS` `XML` content as when using ``f=xml``.
+  If combined with `JSON` format (i.e.: ``?f=json&profile=wps``), the `OGC API - Processes` `Job` status information
+  will be returned instead, but using the corresponding `WPS` ``status`` values. Specifically, this allows returning
+  the previous `WPS`  ``succeeded`` and ``started`` status values instead of the `OGC API - Processes` ``successful``
+  and ``running`` values respectively. This is provided to help clients that have to deal with the mixture of
+  properties until the standard is properly stabilized and released. However, the default status values returned
+  by ``profile=ogc`` should be preferred and employed whenever possible.
 - Enable Docker `Provenance <https://docs.docker.com/build/metadata/attestations/slsa-provenance>`_
   and `Software Bill of Materials (SBOM) <https://docs.docker.com/build/metadata/attestations/sbom>`_
   within the CI to release |pavics_weaver|_ images including this tracking information by default for

--- a/tests/wps_restapi/test_jobs.py
+++ b/tests/wps_restapi/test_jobs.py
@@ -2442,6 +2442,234 @@ class WpsRestApiJobsTest(JobUtils):
                 JobStatusType.OPENEO,
                 Status.QUEUED,
             ),
+            # using '?schema=wps&f=json'
+            (
+                # this is a special combination that basically means to return
+                # the OGC Jobs schema representation, but using WPS status values
+                {"schema": JobStatusProfileSchema.WPS, "f": OutputFormat.JSON},
+                {},
+                0,
+                Status.SUCCESSFUL,
+                f"{ContentType.APP_JSON}; profile={JobStatusProfileSchema.WPS}",
+                None,  # not schema reported since they are not "valid references"
+                None,
+                JobStatusType.WPS,
+                Status.SUCCEEDED,
+            ),
+            (
+                {"schema": JobStatusProfileSchema.WPS, "f": OutputFormat.JSON},
+                {},
+                1,
+                Status.FAILED,
+                f"{ContentType.APP_JSON}; profile={JobStatusProfileSchema.WPS}",
+                None,
+                None,
+                JobStatusType.WPS,
+                Status.FAILED,
+            ),
+            (
+                {"schema": JobStatusProfileSchema.WPS, "f": OutputFormat.JSON},
+                {},
+                9,
+                Status.RUNNING,
+                f"{ContentType.APP_JSON}; profile={JobStatusProfileSchema.WPS}",
+                None,
+                None,
+                JobStatusType.WPS,
+                Status.STARTED,
+            ),
+            (
+                {"schema": JobStatusProfileSchema.WPS, "f": OutputFormat.JSON},
+                {},
+                11,
+                Status.ACCEPTED,
+                f"{ContentType.APP_JSON}; profile={JobStatusProfileSchema.WPS}",
+                None,
+                None,
+                JobStatusType.WPS,
+                Status.ACCEPTED,
+            ),
+            # using '?schema=wps' + Accept JSON
+            # (mixing query/headers to make sure they are interpreted separately and combined)
+            (
+                {"schema": JobStatusProfileSchema.WPS},
+                {"Accept": ContentType.APP_JSON},
+                0,
+                Status.SUCCESSFUL,
+                f"{ContentType.APP_JSON}; profile={JobStatusProfileSchema.WPS}",
+                None,
+                None,
+                JobStatusType.WPS,
+                Status.SUCCEEDED,
+            ),
+            (
+                {"schema": JobStatusProfileSchema.WPS},
+                {"Accept": ContentType.APP_JSON},
+                1,
+                Status.FAILED,
+                f"{ContentType.APP_JSON}; profile={JobStatusProfileSchema.WPS}",
+                None,
+                None,
+                JobStatusType.WPS,
+                Status.FAILED,
+            ),
+            (
+                {"schema": JobStatusProfileSchema.WPS},
+                {"Accept": ContentType.APP_JSON},
+                9,
+                Status.RUNNING,
+                f"{ContentType.APP_JSON}; profile={JobStatusProfileSchema.WPS}",
+                None,
+                None,
+                JobStatusType.WPS,
+                Status.STARTED,
+            ),
+            (
+                {"schema": JobStatusProfileSchema.WPS},
+                {"Accept": ContentType.APP_JSON},
+                11,
+                Status.ACCEPTED,
+                f"{ContentType.APP_JSON}; profile={JobStatusProfileSchema.WPS}",
+                None,
+                None,
+                JobStatusType.WPS,
+                Status.ACCEPTED,
+            ),
+            # using 'Accept: ...; profile=wps'
+            (
+                {},
+                {"Accept": f"{ContentType.APP_JSON}; profile={JobStatusProfileSchema.WPS}"},
+                0,
+                Status.SUCCESSFUL,
+                f"{ContentType.APP_JSON}; profile={JobStatusProfileSchema.WPS}",
+                None,
+                None,
+                JobStatusType.WPS,
+                Status.SUCCEEDED,
+            ),
+            (
+                {},
+                {"Accept": f"{ContentType.APP_JSON}; profile={JobStatusProfileSchema.WPS}"},
+                1,
+                Status.FAILED,
+                f"{ContentType.APP_JSON}; profile={JobStatusProfileSchema.WPS}",
+                None,
+                None,
+                JobStatusType.WPS,
+                Status.FAILED,
+            ),
+            (
+                {},
+                {"Accept": f"{ContentType.APP_JSON}; profile={JobStatusProfileSchema.WPS}"},
+                9,
+                Status.RUNNING,
+                f"{ContentType.APP_JSON}; profile={JobStatusProfileSchema.WPS}",
+                None,
+                None,
+                JobStatusType.WPS,
+                Status.STARTED,
+            ),
+            (
+                {},
+                {"Accept": f"{ContentType.APP_JSON}; profile={JobStatusProfileSchema.WPS}"},
+                11,
+                Status.ACCEPTED,
+                f"{ContentType.APP_JSON}; profile={JobStatusProfileSchema.WPS}",
+                None,
+                None,
+                JobStatusType.WPS,
+                Status.ACCEPTED,
+            ),
+            # using ONLY '?schema=wps' or '?profile=wps' (no Accept header nor format query)
+            # because WPS is typically XML, it should default to that representation instead of JSON
+            (
+                {"profile": JobStatusProfileSchema.WPS},
+                {},
+                0,
+                Status.SUCCESSFUL,
+                f"{ContentType.APP_XML}; profile={JobStatusProfileSchema.WPS}",
+                sd.OGC_WPS_1_SCHEMA_JOB_STATUS_URL,  # schema provided in header
+                None,  # however, not returned in "type" property since not JSON
+                JobStatusType.WPS,
+                Status.SUCCEEDED,
+            ),
+            (
+                {"schema": JobStatusProfileSchema.WPS},
+                {},
+                0,
+                Status.SUCCESSFUL,
+                f"{ContentType.APP_XML}; profile={JobStatusProfileSchema.WPS}",
+                sd.OGC_WPS_1_SCHEMA_JOB_STATUS_URL,
+                None,
+                JobStatusType.WPS,
+                Status.SUCCEEDED,
+            ),
+            (
+                {"profile": JobStatusProfileSchema.WPS},
+                {},
+                1,
+                Status.FAILED,
+                f"{ContentType.APP_XML}; profile={JobStatusProfileSchema.WPS}",
+                sd.OGC_WPS_1_SCHEMA_JOB_STATUS_URL,
+                None,
+                JobStatusType.WPS,
+                Status.FAILED,
+            ),
+            (
+                {"schema": JobStatusProfileSchema.WPS},
+                {},
+                1,
+                Status.FAILED,
+                f"{ContentType.APP_XML}; profile={JobStatusProfileSchema.WPS}",
+                sd.OGC_WPS_1_SCHEMA_JOB_STATUS_URL,
+                None,
+                JobStatusType.WPS,
+                Status.FAILED,
+            ),
+            (
+                {"profile": JobStatusProfileSchema.WPS},
+                {},
+                9,
+                Status.RUNNING,
+                f"{ContentType.APP_XML}; profile={JobStatusProfileSchema.WPS}",
+                sd.OGC_WPS_1_SCHEMA_JOB_STATUS_URL,
+                None,
+                JobStatusType.WPS,
+                Status.STARTED,
+            ),
+            (
+                {"schema": JobStatusProfileSchema.WPS},
+                {},
+                9,
+                Status.RUNNING,
+                f"{ContentType.APP_XML}; profile={JobStatusProfileSchema.WPS}",
+                sd.OGC_WPS_1_SCHEMA_JOB_STATUS_URL,
+                None,
+                JobStatusType.WPS,
+                Status.STARTED,
+            ),
+            (
+                {"profile": JobStatusProfileSchema.WPS},
+                {},
+                11,
+                Status.ACCEPTED,
+                f"{ContentType.APP_XML}; profile={JobStatusProfileSchema.WPS}",
+                sd.OGC_WPS_1_SCHEMA_JOB_STATUS_URL,
+                None,
+                JobStatusType.WPS,
+                Status.ACCEPTED,
+            ),
+            (
+                {"schema": JobStatusProfileSchema.WPS},
+                {},
+                11,
+                Status.ACCEPTED,
+                f"{ContentType.APP_XML}; profile={JobStatusProfileSchema.WPS}",
+                sd.OGC_WPS_1_SCHEMA_JOB_STATUS_URL,
+                None,
+                JobStatusType.WPS,
+                Status.ACCEPTED,
+            ),
         ]
     )
     @pytest.mark.oap_part4
@@ -2453,8 +2681,8 @@ class WpsRestApiJobsTest(JobUtils):
         reference_job_index,    # type: int
         reference_job_status,   # type: Status
         expect_content_type,    # type: AnyContentType
-        expect_content_schema,  # type: str
-        expect_json_schema,     # type: str
+        expect_content_schema,  # type: Optional[str]
+        expect_json_schema,     # type: Optional[str]
         expect_job_type,        # type: JobStatusType
         expect_job_status,      # type: Status
     ):                          # type: (...) -> None
@@ -2467,14 +2695,42 @@ class WpsRestApiJobsTest(JobUtils):
         """
         job = self.job_info[reference_job_index]
         assert job.status == reference_job_status, "Precondition invalid."
-        path = f"/jobs/{job.id}"
-        resp = self.app.get(path, headers=headers, params=params)
+
+        # mock creation of XML status file for test combinations that need it
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".xml") as tmp_xml_status:
+            xml_text = load_example("wps_execute_response.xml", text=True)
+            tmp_xml_status.write(xml_text)
+            tmp_xml_status.flush()
+            tmp_xml_status.seek(0)
+            with mock.patch(
+                "weaver.wps_restapi.jobs.utils.get_wps_local_status_location",
+                return_value=tmp_xml_status.name,
+            ):
+                path = f"/jobs/{job.id}"
+                resp = self.app.get(path, headers=headers, params=params)
+
         assert resp.status_code == 200
         assert resp.headers["Content-Type"] == expect_content_type
-        assert resp.headers["Content-Schema"] == expect_content_schema
-        assert resp.json["$schema"] == expect_json_schema
-        assert resp.json["type"] == expect_job_type
-        assert resp.json["status"] == expect_job_status
+        assert resp.headers.get("Content-Schema") == expect_content_schema
+        if ContentType.APP_JSON in expect_content_type:
+            assert resp.json.get("$schema") == expect_json_schema
+            assert resp.json["type"] == expect_job_type
+            assert resp.json["status"] == expect_job_status
+        elif ContentType.APP_XML in expect_content_type:
+            # just ensure that at least it is aligned with what is expected as WPS execution status response (not HTML)
+            # since we use a mock, the actual content is not important, as long as the schema/type resolution made sense
+            assert f"{expect_job_type}:" in resp.text, "type should be used as namespace in XML representation"
+            assert expect_content_schema.rsplit("/", 1)[-1] in resp.text, "Schema name should be in XML contents."
+        else:
+            raise AssertionError(f"Invalid response Content-Type [{expect_content_type}] is not expected.")
+
+    def test_job_status_xml_gone(self):
+        # this test considers that jobs are not created by actual execution
+        # therefore, the XML file does not actually exist
+        job = self.job_info[0]
+        path = f"/jobs/{job.id}"
+        resp = self.app.get(path, params={"f": OutputFormat.XML}, expect_errors=True)
+        assert resp.status_code == 410
 
     def test_job_status_html_success(self):
         job = self.job_info[0]

--- a/weaver/base.py
+++ b/weaver/base.py
@@ -47,8 +47,11 @@ class Constants(object, metaclass=_Const):
         return [member for member in members if not isinstance(member, str) or not member.startswith("_")]
 
     @classmethod
-    def get(cls, key_or_value, default=None):
-        # type: (Union[AnyKey, EnumType, PropertyDataTypeT], Optional[Any]) -> PropertyDataTypeT
+    def get(
+        cls,            # type: Type[PropertyDataTypeT]
+        key_or_value,   # type: Union[AnyKey, EnumType, PropertyDataTypeT]
+        default=None,   # type: Optional[Any]
+    ):                  # type: (...) -> PropertyDataTypeT
         if isinstance(key_or_value, str):
             upper_key = key_or_value.upper()
             lower_key = key_or_value.lower()

--- a/weaver/processes/constants.py
+++ b/weaver/processes/constants.py
@@ -7,7 +7,7 @@ from typing_extensions import Literal, get_args
 from weaver.base import Constants
 
 if TYPE_CHECKING:
-    from typing import Dict
+    from typing import Dict, TypeAlias
 
     from weaver.typedefs import CWL_NamespaceDefinition
 
@@ -386,20 +386,45 @@ OAS_DATA_TYPES = frozenset(
 ProcessSchemaOGCType = Literal["OGC", "ogc"]
 ProcessSchemaOLDType = Literal["OLD", "old"]
 ProcessSchemaWPSType = Literal["WPS", "wps"]
-ProcessSchemaType = Union[ProcessSchemaOGCType, ProcessSchemaOLDType, ProcessSchemaWPSType]
+ProcessSchemaConstType = "ProcessSchema"  # type: TypeAlias
+ProcessSchemaType = Union[
+    ProcessSchemaOGCType,
+    ProcessSchemaOLDType,
+    ProcessSchemaWPSType,
+    ProcessSchemaConstType,
+]
 JobStatusTypeProcess = Literal["process"]
 JobStatusTypeService = Literal["service"]
 JobStatusTypeProvider = Literal["provider"]
+JobStatusConstType = "JobStatusType"  # type: TypeAlias
+JobStatusPropertyType = Union[
+    JobStatusTypeProcess,
+    JobStatusTypeService,
+    JobStatusTypeProvider,
+    JobStatusConstType,
+]
 JobInputsOutputsSchemaType_OGC = Literal["OGC", "ogc"]
 JobInputsOutputsSchemaType_OLD = Literal["OLD", "old"]
 JobInputsOutputsSchemaType_OGC_STRICT = Literal["OGC+STRICT", "ogc+strict"]
 JobInputsOutputsSchemaType_OLD_STRICT = Literal["OLD+STRICT", "old+strict"]
 JobInputsOutputsSchemaAnyOGCType = Union[JobInputsOutputsSchemaType_OGC, JobInputsOutputsSchemaType_OGC_STRICT]
 JobInputsOutputsSchemaAnyOLDType = Union[JobInputsOutputsSchemaType_OLD, JobInputsOutputsSchemaType_OLD_STRICT]
-JobInputsOutputsSchemaType = Union[JobInputsOutputsSchemaAnyOGCType, JobInputsOutputsSchemaAnyOLDType]
+JobInputsOutputsSchemaConstType = "JobInputsOutputsSchema"  # type: TypeAlias
+JobInputsOutputsSchemaType = Union[
+    JobInputsOutputsSchemaAnyOGCType,
+    JobInputsOutputsSchemaAnyOLDType,
+    JobInputsOutputsSchemaConstType,
+]
 JobStatusProfileSchemaType_OGC = Literal["OGC", "ogc"]
 JobStatusProfileSchemaType_OpenEO = Literal["OPENEO", "openeo", "openEO", "OpenEO"]
-JobStatusProfileSchemaType = Union[JobStatusProfileSchemaType_OGC, JobStatusProfileSchemaType_OpenEO]
+JobStatusProfileSchemaType_WPS = Literal["WPS", "wps"]
+JobStatusProfileSchemaConstType = "JobStatusProfileSchema"  # type: TypeAlias
+JobStatusProfileSchemaType = Union[
+    JobStatusProfileSchemaType_OGC,
+    JobStatusProfileSchemaType_OpenEO,
+    JobStatusProfileSchemaType_WPS,
+    JobStatusProfileSchemaConstType,
+]
 
 
 class ProcessSchema(Constants):
@@ -427,6 +452,7 @@ class JobStatusProfileSchema(Constants):
     """
     OGC = "ogc"         # type: JobStatusProfileSchemaType_OGC
     OPENEO = "openeo"   # type: JobStatusProfileSchemaType_OpenEO
+    WPS = "wps"         # type: JobStatusProfileSchemaType_WPS
 
 
 class JobStatusType(Constants):

--- a/weaver/status.py
+++ b/weaver/status.py
@@ -42,11 +42,13 @@ JOB_STATUS_CATEGORIES = {
     # note:
     #   OGC compliant (old): [Accepted, Running, successful, Failed]
     #   OGC compliant (new): [accepted, running, successful, failed, dismissed, created]  ('created' in Part 4 only)
-    #   PyWPS uses:          [Accepted, Started, Succeeded, Failed, Paused, Exception]
-    #   OWSLib uses:         [Accepted, Running, Succeeded, Failed, Paused] (with 'Process' in front)
+    #   PyWPS uses:          [Accepted, Started, Succeeded, Failed, Paused, Exception]                  [WPS 1.0.0]
+    #   OWSLib uses:         [Accepted, Running, Succeeded, Failed, Paused] (with 'Process' in front)   [WPS 2.0]
     #   OpenEO uses:         [queued, running, finished, error, canceled, created]
     # https://github.com/opengeospatial/ogcapi-processes/blob/master/openapi/schemas/processes-core/statusCode.yaml
     # http://docs.opengeospatial.org/is/14-065/14-065.html#17
+    # https://schemas.opengis.net/wps/1.0.0/wpsExecute_response.xsd
+    # https://schemas.opengis.net/wps/2.0/wpsCommon.xsd
 
     # corresponding statuses are aligned vertically for 'COMPLIANT' groups
     StatusCompliant.OGC: frozenset([

--- a/weaver/wps_restapi/jobs/jobs.py
+++ b/weaver/wps_restapi/jobs/jobs.py
@@ -330,6 +330,15 @@ def trigger_job_execution(request):
 @sd.provider_job_service.get(
     tags=[sd.TAG_JOBS, sd.TAG_STATUS, sd.TAG_PROVIDERS],
     schema=sd.GetProviderJobEndpoint(),
+    accept=ContentType.ANY_XML,
+    response_schemas=sd.derive_responses(
+        sd.get_single_job_status_responses,
+        sd.WPSExecuteResponse(description="Job XML status.")
+    ),
+)
+@sd.provider_job_service.get(
+    tags=[sd.TAG_JOBS, sd.TAG_STATUS, sd.TAG_PROVIDERS],
+    schema=sd.GetProviderJobEndpoint(),
     accept=[ContentType.APP_JSON] + [
         f"{ContentType.APP_JSON}; profile={profile}"
         for profile in JobStatusProfileSchema.values()
@@ -350,6 +359,15 @@ def trigger_job_execution(request):
 @sd.process_job_service.get(
     tags=[sd.TAG_JOBS, sd.TAG_STATUS, sd.TAG_PROCESSES],
     schema=sd.GetProcessJobEndpoint(),
+    accept=ContentType.ANY_XML,
+    response_schemas=sd.derive_responses(
+        sd.get_single_job_status_responses,
+        sd.WPSExecuteResponse(description="Job XML status.")
+    ),
+)
+@sd.process_job_service.get(
+    tags=[sd.TAG_JOBS, sd.TAG_STATUS, sd.TAG_PROCESSES],
+    schema=sd.GetProcessJobEndpoint(),
     accept=[ContentType.APP_JSON] + [
         f"{ContentType.APP_JSON}; profile={profile}"
         for profile in JobStatusProfileSchema.values()
@@ -365,6 +383,15 @@ def trigger_job_execution(request):
     response_schemas=sd.derive_responses(
         sd.get_single_job_status_responses,
         sd.GenericHTMLResponse(name="HTMLJobStatus", description="Job status.")
+    ),
+)
+@sd.job_service.get(
+    tags=[sd.TAG_JOBS, sd.TAG_STATUS],
+    schema=sd.GetJobEndpoint(),
+    accept=ContentType.ANY_XML,
+    response_schemas=sd.derive_responses(
+        sd.get_single_job_status_responses,
+        sd.WPSExecuteResponse(description="Job XML status.")
     ),
 )
 @sd.job_service.get(

--- a/weaver/wps_restapi/jobs/utils.py
+++ b/weaver/wps_restapi/jobs/utils.py
@@ -19,6 +19,7 @@ from pyramid.httpexceptions import (
     HTTPNotFound,
     HTTPOk
 )
+from pyramid.response import FileResponse
 from pyramid_celery import celery_app
 from requests_toolbelt.multipart.encoder import MultipartEncoder
 from webob.headers import ResponseHeaders
@@ -74,7 +75,12 @@ from weaver.utils import (
     parse_kvp
 )
 from weaver.visibility import Visibility
-from weaver.wps.utils import get_wps_output_dir, get_wps_output_url, map_wps_output_location
+from weaver.wps.utils import (
+    get_wps_local_status_location,
+    get_wps_output_dir,
+    get_wps_output_url,
+    map_wps_output_location
+)
 from weaver.wps_restapi import swagger_definitions as sd
 from weaver.wps_restapi.processes.utils import resolve_process_tag
 from weaver.wps_restapi.providers.utils import forbid_local_only
@@ -83,7 +89,7 @@ if TYPE_CHECKING:
     from typing import Any, Dict, List, Optional, Sequence, Tuple, Type, Union
 
     from weaver.execute import AnyExecuteResponse, AnyExecuteReturnPreference, AnyExecuteTransmissionMode
-    from weaver.formats import AnyContentEncoding
+    from weaver.formats import AnyContentType, AnyContentEncoding
     from weaver.processes.constants import JobInputsOutputsSchemaType, JobStatusProfileSchemaType
     from weaver.typedefs import (
         AnyDataStream,
@@ -331,42 +337,100 @@ def get_job_status_schema(request):
     # type: (AnyRequestType) -> Tuple[JobStatusProfileSchemaType, HeadersType]
     """
     Identifies if a :term:`Job` status response schema :term:`Profile` applies for the request.
+
+    :raises HTTPBadRequest: If an invalid combination :term:`Profile` and :term:`Media-Type` is requested.
     """
 
-    def make_headers(resolved_schema):
-        # type: (JobStatusProfileSchemaType) -> HeadersType
-        content_type = clean_media_type_format(content_accept.split(",")[0], strip_parameters=True)
-        if content_type in ContentType.ANY_XML | {ContentType.TEXT_HTML}:
+    def make_headers(resolved_schema, content_type):
+        # type: (JobStatusProfileSchemaType, AnyContentType) -> HeadersType
+        if content_type == ContentType.TEXT_HTML:
             return {"Content-Type": content_type}
+        if content_type == ContentType.ANY and resolved_schema != JobStatusProfileSchema.WPS:
+            content_type = ContentType.APP_JSON
         content_profile = f"{content_type}; profile={resolved_schema}"
         content_headers = {"Content-Type": content_profile}
         if resolved_schema == JobStatusProfileSchema.OGC:
             content_headers["Content-Schema"] = sd.OGC_API_SCHEMA_JOB_STATUS_URL
         elif resolved_schema == JobStatusProfileSchema.OPENEO:
             content_headers["Content-Schema"] = sd.OPENEO_API_SCHEMA_JOB_STATUS_URL
+        elif content_type in ContentType.ANY_XML:
+            if resolved_schema not in [JobStatusProfileSchema.WPS, None]:
+                raise HTTPBadRequest(
+                    json={
+                        "code": "InvalidParameterValue",
+                        "description": "Requested job schema profile cannot be combined with XML representation.",
+                        "cause": {"profile" if "profile" in request.params else "schema": schema},
+                    }
+                )
+            content_headers["Content-Type"] = f"{ContentType.APP_XML}; profile={JobStatusProfileSchema.WPS}"
+            content_headers["Content-Schema"] = sd.OGC_WPS_1_SCHEMA_JOB_STATUS_URL
         return content_headers
 
     content_accept = get_header("Accept", request.headers) or ContentType.APP_JSON
-    if content_accept == ContentType.ANY:
-        content_accept = ContentType.APP_JSON
+    content_media_type = clean_media_type_format(content_accept.split(",")[0], strip_parameters=True)
 
     params = get_request_args(request)
     schema = JobStatusProfileSchema.get(params.get("profile") or params.get("schema"))
     if schema:
-        headers = make_headers(schema)
+        headers = make_headers(schema, content_media_type)
         return schema, headers
+
     params = parse_kvp(content_accept)
     profile = params.get("profile")
     if not profile:
-        schema = JobStatusProfileSchema.OGC
-        headers = make_headers(schema)
+        if content_media_type in ContentType.ANY_XML:
+            schema = JobStatusProfileSchema.WPS
+        else:
+            schema = JobStatusProfileSchema.OGC
+        headers = make_headers(schema, content_media_type)
         return schema, headers
-    schema = cast(
-        "JobStatusProfileSchemaType",
-        JobStatusProfileSchema.get(profile[0], default=JobStatusProfileSchema.OGC)
-    )
-    headers = make_headers(schema)
+
+    schema = JobStatusProfileSchema.get(profile[0], default=JobStatusProfileSchema.OGC)
+    headers = make_headers(schema, content_media_type)
     return schema, headers
+
+
+def get_job_status_wps_xml_response(job, request):
+    # type: (Job, AnyRequestType) -> AnyResponseType
+    """
+    Retrieve the :term:`WPS` :term:`XML` status file and return it as response.
+
+    Assumes that :func:`get_job_status_schema` was invoked to resolve any relevant schema :term:`Profile` and
+    content :term:`Media-Type` that is enforced by handling of the response representation from this function.
+
+    If the :term:`XML` file cannot be resolved (e.g.: removed by automatic cleanup or :term:`Job` dismiss),
+    an appropriate HTTP error will be raised.
+    """
+    schema = sd.OGC_WPS_1_SCHEMA_JOB_STATUS_URL
+    headers = {
+        "Content-Type": f"{ContentType.APP_XML}; profile={JobStatusProfileSchema.WPS}",
+        "Content-Schema": schema,
+    }
+    wps_status_file = get_wps_local_status_location(
+        job.status_location or job.status_url(request),
+        container=request,
+        must_exist=True,
+    )
+    if not wps_status_file:
+        accept_header = get_header("Accept", request.headers)
+        format_query = "f" if "f" in request.params else "format"
+        raise JobGone(
+            json={
+                "title": "JobStatusGone",
+                "type": "JobStatusGone",
+                "status": JobGone.code,
+                "detail": "Job status artifact in XML representation cannot be resolved.",
+                "cause": (
+                    {"in": "headers", "name": "Accept", "value": accept_header}
+                    if accept_header else
+                    {"in": "query", "name": format_query, "value": "xml"}
+                ),
+                "value": {"jobID": str(job.id), "status": job.status},
+            }
+        )
+    resp = FileResponse(wps_status_file, request=request)
+    resp.headers.update(headers)
+    return resp
 
 
 def make_result_link(

--- a/weaver/wps_restapi/jobs/utils.py
+++ b/weaver/wps_restapi/jobs/utils.py
@@ -89,7 +89,7 @@ if TYPE_CHECKING:
     from typing import Any, Dict, List, Optional, Sequence, Tuple, Type, Union
 
     from weaver.execute import AnyExecuteResponse, AnyExecuteReturnPreference, AnyExecuteTransmissionMode
-    from weaver.formats import AnyContentType, AnyContentEncoding
+    from weaver.formats import AnyContentEncoding, AnyContentType
     from weaver.processes.constants import JobInputsOutputsSchemaType, JobStatusProfileSchemaType
     from weaver.typedefs import (
         AnyDataStream,

--- a/weaver/wps_restapi/swagger_definitions.py
+++ b/weaver/wps_restapi/swagger_definitions.py
@@ -3413,7 +3413,7 @@ class JobStatusQueryProfileSchema(ExtendedSchemaNode):
     validator = OneOfCaseInsensitive(JobStatusProfileSchema.values())
 
 
-class GetJobQuery(ExtendedMappingSchema):
+class GetJobQuery(FormatQuery):
     schema = JobStatusQueryProfileSchema(missing=drop)
     profile = JobStatusQueryProfileSchema(missing=drop)
 

--- a/weaver/wps_restapi/swagger_definitions.py
+++ b/weaver/wps_restapi/swagger_definitions.py
@@ -235,6 +235,7 @@ OGC_API_BBOX_FORMAT = "ogc-bbox"  # equal CRS:84 and EPSG:4326, equivalent to WG
 OGC_API_BBOX_EPSG = "EPSG:4326"
 
 OGC_API_SCHEMA_JOB_STATUS_URL = f"{OGC_API_PROC_PART1_SCHEMAS}/statusInfo.yaml"
+OGC_WPS_1_SCHEMA_JOB_STATUS_URL = f"{OGC_WPS_1_SCHEMAS}/wpsExecute_response.xsd"
 
 OPENEO_API_SCHEMA_URL = "https://openeo.org/documentation/1.0/developers/api/openapi.yaml"
 OPENEO_API_SCHEMA_JOB_STATUS_URL = f"{OPENEO_API_SCHEMA_URL}#/components/schemas/batch_job"
@@ -3253,7 +3254,7 @@ class WPSProcessOutputs(ExtendedSequenceSchema, WPSNamespace):
 
 
 class WPSExecuteResponse(WPSResponseBaseType, WPSProcessVersion):
-    _schema = f"{OGC_WPS_1_SCHEMAS}/wpsExecute_response.xsd"
+    _schema = OGC_WPS_1_SCHEMA_JOB_STATUS_URL
     name = "ExecuteResponse"
     title = "ExecuteResponse"  # not to be confused by 'Execute' used for request
     location = WPSStatusLocationAttribute()


### PR DESCRIPTION
- Add ``f=xml`` support for `Job` status endpoints to directly retrieve the corresponding `WPS` `XML` status content.
- Add ``schema=wps`` and ``profile=wps`` query parameter support for `Job` status endpoints.
  If used by themselves, these query parameter values will return the same `WPS` `XML` content as when using ``f=xml``.
  If combined with `JSON` format (i.e.: ``?f=json&profile=wps``), the `OGC API - Processes` `Job` status information
  will be returned instead, but using the corresponding `WPS` ``status`` values. Specifically, this allows returning
  the previous `WPS`  ``succeeded`` and ``started`` status values instead of the `OGC API - Processes` ``successful``
  and ``running`` values respectively. This is provided to help clients that have to deal with the mixture of
  properties until the standard is properly stabilized and released. However, the default status values returned
  by ``profile=ogc`` should be preferred and employed whenever possible.
- Add missing ``f`` and ``format`` query parameters for `Job` status endpoints in `OpenAPI` schema.