### PR TITLE
improve OpenAPI examples for per-content-type process deployment

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,8 @@ Changes:
 
 Fixes:
 ------
+- Fix rendering of `OpenAPI` definitions for ``POST /processes`` deployment such that each indicated ``Content-Type``
+  correctly provides its corresponding examples for `OGC Application Package` and `CWL` representations in YAML/JSON.
 - Fix the `CLI` documentation about the reported result from ``undeploy`` command. It referred to a missing JSON
   response file, which is not valid since ``HTTP 204 No Content`` is returned for that successful operation.
 - Adjusted OpenAPI `Job` result examples with by-value/href responses.

--- a/weaver/processes/utils.py
+++ b/weaver/processes/utils.py
@@ -968,7 +968,7 @@ def deploy_process_from_payload(payload, container, overwrite=False):  # pylint:
         request=container if hasattr(container, 'body') else None,
         content=payload,
         content_type=c_type_full,  # Pass full Content-Type with parameters (e.g., boundary)
-        content_type_schema=sd.DeployContentType,
+        content_type_schema=sd.DeployContentTypeAny,
     )
 
     # Extract process ID from Content-ID header if provided (RFC 2392)

--- a/weaver/wps_restapi/processes/processes.py
+++ b/weaver/wps_restapi/processes/processes.py
@@ -187,16 +187,21 @@ def get_processes(request):
 
 @sd.processes_service.post(
     tags=[sd.TAG_PROCESSES, sd.TAG_DEPLOY],
-    schema=sd.PostProcessesEndpointCWLYAML(),
+    schema=sd.PostProcessesEndpointCWL(),
     accept=ContentType.APP_JSON,
-    content_type=[ContentType.APP_CWL_YAML, ContentType.APP_CWL, ContentType.APP_CWL_X],
+    content_type=[
+        ctype for ctype in
+        sd.DeployContentTypeCWL.validator.choices
+        if ctype not in sd.DeployContentTypeOGC.validator.choices
+    ],
     renderer=OutputFormat.JSON,
     response_schemas=sd.post_processes_responses,
 )
 @sd.processes_service.post(
     tags=[sd.TAG_PROCESSES, sd.TAG_DEPLOY],
-    schema=sd.PostProcessesEndpoint(),
+    schema=sd.PostProcessesEndpointOGC(),
     accept=ContentType.APP_JSON,
+    content_type=sd.DeployContentTypeOGC.validator.choices,
     renderer=OutputFormat.JSON,
     response_schemas=sd.post_processes_responses,
 )

--- a/weaver/wps_restapi/swagger_definitions.py
+++ b/weaver/wps_restapi/swagger_definitions.py
@@ -7558,7 +7558,7 @@ class Deploy(OneOfKeywordSchema):
     ]
 
 
-class DeployContentType(ContentTypeHeader):
+class DeployContentTypeAny(ContentTypeHeader):
     example = ContentType.APP_JSON
     default = ContentType.APP_JSON
     validator = OneOf([
@@ -7573,19 +7573,52 @@ class DeployContentType(ContentTypeHeader):
     ])
 
 
-class DeployHeaders(RequestHeadersBody):
+class DeployContentTypeOGC(ContentTypeHeader):
+    example = ContentType.APP_JSON
+    default = ContentType.APP_JSON
+    validator = OneOf([
+        ContentType.APP_JSON,
+        ContentType.APP_OGC_PKG_JSON,
+        ContentType.APP_OGC_PKG_YAML,
+        ContentType.APP_YAML,
+    ])
+
+
+class DeployContentTypeCWL(ContentTypeHeader):
+    example = ContentType.APP_JSON
+    default = ContentType.APP_JSON
+    validator = OneOf([
+        ContentType.APP_CWL,
+        ContentType.APP_CWL_JSON,
+        ContentType.APP_CWL_YAML,
+        ContentType.APP_CWL_X,
+        ContentType.APP_YAML,
+        ContentType.APP_JSON,
+    ])
+
+
+class DeployHeadersAny(RequestHeadersBody):
     x_auth_docker = XAuthDockerHeader()
-    content_type = DeployContentType()
+    content_type = DeployContentTypeAny()
+
+
+class DeployHeadersOGC(RequestHeadersBody):
+    x_auth_docker = XAuthDockerHeader()
+    content_type = DeployContentTypeOGC()
+
+
+class DeployHeadersCWL(RequestHeadersBody):
+    x_auth_docker = XAuthDockerHeader()
+    content_type = DeployContentTypeCWL()
 
 
 class PostProcessesEndpoint(ExtendedMappingSchema):
-    header = DeployHeaders(description="Headers employed for process deployment.")
+    header = DeployHeadersAny(description="Headers employed for process deployment.")
     querystring = FormatQuery()
-    body = Deploy(title="Deploy", examples={
-        "DeployCWL": {
-            "summary": "Deploy a process from a CWL+JSON definition.",
-            "value": EXAMPLES["deploy_process_cwl.json"],
-        },
+
+
+class DeployBodyOGC(Deploy):
+    examples = {
         "DeployOGC": {
             "summary": "Deploy a process from an OGC Application Package definition.",
             "value": EXAMPLES["deploy_process_ogcapppkg.json"],
@@ -7594,16 +7627,32 @@ class PostProcessesEndpoint(ExtendedMappingSchema):
             "summary": "Deploy a process from a remote WPS-1 reference URL.",
             "value": EXAMPLES["deploy_process_wps1.json"],
         }
-    })
+    }
 
 
-class PostProcessesEndpointCWLYAML(PostProcessesEndpoint):
-    body = PermissiveMappingSchema(title="DeployCWLYAML", examples={
+class DeployBodyCWL(Deploy):
+    examples = {
+        "DeployCWLJSON": {
+            "summary": "Deploy a process from a CWL+JSON definition.",
+            "value": EXAMPLES["deploy_process_cwl.json"],
+        },
         "DeployCWLYAML": {
             "summary": "Deploy a process from a CWL+YAML definition.",
             "value": EXAMPLES["deploy_process_yaml.cwl"],
         },
-    })
+    }
+
+
+class PostProcessesEndpointOGC(PostProcessesEndpoint):
+    header = DeployHeadersOGC(description="Headers employed for process deployment.")
+    querystring = FormatQuery()
+    body = DeployBodyOGC()
+
+
+class PostProcessesEndpointCWL(PostProcessesEndpoint):
+    header = DeployHeadersCWL(description="Headers employed for process deployment.")
+    querystring = FormatQuery()
+    body = DeployBodyCWL()
 
 
 class UpdateInputOutputBase(DescriptionType, InputOutputDescriptionMeta):

--- a/weaver/wps_restapi/swagger_definitions.py
+++ b/weaver/wps_restapi/swagger_definitions.py
@@ -7644,13 +7644,17 @@ class DeployBodyCWL(Deploy):
 
 
 class PostProcessesEndpointOGC(PostProcessesEndpoint):
-    header = DeployHeadersOGC(description="Headers employed for process deployment.")
+    header = DeployHeadersOGC(
+        description="Headers employed for process deployment to represent OGC Application Package content.",
+    )
     querystring = FormatQuery()
     body = DeployBodyOGC()
 
 
 class PostProcessesEndpointCWL(PostProcessesEndpoint):
-    header = DeployHeadersCWL(description="Headers employed for process deployment.")
+    header = DeployHeadersCWL(
+        description="Headers employed for process deployment to represent CWL content.",
+    )
     querystring = FormatQuery()
     body = DeployBodyCWL()
 


### PR DESCRIPTION
## Changes

API rendering used to return the examples in mixed order/combination per request body content-type because they were are combined under one schema.

Now, they properly offer all media-types (some of which were missing), and picking one will offer corresponding OGC/CWL representations.

For now, JSON/YAML are still returned together. Otherwise we would need to create even more schema class combinations to actually represent each one separately. We keep it relatively simple with that simplification.


<img width="1097" height="618" alt="{AACEE60A-E1FC-4015-B920-AEC0F21842D8}" src="https://github.com/user-attachments/assets/38d80f71-0fce-4e21-bdf0-4ee58c8d4c95" />

<img width="1115" height="501" alt="{D373D01D-D4E0-4BA6-B3C8-36A29375D7AD}" src="https://github.com/user-attachments/assets/38755998-17e9-411f-a9bb-22bbef7a925a" />

<img width="1099" height="542" alt="{4CC53AA4-1057-4F62-B5F7-3B9039279011}" src="https://github.com/user-attachments/assets/448c040c-c914-42d9-b4ed-291e55b37cf8" />

<img width="1087" height="501" alt="{CB9918FD-5941-4868-AA4B-D5F27CE20DAD}" src="https://github.com/user-attachments/assets/d6dc60e6-5485-423c-9b00-4aa6c8de2a6a" />


