### PR TITLE
patch failing linkcheck by allow_redirect on stackoverflow doc URLs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -473,6 +473,9 @@ linkcheck_ignore = [
     # ignore agent skills during docs build,
     # links will be validated by local markdown checks instead
     r"./\.agents/.*",
+    # ignore stackoverflow redirects causing failures
+    # https://github.com/orgs/sphinx-doc/discussions/12032
+    r"https://stackoverflow\.com/.*",
 ]
 linkcheck_anchors_ignore = [
     "xml-object",  # https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md

--- a/weaver/notify.py
+++ b/weaver/notify.py
@@ -127,11 +127,13 @@ def notify_job_email(job, to_email_recipient, container):
         raise IOError(f"Code: {code}, Message: {error_message}")
 
 
-# https://stackoverflow.com/a/55147077
 def get_crypto_key(settings, salt, rounds):
     # type: (SettingsType, bytes, int) -> bytes
     """
     Get the cryptographic key used for encoding and decoding the email.
+
+    .. seealso::
+        https://stackoverflow.com/a/55147077
     """
     backend = default_backend()
     pwd = str2bytes(settings.get("weaver.wps_email_encrypt_salt"))  # use old param for backward-compat even if not salt


### PR DESCRIPTION
Avoid noisy failures in CI. 
URLs are fine, but sphinx linkcheck fails during redirect-follow check, althoug the initial request returns 302. 

- relates to https://github.com/orgs/sphinx-doc/discussions/12032

