### PR TITLE
fix deploy openapi for multipart

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,7 +19,11 @@ Changes:
 Fixes:
 ------
 - Fix rendering of `OpenAPI` definitions for ``POST /processes`` deployment such that each indicated ``Content-Type``
+  correctly provides an example for ``multipart/*`` representation of a `Workflow`.
+- Fix rendering of `OpenAPI` definitions for ``POST /processes`` deployment such that each indicated ``Content-Type``
   correctly provides its corresponding examples for `OGC Application Package` and `CWL` representations in YAML/JSON.
+- Fix `OpenAPI` combination of ``Accept`` and ``Content-Type`` header values from all `OGC Application Package`, `CWL`
+  and ``multipart/*`` schemas when aggregated under the *request parameters* of the `Swagger-UI` representation.
 - Fix the `CLI` documentation about the reported result from ``undeploy`` command. It referred to a missing JSON
   response file, which is not valid since ``HTTP 204 No Content`` is returned for that successful operation.
 - Adjusted OpenAPI `Job` result examples with by-value/href responses.

--- a/weaver/cli.py
+++ b/weaver/cli.py
@@ -746,7 +746,6 @@ class WeaverClient(object):
                 LOGGER.debug("Processing multi-CWL deployment with %d files", len(cwl))
 
                 cwl_packages = self._parse_cwl_items(cwl)
-
                 multipart_content, content_type = create_multipart_deploy(
                     cwl_files=cwl_packages,
                     url=url,

--- a/weaver/formats.py
+++ b/weaver/formats.py
@@ -1072,7 +1072,7 @@ def map_cwl_media_type(cwl_format):
 def clean_media_type_format(media_type, suffix_subtype=False, strip_parameters=False):
     # type: (str, bool, bool) -> Optional[str]
     """
-    Obtains a generic media-type identifier by cleaning up any additional parameters.
+    Obtains a generic :term:`Media-Type` identifier by cleaning up any additional parameters.
 
     Removes any additional namespace key or URL from :paramref:`media_type` so that it corresponds to the generic
     representation (e.g.: ``application/json``) instead of the ``<namespace-name>:<format>`` mapping variant used
@@ -1115,7 +1115,7 @@ def clean_media_type_format(media_type, suffix_subtype=False, strip_parameters=F
                 media_type = media_type.split(",", 1)[0] + media_type[colon_pos:]
         else:
             media_type = media_type.split(",", 1)[0]
-    media_type = media_type.strip()
+    media_type = media_type.strip().lower()
     if suffix_subtype and "+" in media_type:
         # parameters are not necessarily stripped, need to re-append them after if any
         parts = media_type.split(";", 1)

--- a/weaver/formats.py
+++ b/weaver/formats.py
@@ -1115,7 +1115,7 @@ def clean_media_type_format(media_type, suffix_subtype=False, strip_parameters=F
                 media_type = media_type.split(",", 1)[0] + media_type[colon_pos:]
         else:
             media_type = media_type.split(",", 1)[0]
-    media_type = media_type.strip().lower()
+    media_type = media_type.strip()
     if suffix_subtype and "+" in media_type:
         # parameters are not necessarily stripped, need to re-append them after if any
         parts = media_type.split(";", 1)

--- a/weaver/processes/utils.py
+++ b/weaver/processes/utils.py
@@ -51,7 +51,7 @@ from weaver.exceptions import (
     ServiceNotFound,
     log_unhandled_exceptions
 )
-from weaver.formats import ContentType, repr_json
+from weaver.formats import ContentType, clean_media_type_format, repr_json
 from weaver.processes.constants import PACKAGE_EXTENSIONS
 from weaver.processes.convert import get_field, normalize_ordered_io, set_field
 from weaver.processes.types import ProcessType
@@ -877,7 +877,7 @@ def parse_process_deploy_content(
     # If content is already a parsed dict (from recursive calls), skip parsing
     if isinstance(content, dict):
         pass  # Content already parsed, proceed to validation
-    elif content_type and any(mt in content_type.lower() for mt in ContentType.ANY_MULTIPART):
+    elif content_type and (clean_media_type_format(content_type, strip_parameters=True) in ContentType.ANY_MULTIPART):
         LOGGER.info("Detected multipart deployment request")
         cwl_packages, _ = parse_multipart_deploy(
             content=content if content is not None else request.body,

--- a/weaver/processes/utils.py
+++ b/weaver/processes/utils.py
@@ -877,7 +877,10 @@ def parse_process_deploy_content(
     # If content is already a parsed dict (from recursive calls), skip parsing
     if isinstance(content, dict):
         pass  # Content already parsed, proceed to validation
-    elif content_type and (clean_media_type_format(content_type, strip_parameters=True) in ContentType.ANY_MULTIPART):
+    elif (
+        content_type and
+        clean_media_type_format(content_type, strip_parameters=True).lower() in ContentType.ANY_MULTIPART
+    ):
         LOGGER.info("Detected multipart deployment request")
         cwl_packages, _ = parse_multipart_deploy(
             content=content if content is not None else request.body,

--- a/weaver/wps_restapi/colander_extras.py
+++ b/weaver/wps_restapi/colander_extras.py
@@ -807,17 +807,19 @@ class OAS3Parameter(object):
     def convert(self):
         # type: () -> Dict[str, Any]
         spec = {}
-        for name, attr in [
-            ("style", "style"),
-            ("explode", "explode"),
-            ("allowReserved", "allow_reserved"),
-            ("summary", "summary"),
-            ("description", "description"),
-            ("example", "example"),
-            ("examples", "examples"),
+        for name, attr, strip in [
+            ("style", "style", True),
+            ("explode", "explode", True),
+            ("allowReserved", "allow_reserved", False),
+            ("summary", "summary", True),
+            ("description", "description", True),
+            ("example", "example", False),  # in case content newlines are relevant
+            ("examples", "examples", False),
         ]:
             value = getattr(self, attr)
             if value is not None:
+                if strip and isinstance(value, str):
+                    value = value.strip()
                 spec[name] = value
         return spec
 

--- a/weaver/wps_restapi/examples/deploy_process_multipart_cwl.txt
+++ b/weaver/wps_restapi/examples/deploy_process_multipart_cwl.txt
@@ -1,0 +1,56 @@
+--boundary123
+Content-Type: application/cwl+json
+Content-ID: <echo-tool@weaver.example.com>
+Content-Location: echo-tool
+
+{
+  "cwlVersion": "v1.2",
+  "class": "CommandLineTool",
+  "id": "echo-tool",
+  "baseCommand": ["echo"],
+  "inputs": {
+    "message": "string"
+  },
+  "outputs": {
+    "output": {
+      "type": "stdout"
+    }
+  },
+  "requirements": {
+    "DockerRequirement": {
+      "dockerPull": "alpine:latest"
+    }
+  },
+  "stdout": "output.txt"
+}
+
+--boundary123
+Content-Type: application/cwl+json
+Content-ID: <main-workflow@weaver.example.com>
+Content-Location: main-workflow
+
+{
+  "cwlVersion": "v1.2",
+  "class": "Workflow",
+  "id": "main-workflow",
+  "inputs": {
+    "input_message": "string"
+  },
+  "outputs": {
+    "result": {
+      "type": "File",
+      "outputSource": "echo_step/output"
+    }
+  },
+  "steps": {
+    "echo_step": {
+      "run": "echo-tool",
+      "in": {
+        "message": "input_message"
+      },
+      "out": ["output"]
+    }
+  }
+}
+
+--boundary123--

--- a/weaver/wps_restapi/patches.py
+++ b/weaver/wps_restapi/patches.py
@@ -78,8 +78,12 @@ class ServiceAutoAcceptDecorator(CorniceService):
     parameters over multiple separate decorator calls.
     """
 
-    def decorator(self, method, accept=None, **kwargs):
-        # type: (RequestMethod, Optional[str, Sequence[str]], Any) -> Callable[[AnyViewCallable], AnyViewCallable]
+    def decorator(
+        self,
+        method,         # type: RequestMethod
+        accept=None,    # type: Optional[Union[str, Sequence[str]]]
+        **kwargs,       # type: Any
+    ):                  # type: (...) -> Callable[[AnyViewCallable], AnyViewCallable]
         if not accept:
             return super().decorator(method, **kwargs)  # don't inject 'accept=None', causes cornice-swagger error
         if isinstance(accept, str):

--- a/weaver/wps_restapi/processes/processes.py
+++ b/weaver/wps_restapi/processes/processes.py
@@ -185,15 +185,23 @@ def get_processes(request):
         })
 
 
+# place multipart at the top such that the OpenAPI specification will load the decorator last
+# which ensures that the most common OGC / JSON content representation is shown by default on Swagger-UI
+@sd.processes_service.post(
+    tags=[sd.TAG_PROCESSES, sd.TAG_DEPLOY],
+    schema=sd.PostProcessesEndpointMultipart(),
+    accept=ContentType.APP_JSON,
+    # pyramid/webob 'request.content_type' automatically strips extra parameters
+    # therefore, the cornice validator does not need to manage the dynamic boundary
+    content_type=sd.DeployContentTypeMultipart.validator.choices,
+    renderer=OutputFormat.JSON,
+    response_schemas=sd.post_processes_responses,
+)
 @sd.processes_service.post(
     tags=[sd.TAG_PROCESSES, sd.TAG_DEPLOY],
     schema=sd.PostProcessesEndpointCWL(),
     accept=ContentType.APP_JSON,
-    content_type=[
-        ctype for ctype in
-        sd.DeployContentTypeCWL.validator.choices
-        if ctype not in sd.DeployContentTypeOGC.validator.choices
-    ],
+    content_type=list(set(sd.DeployContentTypeCWL.validator.choices) - set(sd.DeployContentTypeOGC.validator.choices)),
     renderer=OutputFormat.JSON,
     response_schemas=sd.post_processes_responses,
 )
@@ -211,7 +219,7 @@ def add_local_process(request):
     """
     Register a local process.
     """
-    return deploy_process_from_payload(request.text, request)  # use text to allow parsing as JSON or YAML
+    return deploy_process_from_payload(request.text, request)  # use text to allow parsing JSON, YAML, Multipart, etc.
 
 
 @sd.process_service.put(

--- a/weaver/wps_restapi/swagger_definitions.py
+++ b/weaver/wps_restapi/swagger_definitions.py
@@ -7558,21 +7558,6 @@ class Deploy(OneOfKeywordSchema):
     ]
 
 
-class DeployContentTypeAny(ContentTypeHeader):
-    example = ContentType.APP_JSON
-    default = ContentType.APP_JSON
-    validator = OneOf([
-        ContentType.APP_JSON,
-        ContentType.APP_CWL,
-        ContentType.APP_CWL_JSON,
-        ContentType.APP_CWL_YAML,
-        ContentType.APP_CWL_X,
-        ContentType.APP_OGC_PKG_JSON,
-        ContentType.APP_OGC_PKG_YAML,
-        ContentType.APP_YAML,
-    ])
-
-
 class DeployContentTypeOGC(ContentTypeHeader):
     example = ContentType.APP_JSON
     default = ContentType.APP_JSON
@@ -7597,6 +7582,25 @@ class DeployContentTypeCWL(ContentTypeHeader):
     ])
 
 
+class DeployContentTypeMultipart(ContentTypeHeader):
+    # boundary value aligned with 'DeployBodyMultipart' example
+    # aligned with the documented multipart definition in 'package.rst' (but more complete with entire request)
+    example = f"{ContentType.MULTIPART_RELATED}; boundary=\"boundary123\""
+    default = ContentType.MULTIPART_MIXED
+    # mostly for listing the plain headers via OpenAPI, actual validation needs 'allow_content_type_multipart' callable
+    validator = OneOf(list(ContentType.ANY_MULTIPART))
+
+
+class DeployContentTypeAny(ContentTypeHeader):
+    example = ContentType.APP_JSON
+    default = ContentType.APP_JSON
+    validator = OneOf(sorted(
+        set(DeployContentTypeOGC.validator.choices) |
+        set(DeployContentTypeCWL.validator.choices) |
+        set(DeployContentTypeMultipart.validator.choices)
+    ))
+
+
 class DeployHeadersAny(RequestHeadersBody):
     x_auth_docker = XAuthDockerHeader()
     content_type = DeployContentTypeAny()
@@ -7612,9 +7616,9 @@ class DeployHeadersCWL(RequestHeadersBody):
     content_type = DeployContentTypeCWL()
 
 
-class PostProcessesEndpoint(ExtendedMappingSchema):
-    header = DeployHeadersAny(description="Headers employed for process deployment.")
-    querystring = FormatQuery()
+class DeployHeadersMultipart(RequestHeadersBody):
+    x_auth_docker = XAuthDockerHeader()
+    content_type = DeployContentTypeMultipart()
 
 
 class DeployBodyOGC(Deploy):
@@ -7643,20 +7647,48 @@ class DeployBodyCWL(Deploy):
     }
 
 
-class PostProcessesEndpointOGC(PostProcessesEndpoint):
-    header = DeployHeadersOGC(
-        description="Headers employed for process deployment to represent OGC Application Package content.",
+class DeployBodyMultipart(Deploy):
+    examples = {
+        "DeployMultipartCWL": {
+            "summary": "Deploy a workflow process from multipart CWL definition.",
+            "value": EXAMPLES["deploy_process_multipart_cwl.txt"],
+        },
+    }
+
+
+class PostProcessesEndpoint(ExtendedMappingSchema):
+    # WARNING:
+    #   Although each OGC, CWL, Multipart request/response bodies have their respective content-type values, the
+    #   Cornice Swagger generation employs the 'accept' and 'content_type' view decorator parameters to create a
+    #   distinct toggle menu between them in Swagger UI. The request 'Accept' and 'Content-Type' *global parameters*
+    #   that may be submitted with "Try it out" option must provide all possible combinations. Otherwise, only options
+    #   from the first registered decorator view will be present. However, for Cornice Swagger to detect the views as
+    #   distinct body/content representations (and therefore create the toggle), they need to be registered with
+    #   separate schemas (i.e.: PostProcessesEndpointOGC, PostProcessesEndpointCWL, PostProcessesEndpointMultipart).
+    header = DeployHeadersAny(
+        description=(
+            "Headers employed for process deployment with a single CWL,"
+            "an OGC Application Package, or multipart contents that "
+            "represents multiple CWL applications (forming a workflow) and/or a "
+            "mixture of OGC Application Package and OGC Process Description metadata."
+        ),
     )
     querystring = FormatQuery()
+
+
+class PostProcessesEndpointOGC(PostProcessesEndpoint):
+    # header = DeployHeadersOGC()  # see 'PostProcessesEndpoint'
     body = DeployBodyOGC()
 
 
 class PostProcessesEndpointCWL(PostProcessesEndpoint):
-    header = DeployHeadersCWL(
-        description="Headers employed for process deployment to represent CWL content.",
-    )
-    querystring = FormatQuery()
+    # header = DeployHeadersCWL()  # see 'PostProcessesEndpoint'
     body = DeployBodyCWL()
+
+
+class PostProcessesEndpointMultipart(PostProcessesEndpoint):
+    # header = DeployHeadersMultipart()  # see 'PostProcessesEndpoint'
+    body = DeployBodyMultipart()
 
 
 class UpdateInputOutputBase(DescriptionType, InputOutputDescriptionMeta):


### PR DESCRIPTION
## Detail

The decorator for `multipart/*` combinations was missing from https://github.com/crim-ca/weaver/pull/998
While adding this, it was identified that the `Content-Type` parameter was not containing all possible options, because it simply registered the values from the first view decorator.

This fixes the definition to obtain the valid combinations, and adds a missing example for multipart.

### Toggle Content body per Content-Type
<img width="1333" height="1256" alt="image" src="https://github.com/user-attachments/assets/1a2468ea-ef50-4102-bee2-b27dcd032700" />


### Example multipart 
<img width="1313" height="631" alt="image" src="https://github.com/user-attachments/assets/cee3a5a4-b0d5-4f55-803e-1b8a5dd4dbb1" />

### Aggregated `Content-Type` parameter with "*Try it out*" submission
<img width="1330" height="903" alt="image" src="https://github.com/user-attachments/assets/cd072ab2-b42d-4398-9556-bdc241dbdf9d" />


## Changes

- Fix rendering of `OpenAPI` definitions for ``POST /processes`` deployment such that each indicated ``Content-Type``   correctly provides an example for ``multipart/*`` representation of a `Workflow`.
- Fix `OpenAPI` combination of ``Accept`` and ``Content-Type`` header values from all `OGC Application Package`, `CWL`   and ``multipart/*`` schemas when aggregated under the *request parameters* of the `Swagger-UI` representation.

## References

- Continuation of adjustments from #998 
- Relates to #717 
- Relates to #968