### PR TITLE
ignore links always being blocked

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -461,6 +461,8 @@ linkcheck_ignore = [
     # URLs causing 403 (USer-Agent blocked or bot protection)
     "https://www.iso.org/iso-4217-currency-codes.html",
     "https://www.mongodb.com/.*",
+    "https://zenodo.org/.*",
+    "https://prairieclimatecentre.ca/",
     # ignore the various weaver instances that could be down temporarily from the hosting server
     # their corresponding version checks in the readme's shields will indicate if such an error occurs
     "https://hirondelle.crim.ca/weaver",


### PR DESCRIPTION
Would be better to validate these links in case server go down or DOIs are improperly defined, but this is causing more unnecessary noise during PR review... 

PrairieClimate should be ok since it doesn't change, and worst case we don't care if it cannot be reached since not actively used by the code (just giving credit to ClimateData participants...). 

DOIs should be fine since they are self-updated by the CI.