### PR TITLE
update dockers to remove outdated Python 3.11 packages and other build dependencies

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,7 +16,9 @@ Changes:
 
 Fixes:
 ------
-- No change.
+- Remove additional software dependency in worker Docker image leading to outdated Python 3.11 and
+  its insecure dependencies to be installed along updated Python 3.12 with specific `Weaver` requirements.
+- Reduce all Docker image sizes by approximately 1/3 with post-install removal of build dependencies.
 
 .. _changes_6.6.0:
 

--- a/Makefile
+++ b/Makefile
@@ -837,6 +837,8 @@ generate-archive:	## generate ZIP and TAR.GZ archives using current contents
 DOCKER_REPO ?= pavics/weaver
 #DOCKER_REPO ?= docker-registry.crim.ca/ogc/weaver
 
+DOCKER_BUILD_XARGS ?=
+
 # NOTE:
 #	Because of the --push requirement when involving provenance/SBOM
 #	only full '[registry.uri/]org/weaver:tag' can be passed as '-t' label
@@ -893,6 +895,7 @@ docker-info:		## obtain docker image information
 docker-build-base: $(DOCKER_BUILDER_STEP)	## build the base docker image
 	docker build "$(APP_ROOT)" \
 		$(DOCKER_BUILDER_ARGS) \
+		$(DOCKER_BUILD_XARGS) \
 		-f "$(APP_ROOT)/docker/Dockerfile-base" \
 		-t "$(DOCKER_REPO):$(APP_VERSION)"
 	@[ "$(DOCKER_TAG_ALIASES)" = "true" ] && ( \
@@ -906,6 +909,7 @@ docker-build-base: $(DOCKER_BUILDER_STEP)	## build the base docker image
 docker-build-manager: $(DOCKER_BUILDER_STEP) docker-build-base		## build the manager docker image
 	docker build "$(APP_ROOT)" \
 		$(DOCKER_BUILDER_ARGS) \
+		$(DOCKER_BUILD_XARGS) \
 		-f "$(APP_ROOT)/docker/Dockerfile-manager" \
 		-t "$(DOCKER_REPO):$(APP_VERSION)-manager"
 	@[ "$(DOCKER_TAG_ALIASES)" = "true" ] && ( \
@@ -919,6 +923,7 @@ docker-build-manager: $(DOCKER_BUILDER_STEP) docker-build-base		## build the man
 docker-build-worker: $(DOCKER_BUILDER_STEP) docker-build-base		## build the worker docker image
 	docker build "$(APP_ROOT)" \
 		$(DOCKER_BUILDER_ARGS) \
+		$(DOCKER_BUILD_XARGS) \
 		-f "$(APP_ROOT)/docker/Dockerfile-worker" \
 		-t "$(DOCKER_REPO):$(APP_VERSION)-worker"
 	@[ "$(DOCKER_TAG_ALIASES)" = "true" ] && ( \

--- a/docker/Dockerfile-base
+++ b/docker/Dockerfile-base
@@ -30,6 +30,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         gcc \
         g++ \
         git \
+    && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/*
 
 # install package

--- a/docker/Dockerfile-worker
+++ b/docker/Dockerfile-worker
@@ -7,7 +7,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         curl \
         gnupg \
         gnupg-agent \
-        software-properties-common \
     # NOTE: Only 'worker' image should be using docker, 'manager' is only for API. \
     && install -m 0755 -d /etc/apt/keyrings \
     && curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
@@ -22,6 +21,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     #   Only install CLI package, 'docker-ce' and 'containerd.io' not required as they should be provided by host.
     #   Docker sibling execution is expected. See 'docker/docker-compose.yml.example' for details.
     && apt-get install --no-install-recommends docker-ce-cli \
+    && apt-get dist-upgrade \
+    && apt-get remove -y \
+        gnupg \
+        gnupg-agent \
+    && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/*
 
 # run app


### PR DESCRIPTION
## Fixes

- Remove additional software dependency in worker Docker image leading to outdated Python 3.11 and
  its insecure dependencies to be installed along updated Python 3.12 with specific `Weaver` requirements.
- Reduce all Docker image sizes by approximately 1/3 with post-install removal of build dependencies.