### PR TITLE
Revert "remove auth override in CI for PyPI using trusted publishers"

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -180,6 +180,10 @@ jobs:
         run: make dist-pypi
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          verbose: true
 
   deploy-docker:
     needs: tests


### PR DESCRIPTION
This reverts commit 21e0349780b5784830fbe6804fd7b87972df88bf.

The warning in https://github.com/crim-ca/weaver/actions/runs/15046776427/job/42293940240 suggested removing the token to employ PyPI trusted publisher feature. Doing simply breaks the operation (maybe because the project is not "created" yet?) https://github.com/crim-ca/weaver/actions/runs/15071189794/job/42369928796

``` 
 Error: Trusted publishing exchange failure: 
Token request failed: the server refused the request for the following reasons:

* `invalid-publisher`: valid token, but no corresponding publisher (All lookup strategies exhausted)
```
