### PR TITLE
Fix get authorized file for multi token

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,7 +16,12 @@ Changes:
 
 Fixes:
 ------
-- No change.
+- Fix multi-token Vault authentication header parsing to support both single and multiple file access tokens.
+  The ``parse_vault_token`` function now handles plain token strings (e.g., from WPS process context) and full
+  header formats (e.g., ``token <value>; id=<uuid>``), and correctly validates token presence for the requested
+  file UUID. The mismatch detection logic was updated to properly check if the requested file ID exists in the
+  parsed tokens rather than only validating against the first token key
+  (fixes `#897 <https://github.com/crim-ca/weaver/issues/897>`_).
 
 .. _changes_6.9.0:
 

--- a/tests/test_vault.py
+++ b/tests/test_vault.py
@@ -71,6 +71,63 @@ def test_parse_vault_token(header, unique, expected):
 
 
 @pytest.mark.vault
+@pytest.mark.parametrize("unique,lookup_id,use_unknown,expected_token", [
+    # With unique=True, multiple tokens are rejected, returns empty dict
+    (True, "file_id_1", False, None),
+    (True, "file_id_2", False, None),
+    # With unique=False, multiple tokens are parsed correctly
+    (False, "file_id_1", False, "token1"),
+    (False, "file_id_2", False, "token2"),
+    # Fallback pattern: vault_token.get(None, vault_token.get(file_id))
+    (False, None, False, None),  # No None key exists in multi-token scenario
+    # When requesting a file_id not in the dict
+    (False, "file_id_1", True, None),  # unknown_id returns None
+])
+def test_parse_vault_token_multiple_tokens_behavior(unique, lookup_id, use_unknown, expected_token):
+    """
+    Test that demonstrates the behavior when retrieving tokens with multiple token entries.
+
+    When an auth header contains multiple tokens (comma-separated):
+    - With unique=True: Returns empty dict {} because multiple tokens are not allowed
+    - With unique=False: Returns dict mapping UUID -> token for each entry
+
+    To retrieve a token for a specific file_id:
+    - Use vault_token.get(file_id) to get the token for that UUID
+    - Use vault_token.get(None) as fallback when no UUID is specified in the token
+    - Pattern: vault_token.get(None, vault_token.get(file_id)) tries both
+    """
+    token1 = VaultFile("").token
+    token2 = VaultFile("").token
+    file_id_1 = str(uuid.uuid4())
+    file_id_2 = str(uuid.uuid4())
+    unknown_id = str(uuid.uuid4())
+
+    # Multi-token auth header (e.g., for batch operations)
+    auth_header = f"token {token1}; id={file_id_1}, token {token2}; id={file_id_2}"
+
+    vault_token = parse_vault_token(auth_header, unique=unique)
+
+    # Map lookup_id string to actual UUID
+    id_map = {
+        "file_id_1": file_id_1,
+        "file_id_2": file_id_2,
+        None: None
+    }
+    token_map = {
+        "token1": token1,
+        "token2": token2,
+        None: None
+    }
+
+    actual_id = unknown_id if use_unknown else id_map[lookup_id]
+    expected = token_map[expected_token]
+
+    # Test retrieval with fallback pattern
+    result = vault_token.get(None, vault_token.get(actual_id))
+    assert result == expected
+
+
+@pytest.mark.vault
 def test_encrypt_decrypt():
     vault_file = VaultFile("")
     assert isinstance(vault_file.secret, bytes) and len(vault_file.secret)

--- a/weaver/vault/utils.py
+++ b/weaver/vault/utils.py
@@ -208,13 +208,21 @@ def get_authorized_file(file_id, auth_token, container=None):
     Obtain the requested file if access is granted.
 
     :param file_id: Vault storage reference file UUID.
-    :param auth_token: Token to obtain access to the file.
+    :param auth_token: Token or multi-token to obtain access to the file.
     :param container: Application settings.
     :return: Authorized file.
     :raises: Appropriate HTTP exception according to use case.
     """
-    vault_token = parse_vault_token(auth_token, unique=True)
-    token = vault_token.get(None, vault_token.get(file_id))
+    # Check if auth_token is already just a plain token string (no "token " prefix)
+    # This happens when the worker tries to access the vault file with the token directly,
+    # without the full header format (e.g., from WPS process)
+    vault_token = {}
+    if auth_token and REGEX_VAULT_TOKEN.match(auth_token):
+        token = auth_token
+    else:
+        vault_token = parse_vault_token(auth_token, unique=False)
+        token = vault_token.get(file_id, vault_token.get(None))
+
     if not token:
         # note:
         #   401 not applicable since no no Authentication endpoint for the Vault
@@ -222,7 +230,7 @@ def get_authorized_file(file_id, auth_token, container=None):
         msg = "Missing authorization token to obtain access to vault file."
         if auth_token:  # if header provided but parsed as invalid
             msg = "Incorrectly formed authorization token to obtain access to vault file."
-        if vault_token and list(vault_token)[0] not in [None, file_id]:
+        if vault_token and file_id not in vault_token and None not in vault_token:
             msg = "Mismatching Vault UUID specified in authorization header."
         raise HTTPForbidden(json={
             "code": "InvalidHeaderValue",

--- a/weaver/vault/utils.py
+++ b/weaver/vault/utils.py
@@ -132,6 +132,10 @@ def parse_vault_token(header, unique=False):
     """
     if not isinstance(header, str):
         return {}
+    # Check if header is already just a plain token string (no "token " prefix)
+    # This happens when the token is passed directly (e.g., from WPS process)
+    if REGEX_VAULT_TOKEN.match(header):
+        return {None: header}
     header = header.lower()
     if unique and "," in header:
         return {}
@@ -213,15 +217,8 @@ def get_authorized_file(file_id, auth_token, container=None):
     :return: Authorized file.
     :raises: Appropriate HTTP exception according to use case.
     """
-    # Check if auth_token is already just a plain token string (no "token " prefix)
-    # This happens when the worker tries to access the vault file with the token directly,
-    # without the full header format (e.g., from WPS process)
-    vault_token = {}
-    if auth_token and REGEX_VAULT_TOKEN.match(auth_token):
-        token = auth_token
-    else:
-        vault_token = parse_vault_token(auth_token, unique=False)
-        token = vault_token.get(file_id, vault_token.get(None))
+    vault_token = parse_vault_token(auth_token, unique=False)
+    token = vault_token.get(file_id, vault_token.get(None))
 
     if not token:
         # note:


### PR DESCRIPTION
Resolves : https://github.com/crim-ca/weaver/issues/894

- Fix multi-token Vault authentication header parsing to support both single and multiple file access tokens.
  The ``parse_vault_token`` function now handles plain token strings (e.g., from WPS process context) and full
  header formats (e.g., ``token <value>; id=<uuid>``), and correctly validates token presence for the requested
  file UUID. The mismatch detection logic was updated to properly check if the requested file ID exists in the
  parsed tokens rather than only validating against the first token key

