### PR TITLE
replace setup.py sdist/sdist_wheel by python build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -797,8 +797,7 @@ dist-pypi: install-sys dist-pypi-only	## publish package distribution on PyPI wi
 .PHONY: dist-pypi-only
 dist-pypi-only: clean-dist	## publish package distribution on PyPI
 	@echo "Build distributions for PyPI ..."
-	@DOC_REMOVE_PYPI=true python setup.py sdist
-	@DOC_REMOVE_PYPI=true python setup.py bdist_wheel
+	@DOC_REMOVE_PYPI=true python -m build
 	@ls -l dist
 
 .PHONY: extract-changes

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,6 +8,7 @@ astroid
 # - https://github.com/PyCQA/bandit/issues/1226
 # - https://github.com/PyCQA/bandit/issues/1227
 bandit>=1.8.3
+build
 bump2version
 codacy-coverage
 coverage


### PR DESCRIPTION
Avoids warnings: https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html
