### PR TITLE
pin `authlib<1.8.0` for `httpx2`/`safety` dependency chain problem with timeout

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,12 @@
 # pylint>=2.5 requires astroid>=2.4
 # install/update sometime fails randomly, so enforce it
 astroid
+# pin authlib to patch broken safety dependency chain
+# - https://github.com/pyupio/safety/issues/822
+# - https://github.com/pyupio/safety/issues/853
+# - https://github.com/authlib/authlib/pull/909
+# - https://github.com/pydantic/httpx2/issues/1162
+authlib<1.8.0
 autopep8
 # pin bandit to avoid issues in early 1.8.x versions
 # - https://github.com/PyCQA/bandit/issues/1226


### PR DESCRIPTION
relates to: 
- https://github.com/pyupio/safety/issues/822
- https://github.com/pyupio/safety/issues/853
- https://github.com/authlib/authlib/pull/909
- https://github.com/pydantic/httpx2/issues/1162