### PR TITLE
fix multiple HTML paging links

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,7 +16,9 @@ Changes:
 
 Fixes:
 ------
-- No change.
+- Fix missing link in `Job` status `HTML` page for ``inputs`` and ``links`` references.
+- Fix invalid link in `Job` status `HTML` page for ``logs`` reference.
+- Fix consistency between link names between `Job` status and `Process` description `HTML` pages.
 
 .. _changes_6.6.0:
 

--- a/tests/wps_restapi/test_jobs.py
+++ b/tests/wps_restapi/test_jobs.py
@@ -2744,7 +2744,7 @@ class WpsRestApiJobsTest(JobUtils):
         row_status = [row.text.strip() for row in rows if "Status" in row.text]
         assert row_status and row_status[0].endswith(Status.SUCCESSFUL)
 
-        logs_divs = list(resp.html.find("h3", id="job-logs").find_next_siblings("div"))
+        logs_divs = list(resp.html.find("h3", id="logs").find_next_siblings("div"))
         logs_scripts = list(logs_divs[-1].find("script"))
         assert "fetch_job_logs" in logs_scripts[-1]
 
@@ -2767,7 +2767,7 @@ class WpsRestApiJobsTest(JobUtils):
         row_status = [row.text.strip() for row in rows if "Status" in row.text]
         assert row_status and row_status[0].endswith(Status.FAILED)
 
-        logs_divs = list(resp.html.find("h3", id="job-logs").find_next_siblings("div"))
+        logs_divs = list(resp.html.find("h3", id="logs").find_next_siblings("div"))
         logs_scripts = list(logs_divs[-1].find("script"))
         assert "fetch_job_logs" in logs_scripts[-1]
 

--- a/weaver/wps_restapi/templates/responses/job_listing.mako
+++ b/weaver/wps_restapi/templates/responses/job_listing.mako
@@ -20,7 +20,7 @@
         <ul>
             <li>
                 <div class="nav-link">
-                    Return to <a href="${weaver.wps_restapi_url}?f=html">API Frontpage</a>.
+                    Return to <a href="${weaver.wps_restapi_url}?f=html">API Frontpage</a>
                 </div>
             </li>
             ${util.get_paging_links()}

--- a/weaver/wps_restapi/templates/responses/job_status.mako
+++ b/weaver/wps_restapi/templates/responses/job_status.mako
@@ -22,12 +22,12 @@
         <ul>
             <li>
                 <div class="nav-link">
-                    Return to <a href="${weaver.wps_restapi_url}?f=html">API Frontpage</a>.
+                    Return to <a href="${weaver.wps_restapi_url}?f=html">API Frontpage</a>
                 </div>
             </li>
             <li>
                 <div class="nav-link">
-                    Return to <a href="${util.get_jobs_link(query='f=html')}">Jobs list</a>.
+                    Return to <a href="${util.get_jobs_link(query='f=html')}">Jobs Listing</a>
                 </div>
             </li>
             <li>
@@ -37,12 +37,12 @@
             </li>
             <li>
                 <div class="nav-link">
-                    Go to <a href="#results">Job Results</a>
+                    Go to <a href="#inputs">Job Inputs</a>
                 </div>
             </li>
             <li>
                 <div class="nav-link">
-                    Go to <a href="#statistics">Job Statistics</a>
+                    Go to <a href="#results">Job Results</a>
                 </div>
             </li>
             <li>
@@ -57,10 +57,19 @@
             </li>
             <li>
                 <div class="nav-link">
+                    Go to <a href="#statistics">Job Statistics</a>
+                </div>
+            </li>
+            <li>
+                <div class="nav-link">
                     Go to <a href="#provenance">Job Provenance</a>
                 </div>
             </li>
-            ${util.get_paging_links()}
+            <li>
+                <div class="nav-link">
+                    Go to <a href="#links">Job Links</a>
+                </div>
+            </li>
         </ul>
     </div>
 
@@ -166,8 +175,8 @@
     </div>
 
     <div class="content-section">
-        <h3 id="job-logs">
-            <a href="#job-logs">Logs</a>
+        <h3 id="logs">
+            <a href="#logs">Logs</a>
         </h3>
         <div class="content-section-summary">
             Logs captured during the job execution.

--- a/weaver/wps_restapi/templates/responses/util.mako
+++ b/weaver/wps_restapi/templates/responses/util.mako
@@ -54,28 +54,28 @@ Assume that the definitions will be inserted into a 'nav-menu' with a parent HTM
     %if first_page:
         <li>
             <div class="nav-link">
-                Go to <a href="${first_page}">first page</a>.
+                Go to <a href="${first_page}">First Page</a>
             </div>
         </li>
     %endif
     %if prev_page:
         <li>
             <div class="nav-link">
-                Go to <a href="${prev_page}">previous page</a>.
+                Go to <a href="${prev_page}">Previous Page</a>
             </div>
         </li>
     %endif
     %if next_page:
         <li>
             <div class="nav-link">
-                Go to <a href="${next_page}">next page</a>.
+                Go to <a href="${next_page}">Next Page</a>
             </div>
         </li>
     %endif
     %if last_page:
         <li>
             <div class="nav-link">
-                Go to <a href="${last_page}">last page</a>.
+                Go to <a href="${last_page}">Last Page</a>
             </div>
         </li>
     %endif


### PR DESCRIPTION
## Fixes

- Fix missing link in `Job` status `HTML` page for ``inputs`` and ``links`` references.
- Fix invalid link in `Job` status `HTML` page for ``logs`` reference.
- Fix consistency between link names between `Job` status and `Process` description `HTML` pages.