### PR TITLE
workaround for partial speedup of CI on multi-pr cases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,9 +2,8 @@
 # Reference: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
 # NOTE: auto-rebase strategy
-#   Disable auto-rebase to avoid too many CI runs on each PR merged
-#   Consider that it is "close enough" if the latest state it was tested at,
-#   and master will re-test the actual latest state when merged anyway
+#   With grouping enabled, auto-rebase impact is manageable (2-3 PRs vs 10+)
+#   PRs are kept up-to-date with master and can auto-merge when CI passes
 
 version: 2
 updates:
@@ -20,7 +19,7 @@ updates:
       github-actions:
         patterns:
           - "*"
-    rebase-strategy: "disabled"
+    rebase-strategy: "auto"
     open-pull-requests-limit: 5
     # Add reviewers and assignees
     reviewers:
@@ -51,7 +50,7 @@ updates:
         update-types:
           - "minor"
       # Major updates remain ungrouped for individual review
-    rebase-strategy: "disabled"
+    rebase-strategy: "auto"
     open-pull-requests-limit: 10
     reviewers:
       - "fmigneault"
@@ -70,7 +69,7 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "14:00"
-    rebase-strategy: "disabled"
+    rebase-strategy: "auto"
     open-pull-requests-limit: 3
     reviewers:
       - "fmigneault"
@@ -92,7 +91,7 @@ updates:
       npm-dependencies:
         patterns:
           - "*"
-    rebase-strategy: "disabled"
+    rebase-strategy: "auto"
     open-pull-requests-limit: 3
     reviewers:
       - "fmigneault"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,7 +33,7 @@ updates:
       include: "scope"
 
   # Python dependencies (pip)
-  # No grouping - each dependency gets its own PR
+  # Group patch/minor updates to reduce PR count; major updates get individual PRs
   # Minor/patch updates are auto-approved; major updates require manual review
   - package-ecosystem: "pip"
     directory: "/"
@@ -41,6 +41,16 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "13:00"
+    groups:
+      # Group all patch updates together (safest, unlikely to break)
+      python-patch-updates:
+        update-types:
+          - "patch"
+      # Group minor updates together (safer than major)
+      python-minor-updates:
+        update-types:
+          - "minor"
+      # Major updates remain ungrouped for individual review
     rebase-strategy: "disabled"
     open-pull-requests-limit: 10
     reviewers:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,6 +1,6 @@
-# Auto-approve safe Dependabot PRs that pass all checks
-# Only auto-approves minor/patch updates for npm and GitHub Actions
-# Critical dependencies (Docker, Python) and major updates require manual review
+# Auto-approve and auto-merge safe Dependabot PRs that pass all checks
+# Only auto-approves/merges minor/patch updates for npm/pip and all GitHub Actions updates
+# Critical dependencies (Docker) and major updates require manual review
 # Reference: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions
 
 name: Dependabot Auto-merge
@@ -28,7 +28,7 @@ jobs:
       # Auto-approve only safe Dependabot PRs:
       # - GitHub Actions (all updates - low risk, sandboxed)
       # - NPM minor/patch updates (grouped, relatively safe)
-      # - Python/pip minor/patch updates (safe incremental updates)
+      # - Python/pip minor/patch updates (grouped, safe incremental updates)
       # Excludes:
       # - Docker updates (breaking changes, manual review required)
       # - Major updates (breaking changes, manual review required)
@@ -38,6 +38,18 @@ jobs:
           (steps.metadata.outputs.package-ecosystem == 'npm' && steps.metadata.outputs.update-type != 'version-update:semver-major') ||
           (steps.metadata.outputs.package-ecosystem == 'pip' && steps.metadata.outputs.update-type != 'version-update:semver-major')
         run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Enable auto-merge for approved PRs
+      # PR will merge automatically once all required checks pass
+      - name: Enable auto-merge
+        if: |
+          (steps.metadata.outputs.package-ecosystem == 'github_actions') ||
+          (steps.metadata.outputs.package-ecosystem == 'npm' && steps.metadata.outputs.update-type != 'version-update:semver-major') ||
+          (steps.metadata.outputs.package-ecosystem == 'pip' && steps.metadata.outputs.update-type != 'version-update:semver-major')
+        run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -161,10 +161,6 @@ jobs:
           pip freeze
           npm list
           make version
-      #- name: Setup Environment Variables
-      #  uses: c-py/action-dotenv-to-setenv@3e796a97c9746d8a3e19461421d94b75528b4ad4  # v2
-      #  with:
-      #    env-file: ./ci/weaver.env
       - name: Display Environment Variables
         if: ${{ steps.should_skip_test.outputs.skip != 'true' }}
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -162,7 +162,7 @@ jobs:
           npm list
           make version
       #- name: Setup Environment Variables
-      #  uses: c-py/action-dotenv-to-setenv@v2
+      #  uses: c-py/action-dotenv-to-setenv@3e796a97c9746d8a3e19461421d94b75528b4ad4  # v2
       #  with:
       #    env-file: ./ci/weaver.env
       - name: Display Environment Variables
@@ -240,17 +240,17 @@ jobs:
   #   permissions:
   #     id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
   #   steps:
-  #     - uses: actions/checkout@v4
+  #     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.2.2
   #       with:
   #         fetch-depth: "0"
   #     - name: Set up Python
-  #       uses: actions/setup-python@v5
+  #       uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.3.0
   #       with:
   #         python-version: "3.12"
   #     - name: Build Distribution Package
   #       run: make dist-pypi
   #     - name: Publish package distributions to PyPI
-  #       uses: pypa/gh-action-pypi-publish@release/v1
+  #       uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
   #       with:
   #         user: __token__
   #         password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -176,7 +176,7 @@ jobs:
         run: make check-info
       - name: Env Test Setup
         if: ${{ steps.should_skip_test.outputs.skip != 'true' && matrix.test-server == true }}
-        uses: falti/dotenv-action@v1.2.0
+        uses: falti/dotenv-action@73fafca04177425fd3e0a0849257015ae9d42034  # v1.2.0
         with:
           path: ./tests/functional/code_sprint/test-servers/weaver-localhost/test.env
           ensure-exists: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,6 +35,10 @@ jobs:
     if: ${{ needs.skip_duplicate.outputs.should_skip != 'true' || contains(github.ref, 'refs/tags') || contains(github.ref, 'refs/heads/master') }}
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.allow-failure }}
+    permissions:
+      contents: read           # read repository contents and checkout code
+      pull-requests: write     # post coverage comments on PRs
+      statuses: write          # update commit status checks (required by codecov on protected branches)
     env:
       # override make command to install directly in active python
       CONDA_CMD: ""
@@ -104,22 +108,40 @@ jobs:
             test-case: test-code-sprint-only
             test-server: true
     steps:
+      # Early detection: skip coverage test entirely for Dependabot PRs to save CI time (since it is much longer)
+      # Because we always perform a second pass of test with the latest state on master after merge,
+      # we can be more lenient on the coverage test for Dependabot PRs to accelerate CI/CD feedback loop.
+      # Always run coverage on push to master/tags regardless of actor to validate the final result
+      - name: Check if should skip
+        id: should_skip_test
+        run: |
+          if [[ "${{ matrix.test-case }}" == "test-coverage-only" && \
+                "${{ github.actor }}" == "dependabot[bot]" && \
+                "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "Coverage test skipped for Dependabot PR to save CI time"
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
       - uses: actions/checkout@v6
+        if: ${{ steps.should_skip_test.outputs.skip != 'true' }}
         with:
           fetch-depth: "0"
       - name: Setup Python
-        # skip python setup if running with docker
-        if: ${{ matrix.test-case != 'test-docker' }}
+        # skip python setup if running with docker or if test should be skipped
+        if: ${{ steps.should_skip_test.outputs.skip != 'true' && matrix.test-case != 'test-docker' }}
         uses: actions/setup-python@v6
         with:
           python-version: "${{ matrix.python-version }}"
           cache: 'pip'
       - name: Parse Python Version
+        if: ${{ steps.should_skip_test.outputs.skip != 'true' }}
         id: python-semver
         run: |
           echo "::set-output name=major:$(echo ${{ matrix.python-version }} | cut -d '.' -f 1)"
           echo "::set-output name=minor:$(echo ${{ matrix.python-version }} | cut -d '.' -f 2)"
       - uses: actions/cache@v5
+        if: ${{ steps.should_skip_test.outputs.skip != 'true' }}
         name: Check Proj Lib Pre-Built in Cache
         id: cache-proj
         with:
@@ -127,14 +149,14 @@ jobs:
           path: /tmp/proj-8.2.1/install
           key: ${{ runner.os }}-python${{ matrix.python-version }}-proj
       - name: Install Dependencies
-        # skip python setup if running with docker
-        if: ${{ matrix.test-case != 'test-docker' }}
+        # skip python setup if running with docker or if test should be skipped
+        if: ${{ steps.should_skip_test.outputs.skip != 'true' && matrix.test-case != 'test-docker' }}
         # install package and dependencies directly,
         # skip sys/conda setup to use active python
         run: make install-sys install-pkg install-pip install-raw install-dev install-dev-npm
       - name: Display Packages
-        # skip python setup if running with docker
-        if: ${{ matrix.test-case != 'test-docker' }}
+        # skip python setup if running with docker or if test should be skipped
+        if: ${{ steps.should_skip_test.outputs.skip != 'true' && matrix.test-case != 'test-docker' }}
         run: |
           pip freeze
           npm list
@@ -144,15 +166,16 @@ jobs:
       #  with:
       #    env-file: ./ci/weaver.env
       - name: Display Environment Variables
+        if: ${{ steps.should_skip_test.outputs.skip != 'true' }}
         run: |
           hash -r
           env | sort
 
       - name: Display Applicable Checks
-        if: ${{ startsWith(matrix.test-case, 'check') }}
+        if: ${{ steps.should_skip_test.outputs.skip != 'true' && startsWith(matrix.test-case, 'check') }}
         run: make check-info
       - name: Env Test Setup
-        if: ${{ matrix.test-server == true }}
+        if: ${{ steps.should_skip_test.outputs.skip != 'true' && matrix.test-server == true }}
         uses: falti/dotenv-action@v1.2.0
         with:
           path: ./tests/functional/code_sprint/test-servers/weaver-localhost/test.env
@@ -161,14 +184,15 @@ jobs:
           log-variables: true
           keys-case: bypass
       - name: Start Test Instance
-        if: ${{ matrix.test-server == true }}
+        if: ${{ steps.should_skip_test.outputs.skip != 'true' && matrix.test-server == true }}
         run: |
           make stop start-only
           sleep 10
       - name: Run Tests
+        if: ${{ steps.should_skip_test.outputs.skip != 'true' }}
         run: make ${{ matrix.test-case }}
       - name: Display Test Logs (failure)
-        if: ${{ failure() && matrix.test-server == true }}
+        if: ${{ steps.should_skip_test.outputs.skip != 'true' && failure() && matrix.test-server == true }}
         run: |
           echo "=== Weaver Manager Logs ==="
           cat /tmp/weaver-manager.log
@@ -178,11 +202,11 @@ jobs:
       # manually invoke reporting in case of test failure to still generate them
       # otherwise, they would have been generated automatically following the successful coverage run
       - name: Handle Failed Coverage Report
-        if: ${{ failure() && matrix.test-case == 'test-coverage-only' }}
+        if: ${{ steps.should_skip_test.outputs.skip != 'true' && failure() && matrix.test-case == 'test-coverage-only' }}
         run: make coverage-reports
       # flaky test analysis, which includes failed tests if applicable
       - name: Upload test results to Codecov
-        if: ${{ !cancelled() && matrix.test-case == 'test-coverage-only' }}
+        if: ${{ steps.should_skip_test.outputs.skip != 'true' && !cancelled() && matrix.test-case == 'test-coverage-only' }}
         uses: codecov/test-results-action@1eb481b01f349d82be85db73edfcb2fc62637dfb  # v1.0.0
         with:
           files: reports/coverage-junit.xml,!./cache
@@ -190,13 +214,17 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
       # coverage test analysis
       - name: Upload coverage report
+        if: ${{ steps.should_skip_test.outputs.skip != 'true' && success() && matrix.test-case == 'test-coverage-only' }}
         uses: codecov/codecov-action@bc114756858cde29e12b6c88f6224db397f7447a  # v5.2.0
-        if: ${{ success() && matrix.test-case == 'test-coverage-only' }}
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./reports/coverage.xml
           fail_ci_if_error: true
           verbose: true
+      # Provide success status when test was skipped (e.g., coverage on Dependabot PRs)
+      - name: Skipped Test Placeholder
+        if: ${{ steps.should_skip_test.outputs.skip == 'true' }}
+        run: echo "Test skipped based on conditional criteria"
 
   # PyPI requires that all packages are distributed in PyPI.
   # Because we have multiple patched/forked dependencies, we cannot use them directly for PyPI releases.


### PR DESCRIPTION
- skip covereage tests if PR triggered by dependabot updates
- allow coverages to update its self-update status on protected branches