### PR TITLE
split out 'all' check and check-links in CI to avoid sporadic failures breaking all tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,6 +38,8 @@ jobs:
       # override make command to install directly in active python
       CONDA_CMD: ""
       DOCKER_TEST_EXEC_ARGS: "-T"
+      # globally excluded 'checks', to be re-executed by dedicated job
+      CHECKS_EXCLUDE: "links"
     services:
       # Label used to access the service container
       mongodb:
@@ -62,13 +64,17 @@ jobs:
           #  allow-failure: true
           #  test-case: test-func-only
           # linter tests
-          # limitation with nested f-string quote styles changed in Python 3.12 (https://peps.python.org/pep-0701/)
-          # forces us to pin Python 3.11 during linting checks in order to evaluate backward-compatible code styles
-          # (see https://github.com/edaniszewski/pylint-quotes/issues/32)
+          # performs all 'check' targets except the 'CHECKS_EXCLUDE' ones (that should be defined by dedicated jobs)
           - os: ubuntu-latest
             python-version: "3.12"
             allow-failure: false
             test-case: check-only
+          # check links separately as they tend to sporadically fail from external factors (timeout, ssl, down, etc.)
+          # avoid wasting a lot of CI test time because one of them doesn't respond
+          - os: ubuntu-latest
+            python-version: "3.12"
+            allow-failure: true
+            test-case: check-links-only
           # documentation build
           - os: ubuntu-latest
             python-version: "3.12"
@@ -133,6 +139,10 @@ jobs:
         run: |
           hash -r
           env | sort
+
+      - name: Display Applicable Checks
+        if: ${{ startsWith(matrix.test-case, 'check') }}
+        run: make check-info
       - name: Run Tests
         run: make stop ${{ matrix.test-case }}
 


### PR DESCRIPTION
- adds Makefile `CHECKS_EXCLUDE` variable that can be used to disable the 'all' `CHECKS` variable
- adds Makefile `check-info` to list enabled/disabled checks
- adds separate GitHub CI `check-links-only` matrix job to avoid failing the entire test combinations because of faulty or unresponsive external servers

>[!NOTE]
> Below CI runs demonstrate the feature, where `check-links-only` job failed, but others kept going with their tests. 