### PR TITLE
improve CLI handling of input local files

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,7 +12,13 @@ Changes
 
 Changes:
 --------
-- No change.
+- Add ``--inputs-ignore-errors`` option to `CLI` ``execute`` operation and corresponding ``inputs_ignore_errors``
+  parameter to ``WeaverClient.execute()`` method. When enabled, missing or unresolved local file references in
+  input definitions will be skipped with warnings rather than causing immediate failure. By default (when disabled),
+  missing files cause the operation to fail with a detailed error message listing all problematic file references.
+- Improve `CLI` ``execute`` operation error handling for multiple input files. When multiple input JSON/YAML files
+  are provided via multiple ``-I`` options, the operation now fails with a clear error message explaining that only
+  a single input file is supported, rather than producing a cryptic attribute error.
 
 Fixes:
 ------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -336,6 +336,361 @@ def test_parse_inputs_from_file_relative_paths():
 
 
 @pytest.mark.cli
+@pytest.mark.parametrize(
+    ["file_refs", "input_structure"],
+    [
+        # Single file references with simple paths
+        (
+            [
+                "./file1.txt",
+                "./file2.txt",
+                "./nested/file3.txt",
+            ],
+            "single"
+        ),
+        # Array file references with simple paths
+        (
+            [
+                "./file1.txt",
+                "./file2.txt",
+                "./nested/file3.txt",
+            ],
+            "array"
+        ),
+        # Single file references with complex nested navigation
+        (
+            [
+                "./file1.txt",
+                "./nested/deep/level/../../file3.txt",
+                "./nested/deep/level/file2.txt",
+            ],
+            "single"
+        ),
+        # Array file references with complex nested navigation
+        (
+            [
+                "./file1.txt",
+                "./nested/deep/level/../../file3.txt",
+                "./nested/deep/level/file2.txt",
+            ],
+            "array"
+        ),
+        # Single file references starting with "../../" (files outside input file directory)
+        (
+            [
+                "../../outside/file1.txt",
+                "./local.txt",
+                "../../outside/nested/file2.txt",
+            ],
+            "single"
+        ),
+        # Array file references starting with "../../" (files outside input file directory)
+        (
+            [
+                "../../outside/file1.txt",
+                "./local.txt",
+                "../../outside/nested/file2.txt",
+            ],
+            "array"
+        ),
+        # Mixed: simple, nested navigation, and parent directory references
+        (
+            [
+                "./simple.txt",
+                "../sibling/file.txt",
+                "./nested/../other.txt",
+            ],
+            "single"
+        ),
+        # file:// URI references (absolute paths)
+        (
+            [
+                "file://",  # placeholders, will be replaced with absolute paths
+                "file://",
+                "file://",
+            ],
+            "single"
+        ),
+    ]
+)
+def test_parse_inputs_relative_paths_extended_resolutions(file_refs, input_structure):
+    """
+    Validate extended scenarios for relative file resolutions from execution input file.
+
+    This test extends :func:`test_parse_inputs_from_file_relative_paths` to cover various combinations:
+    - Simple relative paths (e.g., "./file.txt", "./nested/file.txt")
+    - Complex nested navigation (e.g., "./nested/deep/level/../../file.txt")
+    - Parent directory references starting with "../../" to test files outside input file directory
+    - Single file references vs array of file references (i.e.: mapping to ``File`` vs ``File[]`` CWL types)
+    - Explicit URI references ``file://`` with absolute paths
+
+    The test validates that the CLI properly resolves relative paths regardless of these combinations,
+    ensuring that file references embedded within the provided "inputs file" are primarily resolved relative
+    those file's location, rather than the current working directory of the :term:`CLI` command.
+    """
+    local_inputs = []
+
+    def mock_describe(*_, **__):
+        return OperationResult(False, code=500)
+
+    def mock_upload(href, *_, **__):
+        local_inputs.append(href)
+        f_id = str(uuid.uuid4())
+        body = {"file_href": f"vault://{f_id}", "file_id": f_id, "access_token": f_id}
+        return OperationResult(True, code=200, body=body)
+
+    cwd = os.getcwd()
+    try:
+        with ExitStack() as stack:
+            stack.enter_context(mock.patch("weaver.cli.WeaverClient.describe", side_effect=mock_describe))
+            stack.enter_context(mock.patch("weaver.cli.WeaverClient.upload", side_effect=mock_upload))
+            tmp_base = stack.enter_context(tempfile.TemporaryDirectory())
+            tmp_pwd = stack.enter_context(tempfile.TemporaryDirectory())
+            os.chdir(tmp_pwd)
+
+            # Create inputs file in a nested directory to allow "../../" references
+            inputs_dir = os.path.join(tmp_base, "inputs", "nested")
+            os.makedirs(inputs_dir, exist_ok=True)
+
+            # Create files based on the relative paths specified in file_refs
+            created_files = []
+            resolved_paths = []
+            use_file_uri = all(ref.startswith("file://") for ref in file_refs)
+
+            for idx, rel_path in enumerate(file_refs):
+                if use_file_uri:
+                    # Special case: create simple files and use absolute paths
+                    file_name = f"file{idx + 1}.txt"
+                    file_path = os.path.join(tmp_base, file_name)
+                else:
+                    # Resolve the relative path from the inputs directory
+                    # Use os.path.normpath to resolve all "." and ".." components
+                    file_path = os.path.normpath(os.path.join(inputs_dir, rel_path))
+
+                    # Also ensure all intermediate directories in the non-normalized path exist
+                    # This is needed because os.path.isfile() checks intermediate dirs even when normalizing
+                    non_normalized_path = os.path.join(inputs_dir, rel_path)
+                    intermediate_dir = os.path.dirname(non_normalized_path)
+                    if intermediate_dir:
+                        os.makedirs(intermediate_dir, exist_ok=True)
+
+                # Ensure parent directory of the final normalized file path exists
+                os.makedirs(os.path.dirname(file_path), exist_ok=True)
+                with open(file_path, mode="w", encoding="utf-8") as f:
+                    f.write("test")
+
+                created_files.append(file_path)
+                resolved_paths.append(os.path.abspath(file_path))
+
+            # Build CWL inputs structure
+            if use_file_uri:
+                # Use absolute file:// URIs
+                paths_to_use = [f"file://{abs_path}" for abs_path in resolved_paths]
+            else:
+                # Use the relative paths as specified
+                paths_to_use = file_refs
+
+            if input_structure == "array":
+                cwl_inputs = {
+                    "input1": "data",
+                    "input2": [{"class": "File", "path": path} for path in paths_to_use]
+                }
+            else:
+                cwl_inputs = {"input1": "data"}
+                for idx, path in enumerate(paths_to_use, start=2):
+                    cwl_inputs[f"input{idx}"] = {"class": "File", "path": path}
+
+            inputs_path = os.path.join(inputs_dir, "inputs.json")
+            with open(inputs_path, mode="w", encoding="utf-8") as f:
+                json.dump(cwl_inputs, f)
+
+            result = WeaverClient().execute(
+                "fake_process",
+                inputs=inputs_path,
+                url="https://fake.domain.com"
+            )
+    finally:
+        os.chdir(cwd)
+
+    # Verify all files were resolved correctly
+    assert result.code == 500, f"expected early-stop of execution operation, got {result.code}: {result.message}"
+    assert len(local_inputs) == len(file_refs), (
+        f"expected {len(file_refs)} local file uploads, got {len(local_inputs)}"
+    )
+    expected_files = set(resolved_paths)
+    assert set(local_inputs) == expected_files, (
+        f"expected files {expected_files}, got {set(local_inputs)}"
+    )
+
+
+@pytest.mark.cli
+def test_parse_inputs_multiple_files_rejected():
+    """
+    Validate that multiple input files (e.g., multiple ``-I inputs.json``) are properly rejected.
+
+    When multiple input JSON/YAML files are provided via multiple ``-I`` options, the CLI should detect
+    this case and provide a clear error message, rather than treating the file paths as literal input
+    values or causing a confusing error later in the process.
+    """
+    cwd = os.getcwd()
+    try:
+        with ExitStack() as stack:
+            tmp_dir = stack.enter_context(tempfile.TemporaryDirectory())
+            os.chdir(tmp_dir)
+
+            # Create two separate input files
+            inputs1 = {
+                "input1": {"class": "File", "path": "./file1.txt"},
+            }
+            inputs2 = {
+                "input2": {"class": "File", "path": "./file2.txt"},
+            }
+
+            inputs_path1 = os.path.join(tmp_dir, "inputs1.json")
+            inputs_path2 = os.path.join(tmp_dir, "inputs2.json")
+
+            with open(inputs_path1, mode="w", encoding="utf-8") as f:
+                json.dump(inputs1, f)
+            with open(inputs_path2, mode="w", encoding="utf-8") as f:
+                json.dump(inputs2, f)
+
+            # Simulate multiple -I options as they would be processed by argparse
+            # Each -I creates a sublist, resulting in a 2D list that gets flattened
+            multiple_inputs = [[inputs_path1], [inputs_path2]]
+
+            result = WeaverClient().execute(
+                "fake_process",
+                inputs=multiple_inputs,
+                url="https://fake.domain.com"
+            )
+    finally:
+        os.chdir(cwd)
+
+    # Verify that the operation fails with a clear error message
+    assert not result.success, "expected operation to fail when multiple input files are provided"
+    assert result.message is not None, "expected error message to be provided"
+    assert "multiple" in result.message.lower() or "more than one" in result.message.lower(), (
+        f"expected error message to mention 'multiple' or 'more than one' files, got: {result.message}"
+    )
+
+
+@pytest.mark.cli
+@pytest.mark.parametrize(
+    ["missing_files", "ignore_errors", "expect_success"],
+    [
+        # No missing files - should always succeed
+        ([], False, True),
+        ([], True, True),
+        # One missing file without ignore flag - should fail
+        (["./missing.txt"], False, False),
+        # One missing file with ignore flag - should succeed (file skipped with warning)
+        (["./missing.txt"], True, True),
+        # Multiple missing files without ignore flag - should fail with all files listed
+        (["./missing1.txt", "./missing2.txt", "./nested/missing3.txt"], False, False),
+        # Multiple missing files with ignore flag - should succeed (all skipped with warnings)
+        (["./missing1.txt", "./missing2.txt", "./nested/missing3.txt"], True, True),
+        # Mix of existing and missing files without ignore flag - should fail
+        (["./exists.txt", "./missing.txt"], False, False),
+        # Mix of existing and missing files with ignore flag - should succeed (missing skipped)
+        (["./exists.txt", "./missing.txt"], True, True),
+    ]
+)
+def test_parse_inputs_missing_files_handling(missing_files, ignore_errors, expect_success):
+    """
+    Validate that missing local file references are handled correctly based on ``--inputs-ignore-errors`` flag.
+
+    When ``inputs_ignore_errors=False`` (default):
+    - Missing files should cause a failure with a clear error message without moving on to the execution
+    - All missing files should be listed in the error message (not just the first one that fails resolution)
+
+    When ``inputs_ignore_errors=True``:
+    - Missing files should be skipped with a warning
+    - Execution should proceed with the remaining valid inputs
+    """
+    local_inputs = []
+
+    def mock_describe(*_, **__):
+        return OperationResult(False, code=500)
+
+    def mock_upload(href, *_, **__):
+        local_inputs.append(href)
+        f_id = str(uuid.uuid4())
+        body = {"file_href": f"vault://{f_id}", "file_id": f_id, "access_token": f_id}
+        return OperationResult(True, code=200, body=body)
+
+    cwd = os.getcwd()
+    try:
+        with ExitStack() as stack:
+            stack.enter_context(mock.patch("weaver.cli.WeaverClient.describe", side_effect=mock_describe))
+            stack.enter_context(mock.patch("weaver.cli.WeaverClient.upload", side_effect=mock_upload))
+            tmp_dir = stack.enter_context(tempfile.TemporaryDirectory())
+            os.chdir(tmp_dir)
+
+            # Create the inputs file
+            cwl_inputs = {"input1": "data"}
+            existing_files = []
+
+            # Add file references - some will exist, some won't based on the test case
+            input_idx = 2
+            for file_path in missing_files:
+                # Determine if this should be an existing file (for mixed scenarios)
+                is_existing = file_path == "./exists.txt"
+
+                if is_existing:
+                    # Create the file
+                    full_path = os.path.join(tmp_dir, file_path.lstrip("./"))
+                    os.makedirs(os.path.dirname(full_path), exist_ok=True)
+                    with open(full_path, mode="w", encoding="utf-8") as f:
+                        f.write("test")
+                    existing_files.append(os.path.abspath(full_path))
+
+                # Add to inputs (whether file exists or not)
+                cwl_inputs[f"input{input_idx}"] = {"class": "File", "path": file_path}
+                input_idx += 1
+
+            inputs_path = os.path.join(tmp_dir, "inputs.json")
+            with open(inputs_path, mode="w", encoding="utf-8") as f:
+                json.dump(cwl_inputs, f)
+
+            result = WeaverClient().execute(
+                "fake_process",
+                inputs=inputs_path,
+                url="https://fake.domain.com",
+                inputs_ignore_errors=ignore_errors
+            )
+    finally:
+        os.chdir(cwd)
+
+    # Validate results based on expected outcome
+    if expect_success:
+        # When ignore_errors=True or no missing files, operation should succeed (or fail at describe step)
+        # The describe mock returns 500, so we expect that as the error code
+        assert result.code == 500, f"expected early-stop at describe with code 500, got {result.code}: {result.message}"
+
+        # Verify only existing files were uploaded
+        assert len(local_inputs) == len(existing_files), (
+            f"expected {len(existing_files)} file uploads, got {len(local_inputs)}"
+        )
+    else:
+        # When ignore_errors=False and there are missing files, should fail before describe
+        assert not result.success, "expected operation to fail due to missing files"
+        assert result.code == 404, f"expected 404 Not Found error code, got {result.code}"
+
+        # Verify error message mentions missing files
+        msg_lower = result.message.lower()
+        assert (
+            "missing" in msg_lower or "not found" in msg_lower or "not all files could be resolved" in msg_lower
+        ), f"expected error message to mention missing files, got: {result.message}"
+
+        # Verify ALL missing files are listed in the error message
+        actual_missing = [f for f in missing_files if f != "./exists.txt"]
+        for missing_file in actual_missing:
+            assert missing_file in result.message, (
+                f"expected missing file '{missing_file}' to be mentioned in error message, got: {result.message}"
+            )
+
+
+@pytest.mark.cli
 @pytest.mark.format
 @pytest.mark.parametrize(
     ["data_inputs", "expect_inputs"],

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,7 @@ import argparse
 import base64
 import contextlib
 import inspect
+import itertools
 import json
 import os
 import tempfile
@@ -337,83 +338,50 @@ def test_parse_inputs_from_file_relative_paths():
 
 @pytest.mark.cli
 @pytest.mark.parametrize(
-    ["file_refs", "input_structure"],
-    [
-        # Single file references with simple paths
-        (
+    ["as_cli_list", "input_structure", "file_refs"],
+    itertools.product(
+        # Because the CLI uses 'nargs' to collect potentially multiple '-I' options it can result into a list of path
+        # More than one path is not allowed (see 'test_parse_inputs_multiple_files_rejected'), but the single-item list
+        # must still be handled. These using both invocation cases as the CLI (embedded list) vs WeaverClient (direct).
+        [False, True],
+        # Test both cases where multiple inputs have a single File, or a single input has multiple File[] references
+        ["single", "array"],
+        # Path combinations
+        [
+            # simple relative paths
             [
                 "./file1.txt",
                 "./file2.txt",
                 "./nested/file3.txt",
             ],
-            "single"
-        ),
-        # Array file references with simple paths
-        (
-            [
-                "./file1.txt",
-                "./file2.txt",
-                "./nested/file3.txt",
-            ],
-            "array"
-        ),
-        # Single file references with complex nested navigation
-        (
+            # complex nested navigation
             [
                 "./file1.txt",
                 "./nested/deep/level/../../file3.txt",
                 "./nested/deep/level/file2.txt",
             ],
-            "single"
-        ),
-        # Array file references with complex nested navigation
-        (
-            [
-                "./file1.txt",
-                "./nested/deep/level/../../file3.txt",
-                "./nested/deep/level/file2.txt",
-            ],
-            "array"
-        ),
-        # Single file references starting with "../../" (files outside input file directory)
-        (
+            # file references starting with "../../" (files outside input file directory)
             [
                 "../../outside/file1.txt",
                 "./local.txt",
                 "../../outside/nested/file2.txt",
             ],
-            "single"
-        ),
-        # Array file references starting with "../../" (files outside input file directory)
-        (
-            [
-                "../../outside/file1.txt",
-                "./local.txt",
-                "../../outside/nested/file2.txt",
-            ],
-            "array"
-        ),
-        # Mixed: simple, nested navigation, and parent directory references
-        (
+            # Mixed: simple, nested navigation, and parent directory references
             [
                 "./simple.txt",
                 "../sibling/file.txt",
                 "./nested/../other.txt",
             ],
-            "single"
-        ),
-        # file:// URI references (absolute paths)
-        (
+            # file:// URI references (absolute paths)
             [
                 "file://",  # placeholders, will be replaced with absolute paths
                 "file://",
                 "file://",
             ],
-            "single"
-        ),
-    ]
+        ]
+    )
 )
-def test_parse_inputs_relative_paths_extended_resolutions(file_refs, input_structure):
+def test_parse_inputs_relative_paths_extended_resolutions(as_cli_list, input_structure, file_refs):
     """
     Validate extended scenarios for relative file resolutions from execution input file.
 
@@ -503,6 +471,7 @@ def test_parse_inputs_relative_paths_extended_resolutions(file_refs, input_struc
             inputs_path = os.path.join(inputs_dir, "inputs.json")
             with open(inputs_path, mode="w", encoding="utf-8") as f:
                 json.dump(cwl_inputs, f)
+            inputs_path = [inputs_path] if as_cli_list else inputs_path
 
             result = WeaverClient().execute(
                 "fake_process",

--- a/weaver/cli.py
+++ b/weaver/cli.py
@@ -14,7 +14,7 @@ from urllib.parse import urlparse
 
 import yaml
 from colander import EMAIL_RE, URL_REGEX
-from pyramid.httpexceptions import HTTPNotImplemented
+from pyramid.httpexceptions import HTTPNotFound, HTTPNotImplemented
 from requests.auth import AuthBase, HTTPBasicAuth
 from requests.sessions import Session
 from requests.structures import CaseInsensitiveDict
@@ -1210,6 +1210,15 @@ class WeaverClient(object):
                     inputs = load_file(inputs[0])
                 elif len(inputs) == 1 and inputs[0] == "":
                     inputs = []
+                # multiple file paths provided - purposely not supported to avoid merging ambiguity
+                elif len(inputs) > 1 and all(isinstance(item, str) and "=" not in item for item in inputs):
+                    return OperationResult(
+                        False,
+                        "Multiple input files are not supported to avoid merging ambiguities. "
+                        "Please provide a single JSON/YAML file containing all input definitions, "
+                        "or use literal input definitions with '-I <id>=<value>' format.",
+                        inputs
+                    )
             if isinstance(inputs, list):
                 inputs = {"inputs": inputs}  # convert OLD format provided directly into OGC
 
@@ -1258,10 +1267,11 @@ class WeaverClient(object):
 
     def _upload_files(
         self,
-        inputs,     # type: ExecutionInputsMap
-        url=None,   # type: Optional[URL]
-        cwd=None,   # type: Optional[Path]
-    ):              # type: (...) -> Union[Tuple[ExecutionInputsMap, HeadersType], OperationResult]
+        inputs,                         # type: ExecutionInputsMap
+        inputs_ignore_errors=False,     # type: bool
+        url=None,                       # type: Optional[URL]
+        cwd=None,                       # type: Optional[Path]
+    ):                                  # type: (...) -> Union[Tuple[ExecutionInputsMap, HeadersType], OperationResult]
         """
         Replaces local file paths by references uploaded to the :term:`Vault`.
 
@@ -1275,6 +1285,9 @@ class WeaverClient(object):
               in :ref:`file_vault_token` and :ref:`vault_upload` chapters.
 
         :param inputs: Input values for submission of :term:`Process` execution.
+        :param inputs_ignore_errors:
+            - If ``True``, missing or unresolved local file references will be ignored with a warning.
+            - If ``False`` (default), missing files will cause the operation to fail with a detailed error.
         :param url: Instance URL if not already provided during client creation.
         :param cwd:
             Alternative working directory to resolve relative file paths if applicable.
@@ -1282,6 +1295,7 @@ class WeaverClient(object):
         :return: Updated inputs or the result of a failing intermediate request.
         """
         auth_tokens = {}  # type: Dict[str, str]
+        missing_files = []  # type: List[Tuple[str, Path]]  # (input_id, file_path)
         update_inputs = dict(inputs)
         for input_id, input_data in dict(inputs).items():
             input_array = True
@@ -1311,13 +1325,16 @@ class WeaverClient(object):
                     cwd_href = os.path.join(cwd, href)
                     if os.path.isfile(cwd_href):
                         href = cwd_href
-                if not os.path.isfile(href):  # Case for remote files (ex. http links)
+                if not os.path.isfile(href):
                     if "://" not in href:
-                        LOGGER.warning(
-                            "Ignoring potential local file reference since it does not exist. "
-                            "Cannot upload to vault: [%s]", file
-                        )
-                    continue
+                        # Local file reference that doesn't exist
+                        missing_files.append((input_id, file))
+                        if inputs_ignore_errors:
+                            LOGGER.warning(
+                                "Ignoring missing local file reference for input '%s': [%s]",
+                                input_id, file
+                            )
+                    continue  # Skip upload for missing local files or remote URLs
 
                 href = os.path.abspath(href)  # ensure dot/relative path are resolved
                 fmt = data.get("format", {})
@@ -1346,6 +1363,21 @@ class WeaverClient(object):
                 else:
                     update_inputs[input_id] = input_vault_href
 
+        # Report all missing files if any were found and errors are not ignored
+        if missing_files and not inputs_ignore_errors:
+            files_list = "\n".join([f"  - Input [{inp_id}]: {fpath}" for inp_id, fpath in missing_files])
+            return OperationResult(
+                success=False,
+                message=(
+                    f"Not all files could be resolved. Missing local file references in inputs:\n{files_list}\n"
+                    "Please verify the files exist relative to the inputs file location, "
+                    "relative to the command's invocation directory, "
+                    "or use '--inputs-ignore-errors' to proceed without the missing files."
+                ),
+                title="Files not found.",
+                code=HTTPNotFound.code,
+            )
+
         auth_headers = {}
         if auth_tokens:
             multi_tokens = ",".join([
@@ -1357,12 +1389,18 @@ class WeaverClient(object):
 
     def _prepare_inputs(
         self,
-        inputs=None,    # type: Optional[Union[str, ExecutionInputs, CWL_IO_ValueMap]]
-        url=None,       # type: Optional[URL]
-    ):                  # type: (...) -> Union[Tuple[ExecutionInputsMap, HeadersType], OperationResult]
+        inputs=None,                    # type: Optional[Union[str, ExecutionInputs, CWL_IO_ValueMap]]
+        inputs_ignore_errors=False,     # type: bool
+        url=None,                       # type: Optional[URL]
+    ):                                  # type: (...) -> Union[Tuple[ExecutionInputsMap, HeadersType], OperationResult]
         """
         Performs operations needed to prepare inputs, including parsing provided data/reference and upload as needed.
 
+        :param inputs: Input values for submission of :term:`Process` execution.
+        :param inputs_ignore_errors:
+            - If ``True``, missing or unresolved local file references will be ignored with a warning.
+            - If ``False`` (default), missing files will cause the operation to fail with a detailed error.
+        :param url: Instance URL if not already provided during client creation.
         :returns:
             Operation result is returned in case of any failure.
             Otherwise, returns the parsed inputs and upload access tokens (as applicable).
@@ -1375,7 +1413,7 @@ class WeaverClient(object):
         if isinstance(values, OperationResult):
             return values
         input_file = os.path.dirname(inputs) if isinstance(inputs, str) else None
-        result = self._upload_files(values, url=base, cwd=input_file)
+        result = self._upload_files(values, url=base, cwd=input_file, inputs_ignore_errors=inputs_ignore_errors)
         return result
 
     def _prepare_outputs(
@@ -1409,28 +1447,29 @@ class WeaverClient(object):
 
     def execute(
         self,
-        process_id,             # type: str
-        provider_id=None,       # type: Optional[str]
-        inputs=None,            # type: Optional[Union[str, ExecutionInputs, CWL_IO_ValueMap]]
-        pending=False,          # type: bool
-        monitor=False,          # type: bool
-        timeout=None,           # type: Optional[int]
-        interval=None,          # type: Optional[int]
-        subscribers=None,       # type: Optional[JobSubscribers]
-        url=None,               # type: Optional[URL]
-        auth=None,              # type: Optional[AuthBase]
-        headers=None,           # type: Optional[AnyHeadersContainer]
-        with_links=True,        # type: bool
-        with_headers=False,     # type: bool
-        request_type="core",    # type: Literal["core", "jobs"]
-        request_timeout=None,   # type: Optional[int]
-        request_retries=None,   # type: Optional[int]
-        output_format=None,     # type: Optional[AnyOutputFormat]
-        output_refs=None,       # type: Optional[Iterable[str]]
+        process_id,                     # type: str
+        provider_id=None,               # type: Optional[str]
+        inputs=None,                    # type: Optional[Union[str, ExecutionInputs, CWL_IO_ValueMap]]
+        inputs_ignore_errors=False,     # type: bool
+        pending=False,                  # type: bool
+        monitor=False,                  # type: bool
+        timeout=None,                   # type: Optional[int]
+        interval=None,                  # type: Optional[int]
+        subscribers=None,               # type: Optional[JobSubscribers]
+        url=None,                       # type: Optional[URL]
+        auth=None,                      # type: Optional[AuthBase]
+        headers=None,                   # type: Optional[AnyHeadersContainer]
+        with_links=True,                # type: bool
+        with_headers=False,             # type: bool
+        request_type="core",            # type: Literal["core", "jobs"]
+        request_timeout=None,           # type: Optional[int]
+        request_retries=None,           # type: Optional[int]
+        output_format=None,             # type: Optional[AnyOutputFormat]
+        output_refs=None,               # type: Optional[Iterable[str]]
         # outputs_types=None,   # FIXME: alternate output media-types (https://github.com/crim-ca/weaver/pull/548)
-        output_filter=None,     # type: Optional[Sequence[str]]
-        output_context=None,    # type: Optional[str]
-    ):                          # type: (...) -> OperationResult
+        output_filter=None,             # type: Optional[Sequence[str]]
+        output_context=None,            # type: Optional[str]
+    ):                                  # type: (...) -> OperationResult
         """
         Execute a :term:`Job` for the specified :term:`Process` with provided inputs.
 
@@ -1457,6 +1496,9 @@ class WeaverClient(object):
         :param inputs:
             Literal :term:`JSON` or :term:`YAML` contents of the inputs submitted and inserted into the execution body,
             using either the :term:`OGC API - Processes` or :term:`CWL` format, or a file path/URL referring to them.
+        :param inputs_ignore_errors:
+            - If ``True``, missing or unresolved local file references will be ignored with a warning.
+            - If ``False`` (default), missing files will cause the operation to fail with a detailed error.
         :param pending:
             If enabled, the :term:`Job` will be created, but will not immediately start execution.
             The :term:`Job` will be pending execution until a following :meth:`trigger_job` is sent.
@@ -1506,7 +1548,7 @@ class WeaverClient(object):
         :returns: Results of the operation.
         """
         base = self._get_url(url)  # raise before inputs parsing if not available
-        result = self._prepare_inputs(inputs, url=base)
+        result = self._prepare_inputs(inputs, url=base, inputs_ignore_errors=inputs_ignore_errors)
         if isinstance(result, OperationResult):
             return result
         values, auth_headers = result
@@ -2653,6 +2695,15 @@ def add_job_exec_param(parser):
 
             Example: ``-I message='Hello Weaver' -I value:int=1234 -I file:File=data.xml@mediaType=text/xml``
         """)
+    )
+    parser.add_argument(
+        "--inputs-ignore-errors", dest="inputs_ignore_errors", action="store_true",
+        help=(
+            "When specified, missing or unresolved local file references in inputs will be ignored with a warning, "
+            "allowing execution to proceed (though the server could refuse the request from empty/missing inputs). "
+            "By default, any missing local file will cause the operation to fail "
+            "with a detailed error message listing all problematic files."
+        )
     )
     parser.add_argument(
         "-R", "--ref", "--reference", metavar="REFERENCE", dest="output_refs", action="append",

--- a/weaver/cli.py
+++ b/weaver/cli.py
@@ -1389,7 +1389,7 @@ class WeaverClient(object):
 
     def _prepare_inputs(
         self,
-        inputs=None,                    # type: Optional[Union[str, ExecutionInputs, CWL_IO_ValueMap]]
+        inputs=None,                    # type: Optional[Union[Path, List[Path], ExecutionInputs, CWL_IO_ValueMap]]
         inputs_ignore_errors=False,     # type: bool
         url=None,                       # type: Optional[URL]
     ):                                  # type: (...) -> Union[Tuple[ExecutionInputsMap, HeadersType], OperationResult]
@@ -1412,6 +1412,8 @@ class WeaverClient(object):
         values = self._parse_inputs(inputs)
         if isinstance(values, OperationResult):
             return values
+        if isinstance(inputs, list) and len(inputs) == 1:
+            inputs = inputs[0]
         input_file = os.path.dirname(inputs) if isinstance(inputs, str) else None
         result = self._upload_files(values, url=base, cwd=input_file, inputs_ignore_errors=inputs_ignore_errors)
         return result
@@ -1449,7 +1451,7 @@ class WeaverClient(object):
         self,
         process_id,                     # type: str
         provider_id=None,               # type: Optional[str]
-        inputs=None,                    # type: Optional[Union[str, ExecutionInputs, CWL_IO_ValueMap]]
+        inputs=None,                    # type: Optional[Union[Path, List[Path], ExecutionInputs, CWL_IO_ValueMap]]
         inputs_ignore_errors=False,     # type: bool
         pending=False,                  # type: bool
         monitor=False,                  # type: bool
@@ -1496,6 +1498,8 @@ class WeaverClient(object):
         :param inputs:
             Literal :term:`JSON` or :term:`YAML` contents of the inputs submitted and inserted into the execution body,
             using either the :term:`OGC API - Processes` or :term:`CWL` format, or a file path/URL referring to them.
+            If resolved by the :term:`CLI` invocation, it can also be a single-item list of these types as collected
+            by the input arguments.
         :param inputs_ignore_errors:
             - If ``True``, missing or unresolved local file references will be ignored with a warning.
             - If ``False`` (default), missing files will cause the operation to fail with a detailed error.


### PR DESCRIPTION
- improve CLI handling of single/multi input files
- improve CLI handling of missing local files
- add CLI `--inputs-ignore-errors` (vs error default) to report missing/unresolved input files