### PR TITLE
improve config, install, example and openapi documentation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,11 +12,12 @@ Changes
 
 Changes:
 --------
-- No change.
+- Add documentation to provide better guidance about installation, configuration and example references.
 
 Fixes:
 ------
-- No change.
+- Fix missing documentation of the `Vault` volume mount configuration in the *Docker Compose* example.
+- Fix missing documentation of the `CWL+YAML` deployment `Media-Type` support in the `OpenAPI` schema.
 
 .. _changes_6.8.3:
 

--- a/README.rst
+++ b/README.rst
@@ -351,8 +351,11 @@ Installation of `Weaver` from source can be performed instead of using the Docke
 
     pip install https://github.com/crim.ca/weaver
 
-For more details, please refer to the `Installation <https://pavics-weaver.readthedocs.io/en/latest/installation.html>`_
-section of the documentation.
+.. seealso::
+
+    For more details, please refer to
+    the `Installation <https://pavics-weaver.readthedocs.io/en/latest/installation.html>`_
+    section of the documentation.
 
 ----------------
 Configuration
@@ -362,7 +365,13 @@ All configuration settings can be overridden using a ``weaver.ini`` file that wi
 instantiation of the application. An example of such file is provided here: `weaver.ini.example`_.
 
 Setting the operational mode of `Weaver` (`EMS`/`ADES`/`HYBRID`) is accomplished using the
-``weaver.configuration`` field of ``weaver.ini``. For more configuration details, please refer to Documentation_.
+``weaver.configuration`` field of ``weaver.ini``.
+
+.. seealso::
+
+    For more details, please refer to
+    the `Configuration <https://pavics-weaver.readthedocs.io/en/latest/configuration.html>`_
+    section of the documentation.
 
 .. _weaver.ini.example: ./config/weaver.ini.example
 

--- a/README.rst
+++ b/README.rst
@@ -351,7 +351,8 @@ Installation of `Weaver` from source can be performed instead of using the Docke
 
     pip install https://github.com/crim.ca/weaver
 
-.. seealso::
+.. using 'note' instead of 'seealso' because non-sphinx RST required by setup distribution
+.. note::
 
     For more details, please refer to
     the `Installation <https://pavics-weaver.readthedocs.io/en/latest/installation.html>`_
@@ -367,7 +368,8 @@ instantiation of the application. An example of such file is provided here: `wea
 Setting the operational mode of `Weaver` (`EMS`/`ADES`/`HYBRID`) is accomplished using the
 ``weaver.configuration`` field of ``weaver.ini``.
 
-.. seealso::
+.. using 'note' instead of 'seealso' because non-sphinx RST required by setup distribution
+.. note::
 
     For more details, please refer to
     the `Configuration <https://pavics-weaver.readthedocs.io/en/latest/configuration.html>`_

--- a/docker/docker-compose.yml.example
+++ b/docker/docker-compose.yml.example
@@ -30,6 +30,7 @@ services:
       - ./config/wps_processes.yml.example:/opt/local/src/weaver/config/wps_processes.yml
       # WARNING: see detail in 'worker' definition
       - /tmp/weaver/wps-outputs:/tmp/weaver/wps-outputs
+      - /tmp/vault:/tmp/vault
     networks:
       # network 'default' is created by default by docker-compose
       # adjust to whichever service that offers HTTP access if using more advanced networking definitions
@@ -74,6 +75,11 @@ services:
       #   and will expect to find the same directory locations.
       - /tmp/weaver/wps-outputs:/tmp/weaver/wps-outputs
       - /tmp/weaver/wps-workdir:/tmp/weaver/wps-workdir
+      # NOTE:
+      #   The vault is only relevant if 'weaver.vault' is enabled. It should be equal to the 'weaver.vault_dir'.
+      #   The vault path should align with the one used in the Weaver API to ensure correct path resolution between
+      #   the location the uploaded files were saved to, and where the worker should retrieve them from.
+      - /tmp/vault:/tmp/vault
     restart: always
     logging: *default-logging
 
@@ -124,6 +130,22 @@ services:
       - /data/mongodb_persist:/data/db
     networks:
       - mongodb
+    restart: always
+    logging: *default-logging
+
+  file-proxy:
+    # Serves to provide access to the output files from process executions
+    # Jobs will store files in the configured directory location, but will reference them by HTTP URL in metadata
+    # NOTE: This is provided as example, but you could use other file serving like nginx
+    image: httpd:latest
+    container_name: file-proxy
+    ports:
+      - "8000:80"
+    networks:
+      - default
+    volumes:
+      # NOTE: The path should align with 'weaver.wps_output_dir' and will be referenced by 'weaver.wps_output_url'.
+      - /tmp/weaver/wps-outputs:/usr/local/apache2/htdocs:ro
     restart: always
     logging: *default-logging
 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -8,11 +8,16 @@
 Configuration
 ******************
 
+After you have :ref:`Installed Weaver <installation>`,
+you can customize its behaviour using multiple configuration settings below.
+
 .. contents::
     :local:
     :depth: 2
 
-After you have installed `Weaver`, you can customize its behaviour using multiple configuration settings.
+.. seelalso::
+    - `Example Configuration Files <https://github.com/crim-ca/weaver/tree/master/config>`_
+    - `Example Docker-Compose YAML <https://github.com/crim-ca/weaver/blob/master/docker/docker-compose.yml.example>`_
 
 .. _conf_settings:
 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -15,7 +15,7 @@ you can customize its behaviour using multiple configuration settings below.
     :local:
     :depth: 2
 
-.. seelalso::
+.. seealso::
     - `Example Configuration Files <https://github.com/crim-ca/weaver/tree/master/config>`_
     - `Example Docker-Compose YAML <https://github.com/crim-ca/weaver/blob/master/docker/docker-compose.yml.example>`_
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -9,21 +9,70 @@ Installation
     :local:
     :depth: 2
 
+.. _installation-docker:
+
+Docker Installation
+===================
+
+The Docker installation is recommended to ensure reproducibility of the environment and `Weaver` dependencies.
+It is the quickest way to get started with the application.
+
+You can obtain the latest images (or a specific version of you choosing) as follows.
+The base image contains the source code and all dependencies, while the ``manager`` and ``worker``
+images define the commands used to run the :term:`API` and the `Celery`_ workers respectively.
+
+.. code-block:: sh
+
+    docker pull pavics/weaver:latest
+    docker pull pavics/weaver:latest-manager
+    docker pull pavics/weaver:latest-worker
+
+To run :ref:`CLI <cli>` commands, you can run the following.
+
+.. code-block:: sh
+
+    docker run -it --rm pavics/weaver:latest weaver --help
+
+To run the :term:`API` and worker services, it is recommended to use the *Docker Compose*
+configuration because the service must employ a companion `MongoDB`_ container and a ``docker-proxy``
+service to run :ref:`app_pkg_docker` per respective :term:`Process`.
+
+.. seealso::
+    - See :ref:`configuration` to modify application behaviour. A custom INI file should be mounted in the container.
+    - `Example Configuration Files <https://github.com/crim-ca/weaver/tree/master/config>`_
+    - `Example Docker-Compose YAML <https://github.com/crim-ca/weaver/blob/master/docker/docker-compose.yml.example>`_
+
+.. _installation-python:
+
+Python Installation
+===================
+
+Prerequisites
+-------------------
+
 The installation is using the Python distribution system `Miniconda`_ (default installation of no ``conda`` found)
-to maintain software dependencies. Any ``conda`` installation should work the same. To use a pre-installed ``conda``
-distribution, simply make sure that it can be found on the shell path.
+to maintain software dependencies. Any ``conda``-based installation should work the same.
+To use a pre-installed ``conda`` distribution, simply make sure that it can be found on the shell path.
+If not auto-detected, you can hint ``make`` commands about its location using the ``CONDA_HOME`` variable.
 
-Requirements
-============
+You can also employ your own environment management system, by pre-activating it and running ``make`` commands
+with the ``CONDA_CMD=""`` variable.
 
-The installation works on Linux 64 bit distributions (tested on Ubuntu 16.04).
+To avoid repeating variables on each command, you can define them in ``Makefile.config`` at the root of the repository.
+
+.. seealso::
+    Example `Makefile.config.example`_
+
+The installation works on Linux 64 bit distributions (tested on all Ubuntu LTS versions since 16.04).
 
 .. warning::
-    Windows is *not officially supported*, but some patches have been applied to help using it.
+    :ref:`installation-windows` is *not officially supported*, but some patches have been applied to help using it.
     If you find some problems, please |submit-issue|_ or open a pull request with fixes.
 
+.. _installation-github:
+
 From GitHub Sources
-===================
+-------------------
 
 Install Weaver as normal user from GitHub sources:
 
@@ -48,11 +97,29 @@ that environment. You can also enforce a specific environment using:
 
    make CONDA_ENV=<my-env> install
 
+You can then run the :term:`API` and worker services using the corresponding commands with
+your custom `weaver.ini.example`_ configuration file (see :ref:`Configuration` section).
 
-.. _windows_install:
+.. code-block:: sh
+
+    # API service
+    pserve config/weaver.ini
+
+    # Celery worker service
+    celery -A pyramid_celery.celery_app worker -B -E --ini config/weaver.ini
+
+.. warning::
+    `Weaver` typically relies (or expects) some files to be served online for inputs and outputs staging.
+    To run locally, you might want to consider running a file server to make them look like HTTP resources.
+
+    .. code-block:: sh
+
+        python -m http.server 8000 -b 127.0.0.1 --directory <weaver.wps_output_dir>
+
+.. _installation-windows:
 
 Windows Installation
-=====================
+---------------------
 
 *Minimal* support is provided to run the code on Windows. To do so, the ``Makefile`` assumes you are running in a
 ``MINGW`` environment, that ``conda`` is already installed, and that it is available from ``CONDA_HOME`` variable or
@@ -64,8 +131,10 @@ similar. If this is not the case, you will have to adjust the reference variable
     is regularly evaluated on a Linux virtual machine. It is recommended to run it as so or using the existing
     Docker images.
 
-Known issues
-------------
+.. _installation-windows-issues:
+
+Known Issues
+~~~~~~~~~~~~
 
 * Package ``shapely.geos`` has C++ dependency to ``geos`` library. If the package was installed in a ``conda``
   environment, but through ``pip install`` call, the source path will not be found. You have to make sure to install

--- a/docs/source/package.rst
+++ b/docs/source/package.rst
@@ -117,7 +117,7 @@ provided to tell :term:`CWL` how to map :term:`Job` input values to the dynamica
 
 .. _app_pkg_python:
 
-Python Applications
+Python CLI Applications
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 When the :term:`Application Package` to be generated consists of a Python script, which happens to make use of
@@ -247,9 +247,12 @@ When advanced processing capabilities and more complicated environment preparati
 to package and push pre-built :term:`Docker` images to a remote registry. In this situation, just like
 for :ref:`app_pkg_script` examples, the |cwl-docker-req|_ is needed. The definitions would also be essentially the
 same as previous examples, but with more complicated operations and possibly larger amount of inputs or outputs.
-
 Whenever a :term:`Docker` image reference is detected, `Weaver` will ensure that the application will be pulled
 using :term:`CWL` capabilities in order to run it.
+
+.. literalinclude:: ../../weaver/wps_restapi/examples/deploy_process_yaml.cwl
+    :caption: Sample CWL definition of a Dockerized Application
+    :language: yaml
 
 Because :term:`Application Package` providers could desire to make use of :term:`Docker` images hosted on private
 registries, `Weaver` offers the capability to specify an authorization token through HTTP request headers during
@@ -299,8 +302,9 @@ whenever required for launching new :term:`Job` executions.
     any retention time of cached :term:`Docker` images on the server. If the cache is cleaned, and the :term:`Docker`
     image is made unavailable, `Weaver` will attempt to authenticate itself again when receiving the new :term:`Job`.
     It is left up to the developer and :term:`Application Package` provider to manage expired tokens in `Weaver`
-    according to their needs. To resolve such cases, the |update-token-req|_ request or an entire re-deployment
-    of the :term:`Process` could be accomplished, whichever is more convenient for them.
+    according to their needs. To resolve such cases, the :ref:`Replace Process <proc_op_replace>` request or an
+    entire re-deployment of the :term:`Process` (:ref:`Undeploy <proc_op_undeploy>` and :ref:`Deploy <proc_op_deploy>`)
+    including the new ``X-Auth-Docker`` header can be employed to update the token used for authentication.
 
 .. versionadded:: 4.5
     Specification and handling of the ``X-Auth-Docker`` header for providing an authentication token.

--- a/docs/source/processes.rst
+++ b/docs/source/processes.rst
@@ -497,6 +497,7 @@ the |getcap-req|_ request.
 
 
 .. _proc_op_undeploy:
+.. _proc_op_replace:
 .. _proc_op_update:
 
 Modify an Existing Process (Update, Replace, Undeploy)
@@ -539,23 +540,24 @@ to the following table. When a combination of the below items occur, the higher 
     :name: table-process-version
     :align: center
 
-    +-------------+-----------+---------------------------------+------------------------------------------------------+
-    | HTTP Method | Level     | Change                          | Examples                                             |
-    +=============+===========+=================================+======================================================+
-    | ``PATCH``   | ``PATCH`` | Modifications to metadata       | - :term:`Process` ``description``, ``title`` strings |
-    |             |           | not impacting the               | - :term:`Process` ``keywords``, ``metadata`` lists   |
-    |             |           | :term:`Process` execution       | - inputs/outputs ``description``, ``title`` strings  |
-    |             |           | or definition.                  | - inputs/outputs ``keywords``, ``metadata`` lists    |
-    +-------------+-----------+---------------------------------+------------------------------------------------------+
-    | ``PATCH``   | ``MINOR`` | Modification that impacts *how* | - :term:`Process` ``jobControlOptions`` (async/sync) |
-    |             |           | the :term:`Process` could be    | - :term:`Process` ``outputTransmission`` (ref/value) |
-    |             |           | executed, but not its           | - :term:`Process` ``visibility``                     |
-    |             |           | definition.                     |                                                      |
-    +-------------+-----------+---------------------------------+------------------------------------------------------+
-    | ``PUT``     | ``MAJOR`` | Modification that impacts       | - Any :term:`Application Package` modification       |
-    |             |           | *what* the :term:`Process`      | - Any inputs/outputs change (formats, occurs, type)  |
-    |             |           | executes.                       | - Any inputs/outputs addition or removal             |
-    +-------------+-----------+---------------------------------+------------------------------------------------------+
+    +-------------+-----------+----------------------------+-----------------------------------------------------------+
+    | HTTP Method | Level     | Change                     | Examples                                                  |
+    +=============+===========+============================+===========================================================+
+    | ``PATCH``   | ``PATCH`` | Modifications to metadata  | - :term:`Process` ``description``, ``title`` strings      |
+    |             |           | not impacting the          | - :term:`Process` ``keywords``, ``metadata`` lists        |
+    |             |           | :term:`Process` execution  | - inputs/outputs ``description``, ``title`` strings       |
+    |             |           | or definition.             | - inputs/outputs ``keywords``, ``metadata`` lists         |
+    +-------------+-----------+----------------------------+-----------------------------------------------------------+
+    | ``PATCH``   | ``MINOR`` | Modification that impacts  | - :term:`Process` ``jobControlOptions`` (async/sync)      |
+    |             |           | *how* the :term:`Process`  | - :term:`Process` ``outputTransmission`` (ref/value)      |
+    |             |           | could be executed, but not | - :term:`Process` ``visibility``                          |
+    |             |           | its definition.            |                                                           |
+    +-------------+-----------+----------------------------+-----------------------------------------------------------+
+    | ``PUT``     | ``MAJOR`` | Modification that impacts  | - Any :term:`Application Package` modification            |
+    |             |           | *what* the :term:`Process` | - Any inputs/outputs change (formats, occurs, type)       |
+    |             |           | executes.                  | - Any inputs/outputs addition or removal                  |
+    |             |           |                            | - Replacing a :ref:`Docker Auth-Token <app_pkg_docker>`   |
+    +-------------+-----------+----------------------------+-----------------------------------------------------------+
 
 .. note::
     For all applicable fields of updating a :term:`Process`, refer to the schema of |update-req|_.

--- a/docs/source/processes.rst
+++ b/docs/source/processes.rst
@@ -2602,7 +2602,7 @@ to execute. Content negotiation also happens within the submitted :ref:`proc_exe
 Following is a summary of relevant parameters impacting content negotiation.
 
 .. list-table:: Impact of *Requested Parameters* on *Response Content Negotiation*
-    :name: table-content-negotiation
+    :name: table-content-negotiation-parameters
     :align: center
     :header-rows: 1
     :widths: 10,10,50,15,15
@@ -2610,7 +2610,7 @@ Following is a summary of relevant parameters impacting content negotiation.
     * - Parameter
       - Location
       - Description
-      - Allowed Encoding [#noteParamEncoding]_
+      - Allowed Encoding [#noteEncoding]_
       - Example
     * - ``f`` / ``format``
       - Query
@@ -2695,7 +2695,7 @@ and their corresponding fully-defined :term:`URI` or :term:`Media-Type` represen
     However, the corresponding :term:`URI` or :term:`Media-Type` representations must match *exactly*.
 
 .. list-table:: Common Shorthand Notations Identifiers for Content Negotiation
-    :name: table-content-negotiation
+    :name: table-content-negotiation-shorthand
     :align: center
     :header-rows: 1
     :widths: 10,30,60

--- a/docs/source/references.rst
+++ b/docs/source/references.rst
@@ -253,6 +253,7 @@
 .. |weaver-config| replace:: ``weaver/config``
 .. _weaver-config: ../../../config
 .. _weaver.ini.example: ../../../config/weaver.ini.example
+.. _Makefile.config.example: ../../../Makefile.config.example
 .. _data_sources.yml.example: ../../../config/data_sources.yml.example
 .. _wps_processes.yml.example: ../../../config/wps_processes.yml.example
 .. _request_options.yml.example: ../../../config/request_options.yml.example
@@ -314,8 +315,6 @@
 .. _outputs-req: https://pavics-weaver.readthedocs.io/en/latest/api.html#tag/outputs/paths/~1jobs~1{job_id}~1outputs/get
 .. |results-req| replace:: ``GET {WEAVER_URL}/jobs/{jobID}/results`` (Results)
 .. _results-req: https://pavics-weaver.readthedocs.io/en/latest/api.html#tag/Results/paths/~1jobs~1{job_id}~1results/get
-.. |update-token-req| replace:: Update Token
-.. _update-token-req: https://pavics-weaver.readthedocs.io/en/latest/api.html#tag/UpdateToken/paths/~1processes~1{process_id}/put
 .. |vault-upload-req| replace:: Vault File Upload (POST)
 .. _vault-upload-req: https://pavics-weaver.readthedocs.io/en/latest/api.html#tag/Vault/paths/~1vault/post
 .. |vault-download-req| replace:: Vault File Download (GET)

--- a/weaver/processes/execution.py
+++ b/weaver/processes/execution.py
@@ -989,7 +989,7 @@ def submit_job_dispatch_task(
     .. note::
         Both the :paramref:`container` and :paramref:`request` parameters are provided, although they could contain the
         same nested setting references in certain cases, because other implementations (e.g.: dispatch via :term:`WPS`)
-        might recreate their own :term:`HTTP` request object that doesn't include the application settings.
+        might recreate their own HTTP request object that doesn't include the application settings.
     """
     db = get_db(container)
     store = db.get_store(StoreJobs)

--- a/weaver/wps_restapi/examples/deploy_process_yaml.cwl
+++ b/weaver/wps_restapi/examples/deploy_process_yaml.cwl
@@ -1,0 +1,17 @@
+cwlVersion: "v1.2"
+class: CommandLineTool
+baseCommand: echo
+requirements:
+  DockerRequirement:
+    dockerPull: "debian:stretch-slim"
+inputs:
+  message:
+    type: string
+    inputBinding:
+      position: 1
+outputs:
+  output:
+    type: File
+    outputBinding:
+      glob: "stdout.log"
+stdout: stdout.log

--- a/weaver/wps_restapi/processes/processes.py
+++ b/weaver/wps_restapi/processes/processes.py
@@ -185,6 +185,14 @@ def get_processes(request):
 
 @sd.processes_service.post(
     tags=[sd.TAG_PROCESSES, sd.TAG_DEPLOY],
+    schema=sd.PostProcessesEndpointCWLYAML(),
+    accept=ContentType.APP_JSON,
+    content_type=[ContentType.APP_CWL_YAML, ContentType.APP_CWL, ContentType.APP_CWL_X],
+    renderer=OutputFormat.JSON,
+    response_schemas=sd.post_processes_responses,
+)
+@sd.processes_service.post(
+    tags=[sd.TAG_PROCESSES, sd.TAG_DEPLOY],
     schema=sd.PostProcessesEndpoint(),
     accept=ContentType.APP_JSON,
     renderer=OutputFormat.JSON,

--- a/weaver/wps_restapi/swagger_definitions.py
+++ b/weaver/wps_restapi/swagger_definitions.py
@@ -6845,7 +6845,7 @@ class PostProcessesEndpoint(ExtendedMappingSchema):
     querystring = FormatQuery()
     body = Deploy(title="Deploy", examples={
         "DeployCWL": {
-            "summary": "Deploy a process from a CWL definition.",
+            "summary": "Deploy a process from a CWL+JSON definition.",
             "value": EXAMPLES["deploy_process_cwl.json"],
         },
         "DeployOGC": {
@@ -6856,6 +6856,15 @@ class PostProcessesEndpoint(ExtendedMappingSchema):
             "summary": "Deploy a process from a remote WPS-1 reference URL.",
             "value": EXAMPLES["deploy_process_wps1.json"],
         }
+    })
+
+
+class PostProcessesEndpointCWLYAML(PostProcessesEndpoint):
+    body = PermissiveMappingSchema(title="DeployCWLYAML", examples={
+        "DeployCWLYAML": {
+            "summary": "Deploy a process from a CWL+YAML definition.",
+            "value": EXAMPLES["deploy_process_yaml.cwl"],
+        },
     })
 
 


### PR DESCRIPTION
Changes:
--------
- Add documentation to provide better guidance about installation, configuration and example references.

Fixes:
------
- Fix missing documentation of the `Vault` volume mount configuration in the *Docker Compose* example.
- Fix missing documentation of the `CWL+YAML` deployment `Media-Type` support in the `OpenAPI` schema.