### PR TITLE
remove auth override in CI for PyPI using trusted publishers

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -180,10 +180,6 @@ jobs:
         run: make dist-pypi
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
-          verbose: true
 
   deploy-docker:
     needs: tests

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2243,7 +2243,7 @@ Fixes:
 
 Changes:
 --------
-- Add reference link to ReadTheDocs URL of `Weaver` in API landing page.
+- Add reference link to `ReadTheDocs` URL of `Weaver` in API landing page.
 - Add references to `OGC-API Processes` requirements and recommendations for eventual conformance listing
   (relates to `#231 <https://github.com/crim-ca/weaver/issues/231>`_).
 - Add ``datetime`` query parameter for job searches queries
@@ -2512,11 +2512,11 @@ Fixes:
 
 Changes:
 --------
-- Generate Weaver OpenAPI specification for readthedocs publication.
+- Generate Weaver OpenAPI specification for `ReadTheDocs` publication.
 - Add some sections for documentation (`#61 <https://github.com/crim-ca/weaver/issues/61>`_).
 - Add support of documentation RST file redirection to generated HTML for reference resolution in both Github source
-  and Readthedocs served pages.
-- Improve documentation links, ReadTheDocs format and TOC references.
+  and `ReadTheDocs` served pages.
+- Improve documentation links, `ReadTheDocs` format and TOC references.
 - Avoid logging ``stdout/stderr`` in workflows.
 - Add tests to make sure processes ``stdout/stderr`` are logged.
 - Remove Python 2.7 version as not *officially* supported.
@@ -2810,7 +2810,7 @@ Changes:
 Fixes:
 -------------
 
-- Fix `readthedocs <https://img.shields.io/readthedocs/pavics-weaver>`_ documentation generation.
+- Fix `ReadTheDocs` documentation generation.
 - Fix ``.travis`` docker image build condition.
 - Fix ``geopython/OWSLib>=0.19.1`` requirement for Python 3.8 support
   (`#62 <https://github.com/crim-ca/weaver/issues/62>`_).

--- a/Makefile
+++ b/Makefile
@@ -489,7 +489,7 @@ coverage: test-coverage  ## alias to run test with coverage analysis
 ## -- [variants '<target>-only' without '-only' suffix are also available with pre-install setup]
 
 # autogen check variants with pre-install of dependencies using the '-only' target references
-CHECKS := pep8 lint security security-code security-deps doc8 docf fstring docstring links imports
+CHECKS := pep8 lint security security-code security-deps dist-doc doc8 docf fstring docstring links imports
 CHECKS := $(addprefix check-, $(CHECKS))
 
 # items that should not install python dev packages should be added here instead
@@ -566,6 +566,16 @@ check-security-code-only: mkdir-reports clean-src ## run security checks on sour
 	@bash -c '$(CONDA_CMD) \
 		bandit -v --ini "$(APP_ROOT)/setup.cfg" -r \
 		1> >(tee "$(REPORTS_DIR)/check-security-code.txt")'
+
+.PHONY: check-dist-doc-only
+check-dist-doc-only: mkdir-reports dist-pypi-only	## check that documentation is valid for PyPI package distribution
+	@echo "Running RST documentation checks for PyPI package distribution..."
+	@bash -c '$(CONDA_CMD) \
+		twine check dist/* \
+		1> >(tee "$(REPORTS_DIR)/check-dist-doc.txt")'
+
+.PHONY: check-dist-doc
+check-dist-doc: install-sys check-dist-doc-only
 
 .PHONY: check-doc8-only
 check-doc8-only: mkdir-reports	  ## check documentation RST styles and linting
@@ -777,8 +787,8 @@ dist-pypi: install-sys dist-pypi-only
 .PHONY: dist-pypi-only
 dist-pypi-only: clean-dist	## publish package distribution on PyPI
 	@echo "Build distributions for PyPI ..."
-	@-python setup.py sdist
-	@-python setup.py bdist_wheel
+	@DOC_REMOVE_PYPI=true python setup.py sdist
+	@DOC_REMOVE_PYPI=true python setup.py bdist_wheel
 	@ls -l dist
 
 .PHONY: extract-changes

--- a/README.rst
+++ b/README.rst
@@ -48,7 +48,7 @@ for each process.
     * - citation
       - | |citation-zenodo| |citation-cff|
     * - build status
-      - | |readthedocs| |docker_build_mode| |docker_build_status|
+      - | |readthedocs_build_status| |docker_build_mode| |docker_build_status|
     * - tests status
       - | |github_latest| |github_tagged| |coverage| |codacy|
     * - releases
@@ -82,7 +82,7 @@ for each process.
     :alt: Github Actions CI Build Status (latest tag)
     :target: https://github.com/crim-ca/weaver/actions?query=workflow%3ATests+branch%3A6.6.0
 
-.. |readthedocs| image:: https://img.shields.io/readthedocs/pavics-weaver?logo=readthedocs
+.. |readthedocs_build_status| image:: https://img.shields.io/readthedocs/pavics-weaver?logo=readthedocs
     :alt: ReadTheDocs Build Status (master branch)
     :target: `ReadTheDocs`_
 
@@ -189,6 +189,8 @@ offered by |ades| and |ems| instances like `Weaver`.
 .. |kw12| image:: https://img.shields.io/badge/Open%20Science-blue
    :alt: Open Science
 
+.. remove-pypi-start
+
 Applications
 ~~~~~~~~~~~~~~~~
 
@@ -223,6 +225,10 @@ Observation data processing can evolve, and illustrates the advantages with appl
 .. note::
     See section `Extra Details & Sponsors`_ for further application examples and concrete demonstrations.
 
+.. remove-pypi-end
+
+.. remove-pypi-start
+
 Platform
 ~~~~~~~~~~~~~~~~
 
@@ -249,6 +255,8 @@ application stores, and shows the potential for multidisciplinary workflows in t
         </div>
     </div>
     <br>
+
+.. remove-pypi-end
 
 ----------------
 Links

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -44,6 +44,7 @@ pylint-per-file-ignores
 responses
 safety
 stopit
+twine
 typing_extensions
 WebTest
 wsgiproxy


### PR DESCRIPTION
- Address issues flagged in https://github.com/crim-ca/weaver/actions/runs/15046776427/job/42293940240
- Add checks for generated PyPI dist to early-detect problem RST definitions
- Fix relevant RST issues for PyPI publish
- Relates to #828 
- Relates to #755 