### PR TITLE
pin urllib3>=2.7.0 (CVE-2026-44431, CVE-2026-44432)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -131,8 +131,7 @@ ruamel.yaml>=0.19.1
 schema-salad>=8.9.20260417192335,<9
 shapely
 simplejson
-# urllib3 not directly required, pinned by Snyk to avoid CVE-2024-37891
-urllib3>=2.6.3
+urllib3>=2.7.0
 urlmatch
 xmltodict>=1.0.4
 webob


### PR DESCRIPTION
- [CVE-2026-44431](https://nvd.nist.gov/vuln/detail/CVE-2026-44431): avoid affected urllib3 versions by requiring 2.7.0 or newer.

- [CVE-2026-44432](https://nvd.nist.gov/vuln/detail/CVE-2026-44432): avoid affected urllib3 versions by requiring 2.7.0 or newer.