### PR TITLE
Update to `werkzeug==3.1.8`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -136,5 +136,5 @@ urllib3>=2.6.3
 urlmatch
 xmltodict>=1.0.4
 webob
-werkzeug>=3.1.5
+werkzeug>=3.1.8
 zipp>=3.23.1 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
- Update to `werkzeug==3.1.8`
- fix https://nvd.nist.gov/vuln/detail/CVE-2026-27199 (only 3.1.6 required, but later versions available)